### PR TITLE
fix error set_select() always return selected=selected

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -693,11 +693,6 @@ if (! function_exists('set_select'))
 
         if (($input = $_POST[$field]) !== null)
         {
-            if (! is_array($input))
-            {
-                return ' selected="selected"';
-            }
-
             if (is_array($input))
             {
                 $value = (string)$value;


### PR DESCRIPTION
fix error set_select() always return selected="selected" if $input value is string