### PR TITLE
set default $text parameter value as "" in CLI::write()

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -288,7 +288,7 @@ class CLI
 	 * @param string $foreground
 	 * @param string $background
 	 */
-	public static function write(string $text, string $foreground = null, string $background = null)
+	public static function write(string $text = '', string $foreground = null, string $background = null)
 	{
 		if ($foreground || $background)
 		{

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -63,6 +63,11 @@ first.
 EOT;
 		$this->assertEquals($expected, CLITestStreamFilter::$buffer);
 	}
+
+	public function testWait()
+	{
+		CLI::wait(1, true);
+	}
 }
 
 


### PR DESCRIPTION
to avoid error when it called at as `static::write();` at `CLI::wait()`