### PR TITLE
fix CLI::showProgress()'s message

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -74,13 +74,6 @@ class CLI
 	protected static $initialized = false;
 
 	/**
-	 * Used by the progress bar
-	 *
-	 * @var bool
-	 */
-	protected static $inProgress = false;
-
-	/**
 	 * Foreground color list
 	 * @var array
 	 */
@@ -508,18 +501,14 @@ class CLI
 	 */
 	public static function showProgress($thisStep = 1, int $totalSteps = 10)
 	{
-		// The first time through, save
-		// our position so the script knows where to go
-		// back to when writing the bar, and
-		// at the end of the script.
-		if ( ! static::$inProgress)
-		{
-			fwrite(STDOUT, "\0337");
-			static::$inProgress = true;
-		}
+		static $inProgress = false;
 
-		// Restore position
-		fwrite(STDERR, "\0338");
+		// restore cursor position when progress is continuing.
+		if ($inProgress !== false && $inProgress <= $thisStep)
+		{
+			fwrite(STDOUT, "\033[1A");
+		}
+		$inProgress = $thisStep;
 
 		if ($thisStep !== false)
 		{
@@ -533,13 +522,11 @@ class CLI
 			// Write the progress bar
 			fwrite(STDOUT, "[\033[32m".str_repeat('#', $step).str_repeat('.', 10 - $step)."\033[0m]");
 			// Textual representation...
-			fwrite(STDOUT, " {$percent}% Complete".PHP_EOL);
-			// Move up, undo the PHP_EOL
-			fwrite(STDOUT, "\033[1A");
+			fwrite(STDOUT, sprintf(" %3d%% Complete", $percent).PHP_EOL);
 		}
 		else
 		{
-			fwrite(STDERR, "\007");
+			fwrite(STDOUT, "\007");
 		}
 	}
 

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -2,9 +2,82 @@
 
 class CLITest extends \CIUnitTestCase
 {
+	private $stream_filter;
+
+	public function setUp()
+	{
+		CLITestStreamFilter::$buffer = '';
+		$this->stream_filter = stream_filter_append(STDOUT, 'CLITestStreamFilter');
+	}
+
+	public function tearDown()
+	{
+		stream_filter_remove($this->stream_filter);
+	}
+
 	public function testNew()
 	{
 		$actual = new CLI();
 		$this->assertInstanceOf(CLI::class, $actual);
 	}
+
+	public function testShowProgress()
+	{
+		CLI::write('first.');
+		CLI::showProgress(1, 20);
+		CLI::showProgress(10, 20);
+		CLI::showProgress(20, 20);
+		CLI::write('second.');
+		CLI::showProgress(1, 20);
+		CLI::showProgress(10, 20);
+		CLI::showProgress(20, 20);
+		CLI::write('third.');
+		CLI::showProgress(1, 20);
+
+		$expected = <<<EOT
+first.
+[\033[32m#.........\033[0m]   5% Complete
+\033[1A[\033[32m#####.....\033[0m]  50% Complete
+\033[1A[\033[32m##########\033[0m] 100% Complete
+second.
+[\033[32m#.........\033[0m]   5% Complete
+\033[1A[\033[32m#####.....\033[0m]  50% Complete
+\033[1A[\033[32m##########\033[0m] 100% Complete
+third.
+[\033[32m#.........\033[0m]   5% Complete
+
+EOT;
+		$this->assertEquals($expected, CLITestStreamFilter::$buffer);
+	}
+
+	public function testShowProgressWithoutBar()
+	{
+		CLI::write('first.');
+		CLI::showProgress(false, 20);
+		CLI::showProgress(false, 20);
+		CLI::showProgress(false, 20);
+
+		$expected = <<<EOT
+first.
+\007\007\007
+EOT;
+		$this->assertEquals($expected, CLITestStreamFilter::$buffer);
+	}
 }
+
+
+class CLITestStreamFilter extends \php_user_filter
+{
+	public static $buffer = '';
+
+	public function filter($in, $out, &$consumed, $closing)
+	{
+		while ($bucket = stream_bucket_make_writeable($in)) {
+			self::$buffer .= $bucket->data;
+			$consumed += $bucket->datalen;
+		}
+		return PSFS_PASS_ON;
+	}
+}
+
+stream_filter_register('CLITestStreamFilter', 'CodeIgniter\CLI\CLITestStreamFilter');


### PR DESCRIPTION
https://github.com/bcit-ci/CodeIgniter4/issues/135 is caused by indicator length changing, so I fix length.

By the way, when showProgress() runs 2 cycles, first cycle indicator is deleted.I fix it too.