### PR TITLE
Updated DB Connection Interface Table Method

### DIFF
--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -175,9 +175,9 @@ interface ConnectionInterface
 	/**
 	 * Returns an instance of the query builder for this connection.
 	 *
-	 * @param string|array $tableName
+	 * @param string|array $tableName Table name.
 	 *
-	 * @return QueryBuilder
+	 * @return BaseBuilder Builder.
 	 */
 	public function table($tableName);
 


### PR DESCRIPTION
Changed return type of `QueryBuilder` to `BaseBuilder`.

Signed-off-by: Kristian Matthews <kristian.matthews@me.com>