### PR TITLE
Fix Class 'CodeIgniter\Cache\Handlers\Redis' not found

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -53,7 +53,7 @@ class RedisHandler implements CacheInterface
 	{
 		$config = $this->config;
 
-		$this->redis = new Redis();
+		$this->redis = new \Redis();
 
 		try
 		{


### PR DESCRIPTION
Signed-off-by: Geoffrey Hughes <geoffrey.hughes@otago.ac.nz>

Add the leading \ to look for Redis in the root namespace instead of in CodeIgniter\Cache\Handlers\.