### PR TITLE
correcting sphinx format in general/logging.rst

### DIFF
--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -55,11 +55,11 @@ Using Multiple Log Handlers
 The logging system can support multiple methods of handling logging running at the same time. Each handler can
 be set to handle specific levels and ignore the rest. Currently, two handlers come with a default install:
 
-- **File Handler** is the default handler and will create a single file for every day locally. This is the
-	recommended method of logging.
+- **File Handler** is the default handler and will create a single file for every day locally. This is the 
+  recommended method of logging.
 - **ChromeLogger Handler** If you have the `ChromeLogger extension <https://craig.is/writing/chrome-logger>`_
-	installed in the Chrome web browser, you can use this handler to display the log information in
-	Chrome's console window.
+  installed in the Chrome web browser, you can use this handler to display the log information in
+  Chrome's console window.
 
 The handlers are configured in the main configuration file, in the ``$handlers`` property, which is simply
 an array of handlers and their configuration. Each handler is specified with the key being the fully


### PR DESCRIPTION
Continuing text must be aligned after the bullet and whitespace.