### PR TITLE
Show Debug Toolbar Only For HTML Responses

### DIFF
--- a/application/Filters/DebugToolbar.php
+++ b/application/Filters/DebugToolbar.php
@@ -33,7 +33,9 @@ class DebugToolbar implements FilterInterface
 	 */
 	public function after(RequestInterface $request, ResponseInterface $response)
 	{
-		if ( ! is_cli() && CI_DEBUG)
+        $format = $response->getHeaderLine('content-type');
+
+        if ( ! is_cli() && CI_DEBUG && strpos($format, 'html') !== false)
 		{
 			global $app;
 


### PR DESCRIPTION
Only show the debug toolbar for responses containing HTML, allowing other responses (such as JSON and XML) to show clean.