### PR TITLE
Escape $message in HTML 404 error template

### DIFF
--- a/application/Views/errors/html/error_404.php
+++ b/application/Views/errors/html/error_404.php
@@ -76,7 +76,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 		<p>
 			<?php if (! empty($message) && $message != '(null)') : ?>
-				<?= $message ?>
+				<?= esc($message) ?>
 			<?php else : ?>
 				Sorry! Cannot seem to find the page you were looking for.
 			<?php endif ?>


### PR DESCRIPTION
All variables in HTML should be escaped.
