### PR TITLE
Fix some bugs when using ToolBar with Closure Controller

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -250,6 +250,11 @@ class CodeIgniter
 
             $returned = $this->runController($controller);
         }
+		else
+		{
+			$this->benchmark->stop('controller_constructor');
+			$this->benchmark->stop('controller');
+		}
 
         // If $returned is a string, then the controller output something,
         // probably a view, instead of echoing it directly. Send it along

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -88,8 +88,8 @@ class Routes extends BaseCollector
 		$route = $router->getMatchedRoute();
 
 		// Get our parameters
-        $method = new \ReflectionMethod($router->controllerName(), $router->methodName());
-        $rawParams = $method->getParameters();
+		$method = is_callable($router->controllerName()) ? new \ReflectionFunction($router->controllerName()) : new \ReflectionMethod($router->controllerName(), $router->methodName());
+		$rawParams = $method->getParameters();
 
         $params = [];
         foreach ($rawParams as $key => $param)

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -292,6 +292,14 @@ class Parser extends View {
 
 						continue;
 					}
+					else if (is_object($val))
+					{
+						$val = 'Class: ' . get_class($val);
+					}
+					else if (is_resource($val))
+					{
+						$val = 'Resource';
+					}
 
 					$temp[$this->leftDelimiter . $key . $this->rightDelimiter] = $val;
 				}


### PR DESCRIPTION
1 Got  `Uncaught ErrorException: Object of class Closure could not be converted to string `
  when showing `DEFINED ROUTES`.

2 Got `Uncaught ReflectionException: Method Closure::index() does not exist`
 when showing `MATCHED ROUTE`.

3 Timer for Controller and Controller Constructor should be stopped after running closure controller.