### PR TITLE
fix transStart() connection init

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -781,6 +781,11 @@ abstract class BaseConnection implements ConnectionInterface
             return true;
         }
 
+		if (empty($this->connID))
+		{
+			$this->initialize();
+		}
+
         // Reset the transaction failure flag.
         // If the $test_mode flag is set to TRUE transactions will be rolled back
         // even if the queries produce a successful result.


### PR DESCRIPTION
When $db->transStart() is called before any query, an error occurs because connID is false.

```
An uncaught Exception was encountered

Type:        Error
Message:     Call to a member function autocommit() on boolean
Filename:    /path/to/project/system/Database/MySQLi/Connection.php
Line Number: 479
```

Lazy initialize calling is lacked on trans*()