### PR TITLE
fix BaseBuilder::set()'s escaping param

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1287,11 +1287,11 @@ class BaseBuilder
 	/**
 	 * The "set" function.
 	 *
-	 * Allows key/value pairs to be set for inserting or updating
+	 * Allows key/value pairs to be set for insert(), update() or replace().
 	 *
-	 * @param    mixed
-	 * @param    string
-	 * @param    bool
+	 * @param    string|array $key    Field name, or an array of field/value pairs
+	 * @param    string       $value  Field value, if $key is a single field
+	 * @param    bool                 Whether to escape values and identifiers
 	 *
 	 * @return    BaseBuilder
 	 */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1308,8 +1308,15 @@ class BaseBuilder
 
 		foreach ($key as $k => $v)
 		{
-			$bind = $this->setBind($k, $v);
-			$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ':'.$bind;
+			if ($escape)
+			{
+				$bind = $this->setBind($k, $v);
+				$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ':'.$bind;
+			}
+			else
+			{
+				$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = $v;
+			}
 		}
 
 		return $this;

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -168,7 +168,7 @@ class Builder extends BaseBuilder
 
 		if (empty($exists))
 		{
-			$result = $builder->insert($set, false);
+			$result = $builder->insert($set);
 		}
 		else
 		{

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -196,4 +196,22 @@ WHERE "id" IN(2,3)';
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
 		$this->assertEquals($expectedBinds, $builder->getBinds());
 	}
+
+	//--------------------------------------------------------------------
+
+	// @see https://bcit-ci.github.io/CodeIgniter4/database/query_builder.html#updating-data
+	public function testSetWithoutEscape()
+	{
+		$builder = new BaseBuilder('mytable', $this->db);
+
+		$builder->set('field', 'field+1', false)
+			->where('id', 2)
+			->update(null, null, null, true);
+
+		$expectedSQL = 'UPDATE "mytable" SET field = field+1 WHERE "id" = :id';
+		$expectedBinds = ['id' => 2];
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+		$this->assertEquals($expectedBinds, $builder->getBinds());
+	}
 }

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -209,5 +209,21 @@ class UpdateTest extends \CIDatabaseTestCase
         ]);
     }
 
+	//--------------------------------------------------------------------
+
+	// @see https://bcit-ci.github.io/CodeIgniter4/database/query_builder.html#updating-data
+	public function testSetWithoutEscape()
+	{
+		$this->db->table('job')
+		         ->set('description', 'name', false)
+		         ->update();
+
+		$result = $this->db->table('user')->get()->getResultArray();
+
+		$this->seeInDatabase('job', [
+			'name' => 'Developer',
+			'description' => 'Developer',
+		]);
+	}
 
 }

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -751,7 +751,7 @@ parameter.
 
 	$builder->set('field', 'field+1', FALSE);
 	$builder->where('id', 2);
-	$builder->update(); // gives UPDATE mytable SET field = field+1 WHERE id = 2
+	$builder->update(); // gives UPDATE mytable SET field = field+1 WHERE `id` = 2
 
 	$builder->set('field', 'field+1');
 	$builder->where('id', 2);


### PR DESCRIPTION
Maybe this is different to what you are aiming for.
I don't have a good feeling about assigning raw data to $this->QBSet... But I can't find another way.