### PR TITLE
change self to static

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -570,7 +570,7 @@ class Services
 			// Make sure $getShared is false
 			array_push($params, false);
 
-			static::$instances[$key] = self::$key(...$params);
+			static::$instances[$key] = static::$key(...$params);
 		}
 
 		return static::$instances[$key];


### PR DESCRIPTION
The keyword **self** can only call static function in current class. If We will call static function on child class, We should use **static**,  See [Late Static Binding](http://php.net/manual/en/language.oop5.late-static-bindings.php).  This will solve this issue #294 