### PR TITLE
Fixes Cannot declare class CodeIgniter\Services and already defined ROOTPATH constant in run phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./system</directory>
             <exclude>
+                <file>./system/bootstrap.php</file>
                 <file>./system/Commands/Sessions/Views/migration.tpl.php</file>
                 <file>./system/ComposerScripts.php</file>
                 <directory>./system/Debug/Toolbar/Views</directory>

--- a/tests/_support/_bootstrap.php
+++ b/tests/_support/_bootstrap.php
@@ -67,9 +67,6 @@ require BASEPATH.'Autoloader/Autoloader.php';
 require APPPATH .'Config/Autoload.php';
 require APPPATH .'Config/Services.php';
 
-// Use Config\Services as CodeIgniter\Services
-class_alias('Config\Services', 'CodeIgniter\Services');
-
 $loader = CodeIgniter\Services::autoloader();
 $loader->initialize(new Config\Autoload());
 $loader->register();    // Register the loader with the SPL autoloader stack.


### PR DESCRIPTION
with remove class_alias in tests/_support/bootstrap.php and exclude system/bootstrap.php from phpunit.xml.