### PR TITLE
fix typo session Error Undefined index

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -228,7 +228,7 @@ if (! function_exists('session'))
 		// Returning a single item?
 		if (is_string($val))
 		{
-			return $_SESSION[$val] ?: null;
+			return $_SESSION[$val] ?? null;
 		}
 
 		return \Config\Services::session();


### PR DESCRIPTION
When i use the session function
The following error was encountered

"Undefined index: foobar"

Change

Before
```php
 $_SESSION[$val] ?: null;
```

After
```php
 $_SESSION[$val] ?? null;
```