### PR TITLE
Fix phpunit code coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,10 +20,8 @@
             <directory suffix=".php">./system</directory>
             <exclude>
                 <file>./system/ComposerScripts.php</file>
-                <file>./system/View/Escaper.php</file>
-                <directory suffix=".php">./system/View/Exception</directory>
-                <directory suffix=".php">./system/Debug/Toolbar/View</directory>
-                <directory>./system/Debug/Kint</directory>
+                <directory>./system/ThirdParty</directory>
+                <directory>./system/Debug/Toolbar/View</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -36,8 +36,6 @@
  * @filesource
  */
 
-//use Config\ContentSecurityPolicy;
-
 /**
  * Class ContentSecurityPolicy
  *

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -36,7 +36,7 @@
  * @filesource
  */
 
-use Config\ContentSecurityPolicy;
+//use Config\ContentSecurityPolicy;
 
 /**
  * Class ContentSecurityPolicy
@@ -175,7 +175,7 @@ class ContentSecurityPolicy
 	 *
 	 * @param ContentSecurityPolicy $config
 	 */
-	public function __construct(ContentSecurityPolicy $config)
+	public function __construct(Config\ContentSecurityPolicy $config)
 	{
 		foreach ($config as $setting => $value)
 		{


### PR DESCRIPTION
Running PHPunit with code coverage failed.. Cannot declare class CodeIgniter\HTTP\ContentSecurityPolicy because the name is already in use.
Fixed it by explicitly namespacing the $config constructor parameter.
Also corrected the whitelist filter settings.

