### PR TITLE
set Session\Handlers\FileHandlers::$fileNew default value as TRUE

### DIFF
--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -69,7 +69,7 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	 *
 	 * @var bool
 	 */
-	protected $fileNew;
+	protected $fileNew = true;
 
 	//--------------------------------------------------------------------
 


### PR DESCRIPTION
to avoid error `touch(): Unable to create file` on 2nd refresh after file created as `$fileNew` property never initialized before.