### PR TITLE
Update Filters.php File.

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -232,6 +232,11 @@ class Filters
 				}
 
 				$rules = $rules['except'];
+				
+				if (is_string($rules))
+				{
+					$rules = [$rules];
+				}
 
 				foreach ($rules as $path)
 				{


### PR DESCRIPTION
application/Config/Filters.php  file the globals array, when before's except is defined as a string, ci is running exceptionally.

show demo:
	public $globals = [
		'before' => [
			'csrf' => ['except' => 'home/*']
		],
		'after'  => [
			// 'toolbar'
		]
	];