### PR TITLE
remove 2nd parameter on parent::__construct() in IncomingRequest

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -151,7 +151,7 @@ class IncomingRequest extends Request
 		$this->body   = $body;
 		$this->config = $config;
 
-		parent::__construct($config, $uri);
+		parent::__construct($config);
 
 		$this->populateHeaders();
 


### PR DESCRIPTION
class `CodeIgniter\HTTP\Request::__construct()` only has 1 required parameter.