### PR TITLE
MySQLi sane reconnect

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -227,14 +227,12 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Keep or establish the connection if no queries have been sent for
 	 * a length of time exceeding the server's idle timeout.
 	 *
-	 * @return mixed
+	 * @return void
 	 */
 	public function reconnect()
 	{
-		if ($this->connID !== false && $this->connID->ping() === false)
-		{
-			$this->connID = false;
-		}
+		$this->close();
+		$this->initialize();
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/database/connecting.rst
+++ b/user_guide_src/source/database/connecting.rst
@@ -72,6 +72,9 @@ consider pinging the server by using the reconnect() method before
 sending further queries, which can gracefully keep the connection alive
 or re-establish it.
 
+.. important:: If you are using MySQLi database driver, the reconnect() method
+	does not ping the server but it closes the connection then connects again.
+
 ::
 
 	$db->reconnect();


### PR DESCRIPTION
MySQLi ping will ignore reconnect flag with the mysqlnd driver which is a standard these days. Even if the ping succeeds it is not guaranteed that the connection is working. In my experience you cannot rely on ping. The only sane way to reconnect to the database is to close it and then bring it up again.