### PR TITLE
fix forge using composite key and add getting indexes metadata

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1611,6 +1611,21 @@ abstract class BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns an object with key data
+	 *
+	 * @param	string	$table	the table name
+	 * @return	array
+	 */
+	public function getIndexData(string $table)
+	{
+		$fields = $this->_indexData($this->protectIdentifiers($table, true, false, false));
+
+		return $fields ?? false;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Allows the engine to be set into a mode where queries are not
 	 * actually executed, but they are still generated, timed, etc.
 	 *

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -271,19 +271,12 @@ class Forge
 	 */
 	public function addKey($key, $primary = false)
 	{
-		if (is_array($key))
-		{
-			foreach ($key as $one)
-			{
-				$this->addKey($one, $primary);
-			}
-
-			return $this;
-		}
-
 		if ($primary === true)
 		{
-			$this->primaryKeys[] = $key;
+			foreach ((array) $key as $one)
+			{
+				$this->primaryKeys[] = $one;
+			}
 		}
 		else
 		{
@@ -1068,24 +1061,19 @@ class Forge
 
 		for ($i = 0, $c = count($this->keys); $i < $c; $i++)
 		{
-			if (is_array($this->keys[$i]))
+			$this->keys[$i] = (array) $this->keys[$i];
+
+			for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2++)
 			{
-				for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2++)
+				if ( ! isset($this->fields[$this->keys[$i][$i2]]))
 				{
-					if ( ! isset($this->fields[$this->keys[$i][$i2]]))
-					{
-						unset($this->keys[$i][$i2]);
-						continue;
-					}
+					unset($this->keys[$i][$i2]);
 				}
 			}
-			elseif ( ! isset($this->fields[$this->keys[$i]]))
+			if (count($this->keys[$i]) <= 0)
 			{
-				unset($this->keys[$i]);
 				continue;
 			}
-
-			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sqls[] = 'CREATE INDEX '.$this->db->escapeIdentifiers($table.'_'.implode('_', $this->keys[$i]))
 			          .' ON '.$this->db->escapeIdentifiers($table)

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -321,6 +321,41 @@ class Connection extends BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns an object with index data
+	 *
+	 * @param	string	$table
+	 * @return	array
+	 */
+	public function _indexData(string $table)
+	{
+		$sql = 'SELECT "indexname", "indexdef"
+			FROM "pg_indexes"
+			WHERE LOWER("tablename") = '.$this->escape(strtolower($table)).'
+			  AND "schemaname" = '.$this->escape('public');
+
+		if (($query = $this->query($sql)) === false)
+		{
+			return false;
+		}
+		$query = $query->getResultObject();
+
+		$retval = [];
+		foreach ($query as $row)
+		{
+			$obj         = new \stdClass();
+			$obj->name   = $row->indexname;
+			$_fields     = explode(',', preg_replace('/^.*\((.+?)\)$/', '$1', trim($row->indexdef)));
+			$obj->fields = array_map(function($v){ return trim($v); }, $_fields);
+
+			$retval[] = $obj;
+		}
+
+		return $retval;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the last error code and message.
 	 *
 	 * Must return an array with keys 'code' and 'message':

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -39,5 +39,7 @@ class ForgeTest extends \CIDatabaseTestCase
 		$keys = $this->db->getIndexData('forge_test_1');
 		$this->assertEquals($keys[0]->fields, ['id']);
 		$this->assertEquals($keys[1]->fields, ['code', 'company']);
+
+		$this->forge->dropTable('forge_test_1', true);
 	}
 }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1,0 +1,43 @@
+<?php namespace CodeIgniter\Database\Live;
+
+/**
+ * @group DatabaseLive
+ */
+class ForgeTest extends \CIDatabaseTestCase
+{
+	protected $refresh = true;
+
+	protected $seed = 'CITestSeeder';
+
+	public function setUp()
+	{
+		parent::setUp();
+		$this->forge = \Config\Database::forge($this->DBGroup);
+	}
+
+	public function testCompositeKey()
+	{
+		$this->forge->addField([
+			'id'          => [
+				'type'           => 'INTEGER',
+				'constraint'     => 3,
+				'auto_increment' => true,
+			],
+			'code'        => [
+				'type'       => 'VARCHAR',
+				'constraint' => 40,
+			],
+			'company'        => [
+				'type'       => 'VARCHAR',
+				'constraint' => 40,
+			],
+		]);
+		$this->forge->addKey('id', true);
+		$this->forge->addKey(['code', 'company']);
+		$this->forge->createTable('forge_test_1', true);
+
+		$keys = $this->db->getIndexData('forge_test_1');
+		$this->assertEquals($keys[0]->fields, ['id']);
+		$this->assertEquals($keys[1]->fields, ['code', 'company']);
+	}
+}

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -94,7 +94,7 @@ performing an action. Returns a boolean TRUE/FALSE. Usage example::
 Retrieve Field Metadata
 =======================
 
-**$db->fieldData()**
+**$db->getFieldData()**
 
 Returns an array of objects containing field information.
 
@@ -128,3 +128,10 @@ database:
 -  max_length - maximum length of the column
 -  primary_key - 1 if the column is a primary key
 -  type - the type of the column
+
+List the Indexes in a Table
+==========================
+
+**$db->getIndexData()**
+
+please write this, someone...


### PR DESCRIPTION
https://ci-trans-jp.gitlab.io/user_guide_4_jp/database/forge.html#adding-keys

> $forge->addKey(array('blog_name', 'blog_label'));
> // gives KEY `blog_name_blog_label` (`blog_name`, `blog_label`)

Actually, it gives KEY `blog_name` (`blog_name`) and KEY `blog_label` (`blog_label`).
This PR fixes it.

And the testcode requires a way to get index metadata, so I make functions on DB classes.