### PR TITLE
Modify getCompiledSelect() method

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1328,7 +1328,7 @@ class BaseBuilder
 	 */
 	public function getCompiledSelect($reset = true)
 	{
-		$select = $this->compileSelect();
+		$select = [$this->compileSelect(), $this->binds];
 
 		if ($reset === true)
 		{


### PR DESCRIPTION
It would be more functional to get compiled select and binds at a given point of query construction, so we would be able to do like this:

```
$sql = $this->builder->getCompiledSelect(false);
$partial_result = $this->db->query($sql[0], $sql[1])->getResultArray();
```

And continue building our complete query adding other clauses, like "limit" and "offset", so we would end up with two subsequent queries.

Thanks.