### PR TITLE
Fix issure #413: Pagination::link() cant trans string param which retrieve from $_GET

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -309,7 +309,7 @@ class Pager implements PagerInterface
 
 		$uri = $this->groups[$group]['uri'];
 
-		$uri->setQuery('page='.$page);
+		$uri->addQuery('page='.$page);
 
 		return $returnObject === true
 			? $uri
@@ -443,6 +443,11 @@ class Pager implements PagerInterface
 			'perPage'     => $this->config->perPage,
 			'pageCount'   => 1,
 		];
+
+		if($_GET)
+		{
+			$this->groups[$group]['uri'] = $this->groups[$group]['uri']->setQueryArray($_GET);
+		}
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -309,7 +309,7 @@ class Pager implements PagerInterface
 
 		$uri = $this->groups[$group]['uri'];
 
-		$uri->addQuery('page='.$page);
+		$uri->addQuery('page', $page);
 
 		return $returnObject === true
 			? $uri

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -258,8 +258,10 @@ class PagerTest extends \CIUnitTestCase
 
 	public function testGetNextURIWithQueryStringUsesCurrentURI()
 	{
-		$_GET['page'] = 3;
-		$_GET['status'] = 1;
+		$_GET = [
+			'page' => 3,
+			'status' => 1
+		];
 
 		$expected = current_url(true);
 		$expected = (string)$expected->setQueryArray($_GET);
@@ -273,9 +275,10 @@ class PagerTest extends \CIUnitTestCase
 
 	public function testGetPreviousURIWithQueryStringUsesCurrentURI()
 	{
-		$_GET['page'] = 1;
-		$_GET['status'] = 1;
-
+		$_GET = [
+			'page' => 1,
+			'status' => 1
+		];
 		$expected = current_url(true);
 		$expected = (string)$expected->setQueryArray($_GET);
 

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -255,4 +255,34 @@ class PagerTest extends \CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	public function testGetNextURIWithQueryStringUsesCurrentURI()
+	{
+		$_GET['page'] = 3;
+		$_GET['status'] = 1;
+
+		$expected = current_url(true);
+		$expected = (string)$expected->setQueryArray($_GET);
+
+		$this->pager->store('foo', $_GET['page']-1, 12, 70);
+
+		$this->assertEquals((string)$expected, $this->pager->getNextPageURI('foo'));
+	}
+ 
+	//--------------------------------------------------------------------
+
+	public function testGetPreviousURIWithQueryStringUsesCurrentURI()
+	{
+		$_GET['page'] = 1;
+		$_GET['status'] = 1;
+
+		$expected = current_url(true);
+		$expected = (string)$expected->setQueryArray($_GET);
+
+		$this->pager->store('foo', $_GET['page']+1, 12, 70);
+
+		$this->assertEquals((string)$expected, $this->pager->getPreviousPageURI('foo'));
+	}
+
+	//--------------------------------------------------------------------
 }


### PR DESCRIPTION
 Fix  [issure#413](https://github.com/bcit-ci/CodeIgniter4/issues/413): Pagination::link() cant trans string param which retrieve from $_GET to page href
