### PR TITLE
Fixed sphinx indentation

### DIFF
--- a/user_guide_src/source/database/index.rst
+++ b/user_guide_src/source/database/index.rst
@@ -7,20 +7,20 @@ class that supports both traditional structures and Query Builder
 patterns. The database functions offer clear, simple syntax.
 
 .. toctree::
-	:titlesonly:
+    :titlesonly:
 
-	Quick Start: Usage Examples <examples>
-	Database Configuration <configuration>
-	Connecting to a Database <connecting>
-	Running Queries <queries>
-	Generating Query Results <results>
-	Query Helper Functions <helpers>
-	Query Builder Class <query_builder>
-	Transactions <transactions>
-	Getting MetaData <metadata>
-	Custom Function Calls <call_function>
-	Using CodeIgniter's Model <model>
-	Database Manipulation with Database Forge <forge>
-	Database Migrations <migration>
-	Database Seeding <seeds>
+    Quick Start: Usage Examples <examples>
+    Database Configuration <configuration>
+    Connecting to a Database <connecting>
+    Running Queries <queries>
+    Generating Query Results <results>
+    Query Helper Functions <helpers>
+    Query Builder Class <query_builder>
+    Transactions <transactions>
+    Getting MetaData <metadata>
+    Custom Function Calls <call_function>
+    Using CodeIgniter's Model <model>
+    Database Manipulation with Database Forge <forge>
+    Database Migrations <migration>
+    Database Seeding <seeds>
     Database Hooks <hooks>

--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -3,28 +3,28 @@ General Topics
 ##############
 
 .. toctree::
-	:titlesonly:
+    :titlesonly:
 
-	configuration
-	urls
-	controllers
-	views
-	view_cells
-	view_renderer
-	view_parser
-	helpers
-	core_classes
-	hooks
-	common_functions
-	routing
-	filters
-	logging
-	errors
-	debugging
-	caching
-	cli
+    configuration
+    urls
+    controllers
+    views
+    view_cells
+    view_renderer
+    view_parser
+    helpers
+    core_classes
+    hooks
+    common_functions
+    routing
+    filters
+    logging
+    errors
+    debugging
+    caching
+    cli
     modules
-	managing_apps
-	environments
-	alternative_php
-	testing
+    managing_apps
+    environments
+    alternative_php
+    testing

--- a/user_guide_src/source/installation/index.rst
+++ b/user_guide_src/source/installation/index.rst
@@ -58,12 +58,12 @@ TODO
 
 
 .. toctree::
-	:hidden:
-	:titlesonly:
+    :hidden:
+    :titlesonly:
 
-	downloads
-	self
-	upgrading
-	troubleshooting
+    downloads
+    self
+    upgrading
+    troubleshooting
     local_server
 


### PR DESCRIPTION
Some of the index pages had incorrect indentation, making a bunch of the docs disappear!
Fixed.