### PR TITLE
Create Response Trait Fail Server Error Method

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -299,11 +299,11 @@ trait ResponseTrait
 	/**
 	 * Used when there is a server error.
 	 *
-	 * @param string      $description Description
-	 * @param string|null $code        Code.
-	 * @param string      $message     Message.
+	 * @param string      $description The error message to show the user.
+	 * @param string|null $code        A custom, API-specific, error code.
+	 * @param string      $message     A custom "reason" message to return.
 	 *
-	 * @return Response Response.
+	 * @return Response The value of the Response's send() method.
 	 */
 	public function failServerError(string $description, string $code = null, string $message = ''): Response
 	{

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -36,8 +36,10 @@
  * @filesource
  */
 
+use CodeIgniter\HTTP\Response;
+
 /**
- * Class ResponseTrait
+ * Response trait.
  *
  * Provides common, more readable, methods to provide
  * consistent HTTP responses under a variety of common
@@ -294,6 +296,19 @@ trait ResponseTrait
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * Used when there is a server error.
+	 *
+	 * @param string      $description Description
+	 * @param string|null $code        Code.
+	 * @param string      $message     Message.
+	 *
+	 * @return Response Response.
+	 */
+	public function failServerError(string $description, string $code = null, string $message = ''): Response
+	{
+		return $this->fail($description, $this->codes['server_error'], $code, $message);
+	}
 
 	//--------------------------------------------------------------------
 	// Utility Methods

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -276,4 +276,19 @@ class ResponseTraitTest extends \CIUnitTestCase
         $this->assertEquals(json_encode($expected), $this->response->getBody());
     }
 
+    public function testServerError()
+    {
+    	$controller = $this->makeController();
+    	$controller->failServerError('Nope.', 'FAT-CHANCE', 'A custom reason.');
+
+    	$this::assertEquals('A custom reason.', $this->response->getReason());
+    	$this::assertEquals(500, $this->response->getStatusCode());
+    	$this::assertEquals(json_encode([
+    		'status'   => 500,
+		    'error'    => 'FAT-CHANCE',
+		    'messages' => [
+		    	'Nope.'
+		    ]
+	    ]), $this->response->getBody());
+    }
 }

--- a/user_guide_src/source/libraries/api_responses.rst
+++ b/user_guide_src/source/libraries/api_responses.rst
@@ -278,3 +278,15 @@ Class Reference
 
     return $this->failTooManyRequests('You must wait 15 seconds before making another request.');
 
+.. php:method:: failServerError(string $description[, string $code = null[, string $message = '']])
+
+    :param string $description: The error message to show the user.
+    :param string $code: A custom, API-specific, error code.
+    :param string $message: A custom "reason" message to return.
+    :returns: The value of the Response object's send() method.
+
+    Sets the appropriate status code to use when there is a server error.
+
+    ::
+
+    return $this->failServerError('Server error.');


### PR DESCRIPTION
Created a `failServerError(string $description, string $code = null, string $message = ''): Response` method in the response trait to fail server errors.

Issue: #424