### PR TITLE
Migrations not returning correct latest version

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -417,7 +417,8 @@ class MigrationRunner
 	{
 		$row = $this->db->table($this->table)
 		                ->select('version')
-					    ->where('group', $group)
+				->where('group', $group)
+				->orderBy('version', 'DESC')
 		                ->get()
 		                ->getRow();
 

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -415,6 +415,13 @@ class MigrationRunner
 	 */
 	protected function getVersion($group = 'default')
 	{
+		if (empty($group))
+		{
+			$config = new \Config\Database();
+			$group = $config->defaultGroup;
+			unset($config);
+		}
+
 		$row = $this->db->table($this->table)
 		                ->select('version')
 				->where('group', $group)
@@ -463,6 +470,13 @@ class MigrationRunner
 	 */
 	protected function removeHistory($version, $group = 'default')
 	{
+		if (empty($group))
+		{
+			$config = new \Config\Database();
+			$group = $config->defaultGroup;
+			unset($config);
+		}
+
 		$this->db->table($this->table)
 				 ->where('version', $version)
 				 ->where('group', $group)


### PR DESCRIPTION
I was getting unexpected results while running migrations up and down. Noticed that when it selects from `migrations` table it always returns first value. This should fix that with ordering by `version` so it always returns biggest/latest value.