### PR TITLE
Make `dataCache` public

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -263,7 +263,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @var array
 	 */
-	protected $dataCache = [];
+	public $dataCache = [];
 
 	/**
 	 * Microtime when connection was made


### PR DESCRIPTION
In `system/Database/Forge.php` there are some piece of codes that actually need to access `dataCache` of `DBConnection` instance.
This will surely fail since `dataCache` is protected.

Other alternative solution such as creating `clearDataCache()` method might actually works, but require a lot of changes too.