### PR TITLE
QueryBuilder set() depend call-order when the same column is used at 'where'

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1308,8 +1308,8 @@ class BaseBuilder
 
 		foreach ($key as $k => $v)
 		{
-			$this->binds[$k]                                            = $v;
-			$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ':'.$k;
+			$bind = $this->setBind($k, $v);
+			$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ':'.$bind;
 		}
 
 		return $this;

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -166,6 +166,7 @@ WHERE "id" IN(2,3)';
 
 	public function testUpdateWithWhereSameColumn2()
 	{
+		// calling order: set() -> where()
 		$builder = new BaseBuilder('jobs', $this->db);
 
 		$builder->set('name', 'foobar')
@@ -183,6 +184,7 @@ WHERE "id" IN(2,3)';
 
 	public function testUpdateWithWhereSameColumn3()
 	{
+		// calling order: where() -> set() in update()
 		$builder = new BaseBuilder('jobs', $this->db);
 
 		$builder->where('name', 'Programmer')

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -149,4 +149,49 @@ WHERE "id" IN(2,3)';
 
 	//--------------------------------------------------------------------
 
+	public function testUpdateWithWhereSameColumn()
+	{
+		$builder = new BaseBuilder('jobs', $this->db);
+
+		$builder->update(['name' => 'foobar'], ['name' => 'Programmer'], null, true);
+
+		$expectedSQL = 'UPDATE "jobs" SET "name" = :name WHERE "name" = :name0';
+		$expectedBinds = ['name' => 'foobar', 'name0' => 'Programmer'];
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+		$this->assertEquals($expectedBinds, $builder->getBinds());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testUpdateWithWhereSameColumn2()
+	{
+		$builder = new BaseBuilder('jobs', $this->db);
+
+		$builder->set('name', 'foobar')
+			->where('name', 'Programmer')
+			->update(null, null, null, true);
+
+		$expectedSQL = 'UPDATE "jobs" SET "name" = :name WHERE "name" = :name0';
+		$expectedBinds = ['name' => 'foobar', 'name0' => 'Programmer'];
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+		$this->assertEquals($expectedBinds, $builder->getBinds());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testUpdateWithWhereSameColumn3()
+	{
+		$builder = new BaseBuilder('jobs', $this->db);
+
+		$builder->where('name', 'Programmer')
+			->update(['name' => 'foobar'], null, null, true);
+
+		$expectedSQL = 'UPDATE "jobs" SET "name" = :name0 WHERE "name" = :name';
+		$expectedBinds = ['name' => 'Programmer', 'name0' => 'foobar'];
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+		$this->assertEquals($expectedBinds, $builder->getBinds());
+	}
 }

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -109,6 +109,20 @@ class WhereTest extends \CIUnitTestCase
 		$this->assertSame($expectedBinds, $builder->getBinds());
 	}
 
+	public function testOrWhereSameColumn()
+	{
+		$builder = $this->db->table('jobs');
+
+		$builder->where('name', 'Accountant')
+				->orWhere('name', 'foobar');
+
+		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "name" = :name OR "name" = :name0';
+		$expectedBinds = ['name' => 'Accountant', 'name0' => 'foobar'];
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+		$this->assertSame($expectedBinds, $builder->getBinds());
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testWhereIn()

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -109,6 +109,8 @@ class WhereTest extends \CIUnitTestCase
 		$this->assertSame($expectedBinds, $builder->getBinds());
 	}
 
+	//--------------------------------------------------------------------
+
 	public function testOrWhereSameColumn()
 	{
 		$builder = $this->db->table('jobs');

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -125,6 +125,73 @@ class UpdateTest extends \CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testUpdateWithWhereSameColumn()
+	{
+		$this->db->table('user')
+		         ->update(['country' => 'CA'], ['country' => 'US']);
+
+		$result = $this->db->table('user')->get()->getResultArray();
+
+		$rows = [];
+
+		foreach ($result as $row)
+		{
+			if ($row['country'] == 'CA')
+			{
+				$rows[] = $row;
+			}
+		}
+
+		$this->assertEquals(2, count($rows));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testUpdateWithWhereSameColumn2()
+	{
+		// calling order: set() -> where()
+		$this->db->table('user')
+		         ->set('country', 'CA')
+		         ->where('country', 'US')
+		         ->update();
+
+		$result = $this->db->table('user')->get()->getResultArray();
+
+		$rows = [];
+
+		foreach ($result as $row)
+		{
+			if ($row['country'] == 'CA')
+			{
+				$rows[] = $row;
+			}
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testUpdateWithWhereSameColumn3()
+	{
+		// calling order: where() -> set() in update()
+		$this->db->table('user')
+		         ->where('country', 'US')
+		         ->update(['country' => 'CA']);
+
+		$result = $this->db->table('user')->get()->getResultArray();
+
+		$rows = [];
+
+		foreach ($result as $row)
+		{
+			if ($row['country'] == 'CA')
+			{
+				$rows[] = $row;
+			}
+		}
+	}
+
+	//--------------------------------------------------------------------
+
     /**
      * @group single
      * @see https://github.com/bcit-ci/CodeIgniter4/issues/324

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -73,6 +73,21 @@ class WhereTest extends \CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testOrWhereSameColumn()
+	{
+		$jobs = $this->db->table('job')
+		                ->where('name', 'Developer')
+		                ->orWhere('name', 'Politician')
+		                ->get()
+		                ->getResult();
+
+		$this->assertEquals(2, count($jobs));
+		$this->assertEquals('Developer', $jobs[0]->name);
+		$this->assertEquals('Politician', $jobs[1]->name);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testWhereIn()
 	{
 	    $jobs = $this->db->table('job')


### PR DESCRIPTION
before fixing it, placeholders are duplicated.
This occers just when calling the order: where() -> set().
There is no probrem at set() -> where().

```
$ phpunit tests/system/Database/Builder/UpdateTest.php 

==== Redirecting to composer installed version in vendor/phpunit ====

PHPUnit 5.3.5 by Sebastian Bergmann and contributors.

..........F                                                       11 / 11 (100%)

Time: 45 ms, Memory: 4.00MB

There was 1 failure:

1) CodeIgniter\Database\Builder\UpdateTest::testUpdateWithWhereSameColumn3
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'UPDATE "jobs" SET "name" = :name0 WHERE "name" = :name'
+'UPDATE "jobs" SET "name" = :name WHERE "name" = :name'

/path/to/project/tests/system/Database/Builder/UpdateTest.php:194

FAILURES!
Tests: 11, Assertions: 22, Failures: 1.
```