### PR TITLE
Fix SelectTest to enable --exclude-group=DatabaseLive without database

### DIFF
--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -2,6 +2,9 @@
 
 use CodeIgniter\Database\BasePreparedQuery;
 
+/**
+ * @group DatabaseLive
+ */
 class PreparedQueryTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -7,6 +7,12 @@ use CodeIgniter\Database\Query;
  */
 class PretendTest extends \CIDatabaseTestCase
 {
+	public function tearDown()
+	{
+		// We share `$this->db` in testing, so we need to restore the state.
+		$this->db->pretend(false);
+	}
+
 	public function testPretendReturnsQueryObject()
 	{
 		$result = $this->db->pretend(false)
@@ -17,7 +23,7 @@ class PretendTest extends \CIDatabaseTestCase
 
 		$result = $this->db->pretend(true)
 					->table('user')
-				 	->get();
+					->get();
 
 		$this->assertTrue($result instanceof Query);
 	}

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -11,20 +11,11 @@ class SelectTest extends \CIDatabaseTestCase
 
 	protected $seed = 'CITestSeeder';
 
-	public function __construct()
-	{
-	    parent::__construct();
-
-		$this->db = \Config\Database::connect($this->DBGroup);
-		$this->db->initialize();
-	}
-
 	//--------------------------------------------------------------------
-
 
 	public function testSelectAllByDefault()
 	{
-	    $row = $this->db->table('job')->get()->getRowArray();
+		$row = $this->db->table('job')->get()->getRowArray();
 
 		$this->assertArrayHasKey('id', $row);
 		$this->assertArrayHasKey('name', $row);

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -360,6 +360,9 @@ class ValidationTest extends \CIUnitTestCase
 
     //--------------------------------------------------------------------
 
+    /**
+    * @group DatabaseLive
+    */
     public function testIsUniqueFalse()
     {
         $data = [
@@ -375,6 +378,9 @@ class ValidationTest extends \CIUnitTestCase
 
     //--------------------------------------------------------------------
 
+    /**
+    * @group DatabaseLive
+    */
     public function testIsUniqueTrue()
     {
         $data = [
@@ -390,6 +396,9 @@ class ValidationTest extends \CIUnitTestCase
 
     //--------------------------------------------------------------------
 
+    /**
+    * @group DatabaseLive
+    */
     public function testIsUniqueIgnoresParams()
     {
         $db  = Database::connect();


### PR DESCRIPTION
It seems PHPUnit calls the constructor in SelectTest even if I add `--exclude-group=DatabaseLive`.
So it causes the following error:
```
An uncaught Exception was encountered

Type:        InvalidArgumentException
Message:     You have not selected a database type to connect to.
Filename:    /.../CodeIgniter4/system/Database/Database.php
Line Number: 75
```
