### PR TITLE
fix undefined variable paths on CLI

### DIFF
--- a/ci.php
+++ b/ci.php
@@ -30,6 +30,10 @@ if (substr(php_sapi_name(), 0, 3) == 'cgi')
 // Location to the Paths config file.
 $pathsPath = 'application/Config/Paths.php';
 
+// Load our paths config file
+require $pathsPath;
+$paths = new Config\Paths();
+
 $public = trim($paths->publicDirectory, '/');
 
 // Path to the front controller
@@ -37,10 +41,6 @@ define('FCPATH', realpath($public).DIRECTORY_SEPARATOR);
 
 // Ensure the current directory is pointing to the front controller's directory
 chdir('public');
-
-// Load our paths config file
-require $pathsPath;
-$paths = new Config\Paths();
 
 $app = require rtrim($paths->systemDirectory,'/ ').'/bootstrap.php';
 


### PR DESCRIPTION
Fixes the following warning raised when running commands via CLI
```
PHP Notice:  Undefined variable: paths in /var/www/public/ci4/ci.php on line 33
PHP Stack trace:
PHP   1. {main}() /var/www/public/ci4/ci.php:0
PHP Notice:  Trying to get property of non-object in /var/www/public/ci4/ci.php on line 33
PHP Stack trace:
PHP   1. {main}() /var/www/public/ci4/ci.php:0
```