### PR TITLE
Fixes #363: exclude various templates files and directory from phpunit whitelist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,9 +19,12 @@
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./system</directory>
             <exclude>
+                <file>./system/Commands/Sessions/Views/migration.tpl.php</file>
                 <file>./system/ComposerScripts.php</file>
+                <directory>./system/Debug/Toolbar/Views</directory>
+                <directory>./system/Pager/Views</directory>
                 <directory>./system/ThirdParty</directory>
-                <directory>./system/Debug/Toolbar/View</directory>
+                <directory>./system/Validation/Views</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
Fixes #363 . To avoid undefined variable error during coverage reporting for templates for `--coverage-text` or `--coverage-html`
