### PR TITLE
exclude system/Config/Routes in phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
                 <file>./system/bootstrap.php</file>
                 <file>./system/Commands/Sessions/Views/migration.tpl.php</file>
                 <file>./system/ComposerScripts.php</file>
+                <file>./system/Config/Routes.php</file>
                 <directory>./system/Debug/Toolbar/Views</directory>
                 <directory>./system/Pager/Views</directory>
                 <directory>./system/ThirdParty</directory>


### PR DESCRIPTION
to avoid error undefined variable $routes on run phpunit with coverage generation