### PR TITLE
session->remove fix if passing array

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -481,7 +481,7 @@ class Session implements SessionInterface
 	 *
 	 * @param  $key Identifier of the session property or properties to remove.
 	 */
-	public function remove(string $key)
+	public function remove($key)
 	{
 		if (is_array($key))
 		{

--- a/system/Session/SessionInterface.php
+++ b/system/Session/SessionInterface.php
@@ -111,7 +111,7 @@ interface SessionInterface
 	 *
 	 * @param  $key Identifier of the session property or properties to remove.
 	 */
-	public function remove(string $key);
+	public function remove($key);
 
 	//--------------------------------------------------------------------
 


### PR DESCRIPTION
Documentation says that you can pass array or string to session->remove method. Currently passing an array, will cause error because of the `string` typehint.