### PR TITLE
Validation Get & Set Rule Groups

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -354,11 +354,13 @@ class Validation implements ValidationInterface
 	 */
 	public function getRuleGroup(string $group): array
 	{
-		if (!isset($this->config->$group)) {
+		if (! isset($this->config->$group))
+		{
 			throw new \InvalidArgumentException(sprintf(lang('Validation.groupNotFound'), $group));
 		}
 
-		if (!is_array($this->config->$group)) {
+		if (!is_array($this->config->$group))
+		{
 			throw new \InvalidArgumentException(sprintf(lang('Validation.groupNotArray'), $group));
 		}
 
@@ -366,6 +368,7 @@ class Validation implements ValidationInterface
 	}
 
 	//--------------------------------------------------------------------
+
 	/**
 	 * Set rule group.
 	 *
@@ -380,7 +383,8 @@ class Validation implements ValidationInterface
 		$this->rules = $rules;
 
 		$errorName = $group . '_errors';
-		if (isset($this->config->$errorName)) {
+		if (isset($this->config->$errorName))
+		{
 			$this->customErrors = $this->config->$errorName;
 		}
 	}

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -343,7 +343,50 @@ class Validation implements ValidationInterface
 
 	//--------------------------------------------------------------------
 
-    /**
+	/**
+	 * Get rule group.
+	 *
+	 * @param string $group Group.
+	 *
+	 * @return string[] Rule group.
+	 *
+	 * @throws \InvalidArgumentException If group not found.
+	 */
+	public function getRuleGroup(string $group): array
+	{
+		if (!isset($this->config->$group)) {
+			throw new \InvalidArgumentException(sprintf(lang('Validation.groupNotFound'), $group));
+		}
+
+		if (!is_array($this->config->$group)) {
+			throw new \InvalidArgumentException(sprintf(lang('Validation.groupNotArray'), $group));
+		}
+
+		return $this->config->$group;
+	}
+
+	//--------------------------------------------------------------------
+	/**
+	 * Set rule group.
+	 *
+	 * @param string $group Group.
+	 *
+	 *
+	 * @throws \InvalidArgumentException If group not found.
+	 */
+	public function setRuleGroup(string $group)
+	{
+		$rules = $this->getRuleGroup($group);
+		$this->rules = $rules;
+
+		$errorName = $group . '_errors';
+		if (isset($this->config->$errorName)) {
+			$this->customErrors = $this->config->$errorName;
+		}
+	}
+
+
+/**
      * Returns the rendered HTML of the errors as defined in $template.
      *
      * @param string $template

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -237,7 +237,6 @@ class ValidationTest extends \CIUnitTestCase
 		$this->validation->setRuleGroup('groupZ');
 	}
 
-
 	//--------------------------------------------------------------------
     // Rules Tests
     //--------------------------------------------------------------------

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -202,7 +202,43 @@ class ValidationTest extends \CIUnitTestCase
 
     //--------------------------------------------------------------------
 
-    //--------------------------------------------------------------------
+	public function testGetRuleGroup()
+	{
+		$this->assertEquals([
+			'foo' => 'required|min_length[5]',
+		], $this->validation->getRuleGroup('groupA'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testGetRuleGroupException()
+	{
+		$this->expectException('\InvalidArgumentException');
+		$this->validation->getRuleGroup('groupZ');
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetRuleGroup()
+	{
+		$this->validation->setRuleGroup('groupA');
+
+		$this->assertEquals([
+			'foo' => 'required|min_length[5]',
+		], $this->validation->getRules());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetRuleGroupException()
+	{
+		$this->expectException('\InvalidArgumentException');
+
+		$this->validation->setRuleGroup('groupZ');
+	}
+
+
+	//--------------------------------------------------------------------
     // Rules Tests
     //--------------------------------------------------------------------
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -303,6 +303,23 @@ be used for any errors when this group is used::
 
 See below for details on the formatting of the array.
 
+Getting & Setting Rule Groups
+=============================
+
+Get Rule Group
+--------------
+
+This method gets a rule group from the validation configuration.
+
+    $validation->getRuleGroup('signup');
+
+Set Rule Group
+--------------
+
+This method sets a rule group from the validation configuration to the validation service.
+
+    $validation->setRuleGroup('signup');
+
 *******************
 Working With Errors
 *******************


### PR DESCRIPTION
Created `Validation->getRuleGroup(string $group): array` and `Validation->setRuleGroup(string $group)` methods to get and set rule groups.

Issue: #419

Signed-off-by: Kristian Matthews <kristian.matthews@me.com>