### PR TITLE
Made one unit tests OS-Agnostic: Convert all of them?

### DIFF
--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -29,15 +29,15 @@ class FilesystemHelperTest extends \CIUnitTestCase
         ];
 
         $expected = [
-            'foo/' => [
+            'foo' . DIRECTORY_SEPARATOR => [
                 'bar',
                 'baz'
             ],
-            'boo/' => [
+            'boo' . DIRECTORY_SEPARATOR => [
                 'far',
                 'faz'
             ],
-            'AnEmptyFolder/' => [],
+            'AnEmptyFolder' . DIRECTORY_SEPARATOR => [],
             'simpleFile'
         ];
 
@@ -69,15 +69,15 @@ class FilesystemHelperTest extends \CIUnitTestCase
         ];
 
         $expected = [
-            'foo/' => [
+            'foo' . DIRECTORY_SEPARATOR => [
                 'bar',
                 'baz'
             ],
-            'boo/' => [
+            'boo' . DIRECTORY_SEPARATOR => [
                 'far',
                 'faz'
             ],
-            'AnEmptyFolder/' => [],
+            'AnEmptyFolder' . DIRECTORY_SEPARATOR => [],
             'simpleFile',
             '.hidden'
         ];
@@ -109,9 +109,9 @@ class FilesystemHelperTest extends \CIUnitTestCase
         ];
 
         $expected = [
-            'foo/',
-            'boo/',
-            'AnEmptyFolder/',
+            'foo' . DIRECTORY_SEPARATOR,
+            'boo' . DIRECTORY_SEPARATOR,
+            'AnEmptyFolder' . DIRECTORY_SEPARATOR,
             'simpleFile',
             '.hidden'
         ];
@@ -285,10 +285,10 @@ class FilesystemHelperTest extends \CIUnitTestCase
         // Not sure the directory names should actually show up
         // here but this matches v3.x results.
         $expected = [
-            '/foo',
-            '/boo',
-            '/AnEmptyFolder',
-            '/simpleFile'
+            DIRECTORY_SEPARATOR . 'foo',
+            DIRECTORY_SEPARATOR . 'boo',
+            DIRECTORY_SEPARATOR . 'AnEmptyFolder',
+            DIRECTORY_SEPARATOR . 'simpleFile'
         ];
 
         $vfs = vfsStream::setup('root', null, $structure);


### PR DESCRIPTION
Hey

As I've started browsing the code through Windows (I know, I'll switch to Linux once the semester is over), I noticed many unit tests would fail due to OS line ending and directory separators. 

While it is a very small fix on a single file, I thought I'd use this Pull Request to discuss the pertinence of fixing these tests.
Since I'd like to start contributing, I thought this would be a nice start to browse and understand the code. 

As reference, there are currently 14 failures under Windows with Xampp.
I'm not sure how many are passing/failing under Linux.

The fix would be to use PHP_EOL and DIRECTORY_SEPARATOR instead of '/' and a newline in the test case. It would most likely be semi-automated.