### PR TITLE
Add Language File Array Support

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -88,14 +88,14 @@ class Language
 
 	/**
 	 * Parses the language string for a file, loads the file, if necessary,
-	 * getting
+	 * getting the line.
 	 *
-	 * @param string $line
-	 * @param array  $args
+	 * @param string $line Line.
+	 * @param array  $args Arguments.
 	 *
-	 * @return string
+	 * @return string|string[] Returns line.
 	 */
-	public function getLine(string $line, array $args = []): string
+	public function getLine(string $line, array $args = [])
 	{
 		// Parse out the file name and the actual alias.
 		// Will load the language file and strings.
@@ -105,11 +105,8 @@ class Language
 			? $this->language[$file][$line]
 			: $line;
 
-		// Do advanced message formatting here
-		// if the 'intl' extension is available.
-		if ($this->intlSupport && count($args))
-		{
-			$output = \MessageFormatter::formatMessage($this->locale, $output, $args);
+		if (count($args)) {
+			$output = $this->formatMessage($output, $args);
 		}
 
 		return $output;
@@ -144,6 +141,32 @@ class Language
 			$file,
 			$this->language[$line] ?? $line
 		];
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Advanced message formatting.
+	 *
+	 * @param string|array $message Message.
+	 * @param array	       $args    Arguments.
+	 *
+	 * @return string|array Returns formatted message.
+	 */
+	protected function formatMessage($message, array $args = [])
+	{
+		if (! $this->intlSupport || ! count($args)) {
+			return $message;
+		}
+
+		if (is_array($message)) {
+			foreach ($message as $index => $value) {
+				$message[$index] = $this->formatMessage($value, $args);
+			}
+			return $message;
+		}
+
+		return \MessageFormatter::formatMessage($this->locale, $message, $args);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -155,12 +155,15 @@ class Language
 	 */
 	protected function formatMessage($message, array $args = [])
 	{
-		if (! $this->intlSupport || ! count($args)) {
+		if (! $this->intlSupport || ! count($args))
+		{
 			return $message;
 		}
 
-		if (is_array($message)) {
-			foreach ($message as $index => $value) {
+		if (is_array($message))
+		{
+			foreach ($message as $index => $value)
+			{
 				$message[$index] = $this->formatMessage($value, $args);
 			}
 			return $message;

--- a/system/Language/en/Language.php
+++ b/system/Language/en/Language.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'languageGetLineInvalidArgumentException' => 'Get line must be a string or array of strings.'
+];

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -67,8 +67,9 @@ class LanguageTest extends \CIUnitTestCase
 
 	public function testGetLineArrayFormatsMessages()
 	{
-		// No intl extension? then we can't test this - go away....
-		if (! class_exists('\MessageFormatter')) {
+		// No intl extension? Then we can't test this - go away...
+		if (! class_exists('\MessageFormatter'))
+		{
 			return;
 		}
 

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -27,6 +27,25 @@ class LanguageTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testGetLineArrayReturnsLineArray()
+	{
+		$lang = new MockLanguage('en');
+
+		$lang->setData([
+			'booksList' => [
+				'The Boogeyman',
+				'We Saved'
+			]
+		]);
+
+		$this->assertEquals([
+			'The Boogeyman',
+			'We Saved'
+		], $lang->getLine('books.booksList'));
+	}
+
+	//--------------------------------------------------------------------
+
 	/**
 	 * @group single
 	 */
@@ -42,6 +61,26 @@ class LanguageTest extends \CIUnitTestCase
 		]);
 
 		$this->assertEquals('45 books have been saved.', $lang->getLine('books.bookCount', [91/2]));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testGetLineArrayFormatsMessages()
+	{
+		// No intl extension? then we can't test this - go away....
+		if (! class_exists('\MessageFormatter')) {
+			return;
+		}
+
+		$lang = new MockLanguage('en');
+
+		$lang->setData([
+			'bookList' => [
+				'{0, number, integer} related books.'
+			]
+		]);
+
+		$this->assertEquals(['45 related books.'], $lang->getLine('books.bookList', [91/2]));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1184,7 +1184,7 @@ class ValidationTest extends \CIUnitTestCase
             ['0', false],
             ['12', true],
             ['42a', false],
-            ['-1', false],
+            ['-1', false]
         ];
     }
 

--- a/user_guide_src/source/libraries/localization.rst
+++ b/user_guide_src/source/libraries/localization.rst
@@ -226,3 +226,22 @@ You should be sure to read up on the MessageFormatter class and the underlying I
 idea on what capabilities it has, like permorming conditional replacement, pluralization, and more. Both of the links provided
 earlier will give you an excellent idea as to the options available.
 
+Nested Arrays
+-------------
+
+Language files also allow nested arrays to make working with lists, etc… easier.
+
+    // Language/en/Fruit.php
+    return [
+        'list' => [
+            'Apples',
+            'Bananas',
+            'Grapes',
+            'Lemons',
+            'Oranges',
+            'Strawberries'
+        ]
+    ];
+
+    // Displays "Apples, Bananas, Graps, Lemons, Oranges, Strawberries"
+    echo implode(', ', lang('Fruit.list'));


### PR DESCRIPTION
Allows a language file to contain an array of strings to make working with lists easier.

Issue: #414

Signed-off-by: Kristian Matthews <kristian.matthews@me.com>