### PR TITLE
fix a mistake on code example $query->getResult()

### DIFF
--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -34,7 +34,7 @@ as an array of arrays::
 
     $query = $db->query("YOUR QUERY");
 
-	foreach ($query->getResult() as $row)
+	foreach ($query->getResult('array') as $row)
 	{
 		echo $row['title'];
 		echo $row['name'];


### PR DESCRIPTION
Body text explains 'array' parameter, but code example lacks the parameter.