### PR TITLE
Refactor stringify_attributes for CI4

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -585,3 +585,41 @@ if (! function_exists('redirect'))
 
 //--------------------------------------------------------------------
 
+if ( ! function_exists('stringify_attributes'))
+{
+	/**
+	 * Stringify attributes for use in HTML tags.
+	 *
+	 * Helper function used to convert a string, array, or object
+	 * of attributes to a string.
+	 *
+	 * @param	mixed	string, array, object
+	 * @param	bool
+	 * @return	string
+	 */
+	function stringify_attributes($attributes, $js = FALSE) : string
+	{
+		$atts = '';
+
+		if (empty($attributes))
+		{
+			return $atts;
+		}
+
+		if (is_string($attributes))
+		{
+			return ' '.$attributes;
+		}
+
+		$attributes = (array) $attributes;
+
+		foreach ($attributes as $key => $val)
+		{
+			$atts .= ($js) ? $key.'='.$val.',' : ' '.$key.'="'.$val.'"';
+		}
+
+		return rtrim($atts, ',');
+	}
+}
+
+// ------------------------------------------------------------------------

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -1,0 +1,46 @@
+<?php 
+
+class CommomFunctionsTest extends \CIUnitTestCase
+{
+
+	//--------------------------------------------------------------------
+
+	public function setUp()
+	{
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testStringifyAttributes()
+	{
+		$this->assertEquals(' class="foo" id="bar"', stringify_attributes(array('class' => 'foo', 'id' => 'bar')));
+
+		$atts = new stdClass;
+		$atts->class = 'foo';
+		$atts->id = 'bar';
+		$this->assertEquals(' class="foo" id="bar"', stringify_attributes($atts));
+
+		$atts = new stdClass;
+		$this->assertEquals('', stringify_attributes($atts));
+
+		$this->assertEquals(' class="foo" id="bar"', stringify_attributes('class="foo" id="bar"'));
+
+		$this->assertEquals('', stringify_attributes(array()));
+	}
+
+	// ------------------------------------------------------------------------
+
+	public function testStringifyJsAttributes()
+	{
+		$this->assertEquals('width=800,height=600', stringify_attributes(array('width' => '800', 'height' => '600'), TRUE));
+
+		$atts = new stdClass;
+		$atts->width = 800;
+		$atts->height = 600;
+		$this->assertEquals('width=800,height=600', stringify_attributes($atts, TRUE));
+	}
+
+	// ------------------------------------------------------------------------
+
+
+}

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -223,6 +223,15 @@ Miscellaneous Functions
 	function will share the same instance of the service, where **service** returns a new
 	instance every time.
 
+.. php:function:: stringify_attributes ( $attributes [, $js] )
+
+	:param   mixed    $attributes: string, array of key value pairs, or object
+	:param   boolean  $js: TRUE if values do not need quotes (Javascript-style)
+	:returns: String containing the attribute key/value pairs, comma-separated
+	:rtype: string
+
+	Helper function used to convert a string, array, or object of attributes to a string.
+
 
 ================
 Global Constants


### PR DESCRIPTION
Refactored _stringify_attributes from CI3 (Common) to stringify_attributes in CI4 (Common).
Updated user guide & refactored unit tests as well.