### PR TITLE
Remove deprecated pieces

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -601,11 +601,10 @@ class Forge
 	 *
 	 * @param    string $table  Table name
 	 * @param    array  $field  Column definition
-	 * @param    string $_after Column for AFTER clause (deprecated)
 	 *
 	 * @return    bool
 	 */
-	public function addColumn($table, $field, $_after = null)
+	public function addColumn($table, $field)
 	{
 		// Work-around for literal column definitions
 		is_array($field) OR $field = [$field];

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -735,10 +735,8 @@ if (! function_exists('random_string'))
 				}
 
 				return substr(str_shuffle(str_repeat($pool, ceil($len/strlen($pool)))), 0, $len);
-			case 'unique': // todo: remove in 3.1+
 			case 'md5':
 				return md5(uniqid(mt_rand()));
-			case 'encrypt': // todo: remove in 3.1+
 			case 'sha1':
 				return sha1(uniqid(mt_rand(), true));
 		}

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -589,22 +589,12 @@ if ( ! function_exists('url_title'))
 	 *
 	 * @todo   Remove old 'dash' and 'underscore' usage in 3.1+.
 	 * @param  string $str       Input string
-	 * @param  string $separator Word separator (usually '-' or '_') (usually '-' or '_')
-	 *             (usually '-' or '_')
+	 * @param  string $separator Word separator (usually '-' or '_') 
 	 * @param  bool   $lowercase Whether to transform the output string to lowercase
 	 * @return string
 	 */
 	function url_title($str, $separator = '-', $lowercase = false): string
 	{
-		if ($separator === 'dash')
-		{
-			$separator = '-';
-		}
-		elseif ($separator === 'underscore')
-		{
-			$separator = '_';
-		}
-
 		$q_separator = preg_quote($separator, '#');
 
 		$trans = array (

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -84,7 +84,6 @@ class TextHelperTest extends \CIUnitTestCase
 	public function test_random_string()
 	{
 		$this->assertEquals(16, strlen(random_string('alnum', 16)));
-		$this->assertEquals(32, strlen(random_string('unique', 16)));
 		$this->assertInternalType('string', random_string('numeric', 16));
 	}
 	// --------------------------------------------------------------------

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -839,7 +839,7 @@ class URLHelperTest extends \CIUnitTestCase
 
 		foreach ($words as $in => $out)
 		{
-			$this->assertEquals($out, url_title($in, 'dash', TRUE));
+			$this->assertEquals($out, url_title($in, '-', TRUE));
 		}
 	}
 
@@ -852,7 +852,7 @@ class URLHelperTest extends \CIUnitTestCase
 
 		foreach ($words as $in => $out)
 		{
-			$this->assertEquals($out, url_title($in, 'underscore'));
+			$this->assertEquals($out, url_title($in, '_'));
 		}
 	}
 

--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -313,11 +313,10 @@ Class Reference
 
 .. php:class:: \CodeIgniter\Database\Forge
 
-	.. php:method:: addColumn($table[, $field = array()[, $_after = NULL]])
+	.. php:method:: addColumn($table[, $field = array()])
 
 		:param	string	$table: Table name to add the column to
 		:param	array	$field: Column definition(s)
-		:param	string	$_after: Column for AFTER clause (deprecated)
 		:returns:	TRUE on success, FALSE on failure
 		:rtype:	bool
 

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -84,31 +84,6 @@ The following functions are available:
 
 	If no results are found, this will return an empty array.
 
-.. php:function:: read_file($file)
-
-	:param	string	$file: File path
-	:returns:	File contents or FALSE on failure
-	:rtype:	string
-
-	Returns the data contained in the file specified in the path.
-
-	Example::
-
-		$string = read_file('./path/to/file.php');
-
-	The path can be a relative or full server path. Returns FALSE (boolean) on failure.
-
-	.. note:: The path is relative to your main site index.php file, NOT your
-		controller or view files. CodeIgniter uses a front controller so paths
-		are always relative to the main site index.
-
-	.. note:: This function is DEPRECATED. Use the native ``file_get_contents()``
-		instead.
-
-	.. important:: If your server is running an **open_basedir** restriction this
-		function might not work if you are trying to access a file above the
-		calling script.
-
 .. php:function:: write_file($path, $data[, $mode = 'wb'])
 
 	:param	string	$path: File path

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -48,9 +48,6 @@ The following functions are available:
 
 		echo random_string('alnum', 16);
 
-	.. note:: Usage of the *unique* and *encrypt* types is DEPRECATED. They
-		are just aliases for *md5* and *sha1* respectively.
-
 .. php:function:: increment_string($str[, $separator = '_'[, $first = 1]])
 
 	:param	string	$str: Input string

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -321,16 +321,13 @@ The following functions are available:
 		// Produces: Whats-wrong-with-CSS
 
 	The second parameter determines the word delimiter. By default dashes
-	are used. Preferred options are: **-** (dash) or **_** (underscore)
+	are used. Preferred options are: **-** (dash) or **_** (underscore).
 
 	Example::
 
 		$title = "What's wrong with CSS?";
 		$url_title = url_title($title, 'underscore');
 		// Produces: Whats_wrong_with_CSS
-
-	.. note:: Old usage of 'dash' and 'underscore' as the second parameter
-		is DEPRECATED.
 
 	The third parameter determines whether or not lowercase characters are
 	forced. By default they are not. Options are boolean TRUE/FALSE.


### PR DESCRIPTION
From the code and/or docs:
- remove filesystem_helper's read_file()
- remove url_helper's url_title separator keyword
- remove Forge::addColumn()'s 'after' parameter