### PR TITLE
Test/APIResponse

### DIFF
--- a/application/Config/Format.php
+++ b/application/Config/Format.php
@@ -20,7 +20,8 @@ class Format extends BaseConfig
 	*/
 	public $supportedResponseFormats = [
 		'application/json',
-		'application/xml'
+		'application/xml',		// machine-readable XML
+		'text/xml'				// human-readable XML
 	];
 
 	/*
@@ -35,7 +36,8 @@ class Format extends BaseConfig
 	*/
 	public $formatters = [
 		'application/json' => \CodeIgniter\Format\JSONFormatter::class,
-		'application/xml'  => \CodeIgniter\Format\XMLFormatter::class
+		'application/xml'  => \CodeIgniter\Format\XMLFormatter::class,
+		'text/xml'  => \CodeIgniter\Format\XMLFormatter::class,
 	];
 
 	//--------------------------------------------------------------------

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -35,7 +35,6 @@
  * @since	Version 3.0.0
  * @filesource
  */
-
 use Config\Format;
 use CodeIgniter\HTTP\Response;
 
@@ -53,6 +52,7 @@ use CodeIgniter\HTTP\Response;
  */
 trait ResponseTrait
 {
+
 	/**
 	 * Allows child classes to override the
 	 * status code that is used in their API.
@@ -60,32 +60,32 @@ trait ResponseTrait
 	 * @var array
 	 */
 	protected $codes = [
-		'created'                   => 201,
-		'deleted'                   => 200,
-		'invalid_request'           => 400,
+		'created' => 201,
+		'deleted' => 200,
+		'invalid_request' => 400,
 		'unsupported_response_type' => 400,
-		'invalid_scope'             => 400,
-		'temporarily_unavailable'   => 400,
-		'invalid_grant'             => 400,
-		'invalid_credentials'       => 400,
-		'invalid_refresh'           => 400,
-		'no_data'                   => 400,
-		'invalid_data'              => 400,
-		'access_denied'             => 401,
-		'unauthorized'              => 401,
-		'invalid_client'            => 401,
-		'forbidden'                 => 403,
-		'resource_not_found'        => 404,
-		'not_acceptable'            => 406,
-		'resource_exists'           => 409,
-		'conflict'                  => 409,
-		'resource_gone'             => 410,
-		'payload_too_large'         => 413,
-		'unsupported_media_type'    => 415,
-		'too_many_requests'         => 429,
-		'server_error'              => 500,
-		'unsupported_grant_type'    => 501,
-		'not_implemented'           => 501,
+		'invalid_scope' => 400,
+		'temporarily_unavailable' => 400,
+		'invalid_grant' => 400,
+		'invalid_credentials' => 400,
+		'invalid_refresh' => 400,
+		'no_data' => 400,
+		'invalid_data' => 400,
+		'access_denied' => 401,
+		'unauthorized' => 401,
+		'invalid_client' => 401,
+		'forbidden' => 403,
+		'resource_not_found' => 404,
+		'not_acceptable' => 406,
+		'resource_exists' => 409,
+		'conflict' => 409,
+		'resource_gone' => 410,
+		'payload_too_large' => 413,
+		'unsupported_media_type' => 415,
+		'too_many_requests' => 429,
+		'server_error' => 500,
+		'unsupported_grant_type' => 501,
+		'not_implemented' => 501,
 	];
 
 	//--------------------------------------------------------------------
@@ -113,14 +113,15 @@ trait ResponseTrait
 		elseif ($data === null && is_numeric($status))
 		{
 			$output = null;
-		} else
+		}
+		else
 		{
 			$status = empty($status) ? 200 : $status;
 			$output = $this->format($data);
 		}
 
 		return $this->response->setBody($output)
-				->setStatusCode($status, $message);
+						->setStatusCode($status, $message);
 	}
 
 	//--------------------------------------------------------------------
@@ -137,14 +138,14 @@ trait ResponseTrait
 	 */
 	public function fail($messages, int $status = 400, string $code = null, string $customMessage = '')
 	{
-		if (! is_array($messages))
+		if ( ! is_array($messages))
 		{
 			$messages = [$messages];
 		}
 
 		$response = [
-			'status'   => $status,
-			'error'    => $code === null ? $status : $code,
+			'status' => $status,
+			'error' => $code === null ? $status : $code,
 			'messages' => $messages,
 		];
 
@@ -152,7 +153,6 @@ trait ResponseTrait
 	}
 
 	//--------------------------------------------------------------------
-
 	//--------------------------------------------------------------------
 	// Response Helpers
 	//--------------------------------------------------------------------
@@ -197,7 +197,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failUnauthorized(string $description, string $code=null, string $message = '')
+	public function failUnauthorized(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['unauthorized'], $code, $message);
 	}
@@ -213,7 +213,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failForbidden(string $description, string $code=null, string $message = '')
+	public function failForbidden(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['forbidden'], $code, $message);
 	}
@@ -228,7 +228,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failNotFound(string $description, string $code=null, string $message = '')
+	public function failNotFound(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['resource_not_found'], $code, $message);
 	}
@@ -243,7 +243,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failValidationError(string $description, string $code=null, string $message = '')
+	public function failValidationError(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['invalid_data'], $code, $message);
 	}
@@ -258,7 +258,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failResourceExists(string $description, string $code=null, string $message = '')
+	public function failResourceExists(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['resource_exists'], $code, $message);
 	}
@@ -275,7 +275,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failResourceGone(string $description, string $code=null, string $message = '')
+	public function failResourceGone(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['resource_gone'], $code, $message);
 	}
@@ -290,7 +290,7 @@ trait ResponseTrait
 	 *
 	 * @return mixed
 	 */
-	public function failTooManyRequests(string $description, string $code=null, string $message = '')
+	public function failTooManyRequests(string $description, string $code = null, string $message = '')
 	{
 		return $this->fail($description, $this->codes['too_many_requests'], $code, $message);
 	}
@@ -328,44 +328,31 @@ trait ResponseTrait
 		// If the data is a string, there's not much we can do to it...
 		if (is_string($data))
 		{
-			$this->setContentType('text/html');
+			// The content type should be text/... and not application/...
+			$contentType = $this->response->getHeaderLine('Content-Type');
+			$contentType = str_replace('application/json', 'text/html', $contentType);
+			$contentType = str_replace('application/', 'text/', $contentType);
+			$this->response->setContentType($contentType);
 
 			return $data;
 		}
 
-		$config = new Format();
-
-		// Determine correct response type through content negotiation
-		$format = $this->request->negotiate('media', $config->supportedResponseFormats);
-
-		$this->setContentType($format);
-
-		$formatter = $config->getFormatter($format);
-
-		return $formatter->format($data);
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Sets the response's content type. If a type is permitted
-	 * ('html', 'json', or 'xml'), the appropriate content type is set.
-	 *
-	 * @param string $type
-	 */
-	protected function setContentType(string $type = null)
-	{
-		switch ($type)
+		// if we don't have a formatter, make one
+		if ($this->formatter == null)
 		{
-			case 'text/html':
-				$this->response = $this->response->setContentType('text/html');
-				break;
-			case 'application/json':
-				$this->response = $this->response->setContentType('application/json');
-				break;
-			case 'application/xml':
-				$this->response = $this->response->setContentType('text/xml');
-				break;
+			$config = new Format();
+
+			// Determine correct response type through content negotiation
+			$format = $this->request->negotiate('media', $config->supportedResponseFormats, true);
+
+			$this->response->setContentType($format);
+
+			// if no formatter, use the default
+			$this->formatter = $config->getFormatter($format);
 		}
+
+		return $this->formatter->format($data);
 	}
+
+
 }

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -60,32 +60,32 @@ trait ResponseTrait
 	 * @var array
 	 */
 	protected $codes = [
-		'created' => 201,
-		'deleted' => 200,
-		'invalid_request' => 400,
-		'unsupported_response_type' => 400,
-		'invalid_scope' => 400,
-		'temporarily_unavailable' => 400,
-		'invalid_grant' => 400,
-		'invalid_credentials' => 400,
-		'invalid_refresh' => 400,
-		'no_data' => 400,
-		'invalid_data' => 400,
-		'access_denied' => 401,
-		'unauthorized' => 401,
-		'invalid_client' => 401,
-		'forbidden' => 403,
-		'resource_not_found' => 404,
-		'not_acceptable' => 406,
-		'resource_exists' => 409,
-		'conflict' => 409,
-		'resource_gone' => 410,
-		'payload_too_large' => 413,
-		'unsupported_media_type' => 415,
-		'too_many_requests' => 429,
-		'server_error' => 500,
-		'unsupported_grant_type' => 501,
-		'not_implemented' => 501,
+		'created'					 => 201,
+		'deleted'					 => 200,
+		'invalid_request'			 => 400,
+		'unsupported_response_type'	 => 400,
+		'invalid_scope'				 => 400,
+		'temporarily_unavailable'	 => 400,
+		'invalid_grant'				 => 400,
+		'invalid_credentials'		 => 400,
+		'invalid_refresh'			 => 400,
+		'no_data'					 => 400,
+		'invalid_data'				 => 400,
+		'access_denied'				 => 401,
+		'unauthorized'				 => 401,
+		'invalid_client'			 => 401,
+		'forbidden'					 => 403,
+		'resource_not_found'		 => 404,
+		'not_acceptable'			 => 406,
+		'resource_exists'			 => 409,
+		'conflict'					 => 409,
+		'resource_gone'				 => 410,
+		'payload_too_large'			 => 413,
+		'unsupported_media_type'	 => 415,
+		'too_many_requests'			 => 429,
+		'server_error'				 => 500,
+		'unsupported_grant_type'	 => 501,
+		'not_implemented'			 => 501,
 	];
 
 	//--------------------------------------------------------------------
@@ -144,9 +144,9 @@ trait ResponseTrait
 		}
 
 		$response = [
-			'status' => $status,
-			'error' => $code === null ? $status : $code,
-			'messages' => $messages,
+			'status'	 => $status,
+			'error'		 => $code === null ? $status : $code,
+			'messages'	 => $messages,
 		];
 
 		return $this->respond($response, $status, $customMessage);
@@ -353,6 +353,5 @@ trait ResponseTrait
 
 		return $this->formatter->format($data);
 	}
-
 
 }

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -35,7 +35,6 @@
  * @since        Version 3.0.0
  * @filesource
  */
-
 use Config\App;
 use Config\ContentSecurityPolicy;
 use Config\Mimes;
@@ -46,6 +45,7 @@ use Config\Mimes;
  */
 class RedirectException extends \Exception
 {
+	
 }
 
 /**
@@ -63,6 +63,7 @@ class RedirectException extends \Exception
  */
 class Response extends Message implements ResponseInterface
 {
+
 	/**
 	 * HTTP status codes
 	 *
@@ -72,8 +73,7 @@ class Response extends Message implements ResponseInterface
 		// 1xx: Informational
 		100 => 'Continue',
 		101 => 'Switching Protocols',
-		102 => 'Processing',    // http://www.iana.org/go/rfc2518
-
+		102 => 'Processing', // http://www.iana.org/go/rfc2518
 		// 2xx: Success
 		200 => 'OK',
 		201 => 'Created',
@@ -82,21 +82,19 @@ class Response extends Message implements ResponseInterface
 		204 => 'No Content',
 		205 => 'Reset Content',
 		206 => 'Partial Content',
-		207 => 'Multi-Status',                  // http://www.iana.org/go/rfc4918
-		208 => 'Already Reported',              // http://www.iana.org/go/rfc5842
-		226 => 'IM Used',                       // 1.1; http://www.ietf.org/rfc/rfc3229.txt
-
+		207 => 'Multi-Status', // http://www.iana.org/go/rfc4918
+		208 => 'Already Reported', // http://www.iana.org/go/rfc5842
+		226 => 'IM Used', // 1.1; http://www.ietf.org/rfc/rfc3229.txt
 		// 3xx: Redirection
 		300 => 'Multiple Choices',
 		301 => 'Moved Permanently',
-		302 => 'Found',              // Formerly 'Moved Temporarily'
-		303 => 'See Other',          // 1.1
+		302 => 'Found', // Formerly 'Moved Temporarily'
+		303 => 'See Other', // 1.1
 		304 => 'Not Modified',
-		305 => 'Use Proxy',          // 1.1
-		306 => 'Switch Proxy',       // No longer used
+		305 => 'Use Proxy', // 1.1
+		306 => 'Switch Proxy', // No longer used
 		307 => 'Temporary Redirect', // 1.1
 		308 => 'Permanent Redirect', // 1.1; Experimental; http://www.ietf.org/rfc/rfc7238.txt
-
 		// 4xx: Client error
 		400 => 'Bad Request',
 		401 => 'Unauthorized',
@@ -116,18 +114,17 @@ class Response extends Message implements ResponseInterface
 		415 => 'Unsupported Media Type',
 		416 => 'Requested Range Not Satisfiable',
 		417 => 'Expectation Failed',
-		418 => "I'm a teapot",                    // April's Fools joke; http://www.ietf.org/rfc/rfc2324.txt
+		418 => "I'm a teapot", // April's Fools joke; http://www.ietf.org/rfc/rfc2324.txt
 		// 419 (Authentication Timeout) is a non-standard status code with unknown origin
-		421 => 'Misdirected Request',             // http://www.iana.org/go/rfc7540 Section 9.1.2
-		422 => 'Unprocessable Entity',            // http://www.iana.org/go/rfc4918
-		423 => 'Locked',                          // http://www.iana.org/go/rfc4918
-		424 => 'Failed Dependency',               // http://www.iana.org/go/rfc4918
+		421 => 'Misdirected Request', // http://www.iana.org/go/rfc7540 Section 9.1.2
+		422 => 'Unprocessable Entity', // http://www.iana.org/go/rfc4918
+		423 => 'Locked', // http://www.iana.org/go/rfc4918
+		424 => 'Failed Dependency', // http://www.iana.org/go/rfc4918
 		426 => 'Upgrade Required',
-		428 => 'Precondition Required',           // 1.1; http://www.ietf.org/rfc/rfc6585.txt
-		429 => 'Too Many Requests',               // 1.1; http://www.ietf.org/rfc/rfc6585.txt
+		428 => 'Precondition Required', // 1.1; http://www.ietf.org/rfc/rfc6585.txt
+		429 => 'Too Many Requests', // 1.1; http://www.ietf.org/rfc/rfc6585.txt
 		431 => 'Request Header Fields Too Large', // 1.1; http://www.ietf.org/rfc/rfc6585.txt
-		451 => 'Unavailable For Legal Reasons',    // http://tools.ietf.org/html/rfc7725
-
+		451 => 'Unavailable For Legal Reasons', // http://tools.ietf.org/html/rfc7725
 		// 5xx: Server error
 		500 => 'Internal Server Error',
 		501 => 'Not Implemented',
@@ -135,10 +132,10 @@ class Response extends Message implements ResponseInterface
 		503 => 'Service Unavailable',
 		504 => 'Gateway Timeout',
 		505 => 'HTTP Version Not Supported',
-		506 => 'Variant Also Negotiates',        // 1.1; http://www.ietf.org/rfc/rfc2295.txt
-		507 => 'Insufficient Storage',           // http://www.iana.org/go/rfc4918
-		508 => 'Loop Detected',                  // http://www.iana.org/go/rfc5842
-		510 => 'Not Extended',                   // http://www.ietf.org/rfc/rfc2774.txt
+		506 => 'Variant Also Negotiates', // 1.1; http://www.ietf.org/rfc/rfc2295.txt
+		507 => 'Insufficient Storage', // http://www.iana.org/go/rfc4918
+		508 => 'Loop Detected', // http://www.iana.org/go/rfc5842
+		510 => 'Not Extended', // http://www.ietf.org/rfc/rfc2774.txt
 		511 => 'Network Authentication Required' // http://www.ietf.org/rfc/rfc6585.txt
 	];
 
@@ -222,18 +219,18 @@ class Response extends Message implements ResponseInterface
 		// Are we enforcing a Content Security Policy?
 		if ($config->CSPEnabled === true)
 		{
-			$this->CSP        = new ContentSecurityPolicy();
+			$this->CSP = new ContentSecurityPolicy();
 			$this->CSPEnabled = true;
 		}
 
-		$this->cookiePrefix   = $config->cookiePrefix;
-		$this->cookieDomain   = $config->cookieDomain;
-		$this->cookiePath     = $config->cookiePath;
-		$this->cookieSecure   = $config->cookieSecure;
+		$this->cookiePrefix = $config->cookiePrefix;
+		$this->cookieDomain = $config->cookieDomain;
+		$this->cookiePath = $config->cookiePath;
+		$this->cookieSecure = $config->cookieSecure;
 		$this->cookieHTTPOnly = $config->cookieHTTPOnly;
 
 		// Default to an HTML Content-Type. Devs can override if needed.
-        $this->setContentType('text/html');
+		$this->setContentType('text/html');
 	}
 
 	//--------------------------------------------------------------------
@@ -280,18 +277,18 @@ class Response extends Message implements ResponseInterface
 		// Valid range?
 		if ($code < 100 || $code > 599)
 		{
-			throw new \InvalidArgumentException($code.' is not a valid HTTP return status code');
+			throw new \InvalidArgumentException($code . ' is not a valid HTTP return status code');
 		}
 
 		// Unknown and no message?
-		if (! array_key_exists($code, static::$statusCodes) && empty($reason))
+		if ( ! array_key_exists($code, static::$statusCodes) && empty($reason))
 		{
 			throw new \InvalidArgumentException('Unknown HTTP status code provided with no message');
 		}
 
 		$this->statusCode = $code;
 
-		if (! empty($reason))
+		if ( ! empty($reason))
 		{
 			$this->reason = $reason;
 		}
@@ -317,16 +314,13 @@ class Response extends Message implements ResponseInterface
 	{
 		if (empty($this->reason))
 		{
-			return ! empty($this->statusCode)
-				? static::$statusCodes[$this->statusCode]
-				: '';
+			return ! empty($this->statusCode) ? static::$statusCodes[$this->statusCode] : '';
 		}
 
 		return $this->reason;
 	}
 
 	//--------------------------------------------------------------------
-
 	//--------------------------------------------------------------------
 	// Convenience Methods
 	//--------------------------------------------------------------------
@@ -342,7 +336,7 @@ class Response extends Message implements ResponseInterface
 	{
 		$date->setTimezone(new \DateTimeZone('UTC'));
 
-		$this->setHeader('Date', $date->format('D, d M Y H:i:s').' GMT');
+		$this->setHeader('Date', $date->format('D, d M Y H:i:s') . ' GMT');
 
 		return $this;
 	}
@@ -360,19 +354,19 @@ class Response extends Message implements ResponseInterface
 	 */
 	public function setContentType(string $mime, string $charset = 'UTF-8')
 	{
-		if (! empty($charset))
+		// add charset attribute if not already there and provided as parm
+		if ((strpos($mime, 'charset=') < 1) && ! empty($charset))
 		{
-			$mime .= '; charset='.$charset;
+			$mime .= '; charset=' . $charset;
 		}
 
+		$this->removeHeader('Content-Type'); // replace existing content type
 		$this->setHeader('Content-Type', $mime);
 
 		return $this;
 	}
 
 	//--------------------------------------------------------------------
-
-
 	//--------------------------------------------------------------------
 	// Cache Control Methods
 	//
@@ -467,7 +461,7 @@ class Response extends Message implements ResponseInterface
 		if ($date instanceof \DateTime)
 		{
 			$date->setTimezone(new \DateTimeZone('UTC'));
-			$this->setHeader('Last-Modified', $date->format('D, d M Y H:i:s').' GMT');
+			$this->setHeader('Last-Modified', $date->format('D, d M Y H:i:s') . ' GMT');
 		}
 		elseif (is_string($date))
 		{
@@ -478,8 +472,6 @@ class Response extends Message implements ResponseInterface
 	}
 
 	//--------------------------------------------------------------------
-
-
 	//--------------------------------------------------------------------
 	// Output Methods
 	//--------------------------------------------------------------------
@@ -532,7 +524,7 @@ class Response extends Message implements ResponseInterface
 		// Send all of our headers
 		foreach ($this->getHeaders() as $name => $values)
 		{
-			header($name.': '.$this->getHeaderLine($name), false, $this->statusCode);
+			header($name . ': ' . $this->getHeaderLine($name), false, $this->statusCode);
 		}
 
 		return $this;
@@ -554,15 +546,15 @@ class Response extends Message implements ResponseInterface
 
 	//--------------------------------------------------------------------
 
-    /**
-     * Perform a redirect to a new URL, in two flavors: header or location.
-     *
-     * @param string $uri  The URI to redirect to
-     * @param string $method
-     * @param int    $code The type of redirection, defaults to 302
-     *
-     * @throws \CodeIgniter\HTTP\RedirectException
-     */
+	/**
+	 * Perform a redirect to a new URL, in two flavors: header or location.
+	 *
+	 * @param string $uri  The URI to redirect to
+	 * @param string $method
+	 * @param int    $code The type of redirection, defaults to 302
+	 *
+	 * @throws \CodeIgniter\HTTP\RedirectException
+	 */
 	public function redirect(string $uri, string $method = 'auto', int $code = null)
 	{
 		// IIS environment likely? Use 'refresh' for better compatibility
@@ -574,9 +566,8 @@ class Response extends Message implements ResponseInterface
 		{
 			if (isset($_SERVER['SERVER_PROTOCOL'], $_SERVER['REQUEST_METHOD']) && $_SERVER['SERVER_PROTOCOL'] === 'HTTP/1.1')
 			{
-				$code = ($_SERVER['REQUEST_METHOD'] !== 'GET')
-					? 303    // reference: http://en.wikipedia.org/wiki/Post/Redirect/Get
-					: 307;
+				$code = ($_SERVER['REQUEST_METHOD'] !== 'GET') ? 303	// reference: http://en.wikipedia.org/wiki/Post/Redirect/Get
+						: 307;
 			}
 			else
 			{
@@ -587,7 +578,7 @@ class Response extends Message implements ResponseInterface
 		switch ($method)
 		{
 			case 'refresh':
-				$this->setHeader('Refresh', '0;url='.$uri);
+				$this->setHeader('Refresh', '0;url=' . $uri);
 				break;
 			default:
 				$this->setHeader('Location', $uri);
@@ -599,7 +590,7 @@ class Response extends Message implements ResponseInterface
 		$this->sendHeaders();
 
 		// CodeIgniter will catch this exception and exit.
-		throw new RedirectException('Redirect to '.$uri, $code);
+		throw new RedirectException('Redirect to ' . $uri, $code);
 	}
 
 	//--------------------------------------------------------------------
@@ -620,15 +611,9 @@ class Response extends Message implements ResponseInterface
 	 * @param bool|false $httponly  Whether only make the cookie accessible via HTTP (no javascript)
 	 */
 	public function setCookie(
-		$name,
-		$value = '',
-		$expire = '',
-		$domain = '',
-		$path = '/',
-		$prefix = '',
-		$secure = false,
-		$httponly = false
-	) {
+	$name, $value = '', $expire = '', $domain = '', $path = '/', $prefix = '', $secure = false, $httponly = false
+	)
+	{
 		if (is_array($name))
 		{
 			// always leave 'name' in last place, as the loop will break otherwise, due to $$item
@@ -666,16 +651,16 @@ class Response extends Message implements ResponseInterface
 			$httponly = $this->cookieHTTPOnly;
 		}
 
-		if (! is_numeric($expire))
+		if ( ! is_numeric($expire))
 		{
-			$expire = time()-86500;
+			$expire = time() - 86500;
 		}
 		else
 		{
-			$expire = ($expire > 0) ? time()+$expire : 0;
+			$expire = ($expire > 0) ? time() + $expire : 0;
 		}
 
-		setcookie($prefix.$name, $value, $expire, $path, $domain, $secure, $httponly);
+		setcookie($prefix . $name, $value, $expire, $path, $domain, $secure, $httponly);
 	}
 
 	//--------------------------------------------------------------------
@@ -698,7 +683,7 @@ class Response extends Message implements ResponseInterface
 		}
 		elseif ($data === null)
 		{
-			if (! @is_file($filename) || ($filesize = @filesize($filename)) === false)
+			if ( ! @is_file($filename) || ($filesize = @filesize($filename)) === false)
 			{
 				return;
 			}
@@ -715,7 +700,7 @@ class Response extends Message implements ResponseInterface
 		// Set the default MIME type to send
 		$mime = 'application/octet-stream';
 
-		$x         = explode('.', $filename);
+		$x = explode('.', $filename);
 		$extension = end($x);
 
 		if ($setMime === true)
@@ -739,8 +724,8 @@ class Response extends Message implements ResponseInterface
 		 */
 		if (count($x) !== 1 && isset($_SERVER['HTTP_USER_AGENT']) && preg_match('/Android\s(1|2\.[01])/', $_SERVER['HTTP_USER_AGENT']))
 		{
-			$x[count($x)-1] = strtoupper($extension);
-			$filename       = implode('.', $x);
+			$x[count($x) - 1] = strtoupper($extension);
+			$filename = implode('.', $x);
 		}
 
 		if ($data === null && ($fp = @fopen($filepath, 'rb')) === false)
@@ -755,11 +740,11 @@ class Response extends Message implements ResponseInterface
 		}
 
 		// Generate the server headers
-		header('Content-Type: '.$mime);
-		header('Content-Disposition: attachment; filename="'.$filename.'"');
+		header('Content-Type: ' . $mime);
+		header('Content-Disposition: attachment; filename="' . $filename . '"');
 		header('Expires: 0');
 		header('Content-Transfer-Encoding: binary');
-		header('Content-Length: '.$filesize);
+		header('Content-Length: ' . $filesize);
 		header('Cache-Control: private, no-transform, no-store, must-revalidate');
 
 		// If we have raw data - just dump it
@@ -769,7 +754,7 @@ class Response extends Message implements ResponseInterface
 		}
 
 		// Flush 1MB chunks of data
-		while (! feof($fp) && ($data = fread($fp, 1048576)) !== false)
+		while ( ! feof($fp) && ($data = fread($fp, 1048576)) !== false)
 		{
 			echo $data;
 		}
@@ -779,5 +764,4 @@ class Response extends Message implements ResponseInterface
 	}
 
 	//--------------------------------------------------------------------
-
 }

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -3,305 +3,401 @@
 use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Controller;
 use CodeIgniter\Format\JSONFormatter;
+use CodeIgniter\Format\XMLFormatter;
 use CodeIgniter\HTTP\MockIncomingRequest;
 use CodeIgniter\HTTP\MockResponse;
 use CodeIgniter\HTTP\URI;
 
 class ResponseTraitTest extends \CIUnitTestCase
 {
-    protected $request;
-    protected $response;
+
+	protected $request;
+	protected $response;
 
 	/**
-	 * @var JSONFormatter
+	 * @var Response formatter
 	 */
-    protected $formatter;
+	protected $formatter;
 
 	public function setUp()
 	{
 		parent::setUp();
 
 		$this->formatter = new JSONFormatter();
-    }
-
+	}
 
 	protected function makeController(array $userConfig = [], string $uri = 'http://example.com', array $userHeaders = [])
-    {
-        $config = [
-            'baseURL'          => 'http://example.com',
-            'uriProtocol'      => 'REQUEST_URI',
-            'defaultLocale'    => 'en',
-            'negotiateLocale'  => false,
-            'supportedLocales' => ['en'],
-            'CSPEnabled'       => false,
-            'cookiePrefix'     => '',
-            'cookieDomain'     => '',
-            'cookiePath'       => '/',
-            'cookieSecure'     => false,
-            'cookieHTTPOnly'   => false,
-            'proxyIPs'         => []
-        ];
+	{
+		$config = [
+			'baseURL' => 'http://example.com',
+			'uriProtocol' => 'REQUEST_URI',
+			'defaultLocale' => 'en',
+			'negotiateLocale' => false,
+			'supportedLocales' => ['en'],
+			'CSPEnabled' => false,
+			'cookiePrefix' => '',
+			'cookieDomain' => '',
+			'cookiePath' => '/',
+			'cookieSecure' => false,
+			'cookieHTTPOnly' => false,
+			'proxyIPs' => []
+		];
 
-        $config = array_merge($config, $userConfig);
+		$config = array_merge($config, $userConfig);
 
-        $this->request  = new MockIncomingRequest((object)$config, new URI($uri), null);
-        $this->response = new MockResponse((object)$config);
+		$this->request = new MockIncomingRequest((object) $config, new URI($uri), null);
+		$this->response = new MockResponse((object) $config);
 
-        // Insert headers into request.
-        $headers = [
-            'Accept' => 'text/html'
-        ];
-        $headers = array_merge($headers, $userHeaders);
+		// Insert headers into request.
+		$headers = [
+			'Accept' => 'text/html'
+		];
+		$headers = array_merge($headers, $userHeaders);
 
-        foreach ($headers as $key => $value)
-        {
-            $this->request->setHeader($key, $value);
-        }
+		foreach ($headers as $key => $value)
+		{
+			$this->request->setHeader($key, $value);
+			if (($key == 'Accept') && ! is_array($value))
+				$this->response->setContentType($value);
+		}
 
-        // Create the controller class finally.
-        $controller = new class($this->request, $this->response)
-        {
-            use ResponseTrait;
+		// Create the controller class finally.
+		$controller = new class($this->request, $this->response, $this->formatter)
+		{
 
-            protected $request;
-            protected $response;
+			use ResponseTrait;
 
-            public function __construct($request, $response)
-            {
-                $this->request = $request;
-                $this->response = $response;
-            }
+			protected $request;
+			protected $response;
+			protected $formatter;
 
-        };
+			public function __construct(&$request, &$response, &$formatter)
+			{
+				$this->request = $request;
+				$this->response = $response;
+				$this->formatter = $formatter;
+			}
+		};
 
-        return $controller;
-    }
+		return $controller;
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
-    public function testRespondSets404WithNoData()
-    {
-        $controller = $this->makeController();
-        $controller->respond(null, null);
+	public function testRespondSets404WithNoData()
+	{
+		$controller = $this->makeController();
+		$controller->respond(null, null);
 
-        $this->assertEquals(404, $this->response->getStatusCode());
-        $this->assertNull($this->response->getBody());
-    }
+		$this->assertEquals(404, $this->response->getStatusCode());
+		$this->assertNull($this->response->getBody());
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
-    public function testRespondSetsStatusWithEmptyData()
-    {
-        $controller = $this->makeController();
-        $controller->respond(null, 201);
+	public function testRespondSetsStatusWithEmptyData()
+	{
+		$controller = $this->makeController();
+		$controller->respond(null, 201);
 
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertNull($this->response->getBody());
-    }
+		$this->assertEquals(201, $this->response->getStatusCode());
+		$this->assertNull($this->response->getBody());
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
-    public function testRespondSetsCorrectBodyAndStatus()
-    {
-        $controller = $this->makeController();
-        $controller->respond('something', 201);
+	public function testRespondSetsCorrectBodyAndStatus()
+	{
+		$controller = $this->makeController();
+		$controller->respond('something', 201);
 
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertEquals('something', $this->response->getBody());
-        $this->assertTrue(strpos($this->response->getHeaderLine('Content-Type'), 'text/html') === 0);
-        $this->assertEquals('Created', $this->response->getReason());
-    }
+		$this->assertEquals(201, $this->response->getStatusCode());
+		$this->assertEquals('something', $this->response->getBody());
+		$this->assertTrue(strpos($this->response->getHeaderLine('Content-Type'), 'text/html') === 0);
+		$this->assertEquals('Created', $this->response->getReason());
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
-    public function testRespondWithCustomReason()
-    {
-        $controller = $this->makeController();
-        $controller->respond('something', 201, 'A Custom Reason');
+	public function testRespondWithCustomReason()
+	{
+		$controller = $this->makeController();
+		$controller->respond('something', 201, 'A Custom Reason');
 
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-    }
+		$this->assertEquals(201, $this->response->getStatusCode());
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+	}
 
-    public function testFailSingleMessage()
-    {
-        $controller = $this->makeController();
-        $controller->fail('Failure to Launch', 500, 'WHAT!', 'A Custom Reason');
+	public function testFailSingleMessage()
+	{
+		$controller = $this->makeController();
 
-        // Will use the JSON formatter by default
-        $expected = [
-            'status'  => 500,
-            'error' => 'WHAT!',
-            'messages' => [
-                'Failure to Launch'
-            ]
-        ];
+		$controller->fail('Failure to Launch', 500, 'WHAT!', 'A Custom Reason');
 
-        $this->assertTrue(strpos($this->response->getHeaderLine('Content-Type'), 'application/json') === 0);
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-        $this->assertEquals(500, $this->response->getStatusCode());
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-    }
+		// Will use the JSON formatter by default
+		$expected = [
+			'status' => 500,
+			'error' => 'WHAT!',
+			'messages' => [
+				'Failure to Launch'
+			]
+		];
 
-    public function testCreated()
-    {
-        $controller = $this->makeController();
-        $controller->respondCreated(['id' => 3], 'A Custom Reason');
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+		$this->assertEquals(500, $this->response->getStatusCode());
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+	}
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
-    }
+	public function testCreated()
+	{
+		$controller = $this->makeController();
+		$controller->respondCreated(['id' => 3], 'A Custom Reason');
 
-    public function testDeleted()
-    {
-        $controller = $this->makeController();
-        $controller->respondDeleted(['id' => 3], 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(201, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
+	}
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
-    }
+	public function testDeleted()
+	{
+		$controller = $this->makeController();
+		$controller->respondDeleted(['id' => 3], 'A Custom Reason');
 
-    public function testUnauthorized()
-    {
-        $controller = $this->makeController();
-        $controller->failUnauthorized('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(200, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 401,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testUnauthorized()
+	{
+		$controller = $this->makeController();
+		$controller->failUnauthorized('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(401, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 401,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testForbidden()
-    {
-        $controller = $this->makeController();
-        $controller->failForbidden('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(401, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 403,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testForbidden()
+	{
+		$controller = $this->makeController();
+		$controller->failForbidden('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(403, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 403,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testNotFound()
-    {
-        $controller = $this->makeController();
-        $controller->failNotFound('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(403, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 404,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testNotFound()
+	{
+		$controller = $this->makeController();
+		$controller->failNotFound('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(404, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 404,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testValidationError()
-    {
-        $controller = $this->makeController();
-        $controller->failValidationError('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(404, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 400,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testValidationError()
+	{
+		$controller = $this->makeController();
+		$controller->failValidationError('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(400, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 400,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testResourceExists()
-    {
-        $controller = $this->makeController();
-        $controller->failResourceExists('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(400, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 409,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testResourceExists()
+	{
+		$controller = $this->makeController();
+		$controller->failResourceExists('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(409, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 409,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testResourceGone()
-    {
-        $controller = $this->makeController();
-        $controller->failResourceGone('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(409, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 410,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testResourceGone()
+	{
+		$controller = $this->makeController();
+		$controller->failResourceGone('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(410, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 410,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testTooManyRequests()
-    {
-        $controller = $this->makeController();
-        $controller->failTooManyRequests('Nope', 'FAT CHANCE', 'A Custom Reason');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(410, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-        $expected = [
-            'status' => 429,
-            'error' => 'FAT CHANCE',
-            'messages' => [
-                'Nope'
-            ]
-        ];
+	public function testTooManyRequests()
+	{
+		$controller = $this->makeController();
+		$controller->failTooManyRequests('Nope', 'FAT CHANCE', 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(429, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-    }
+		$expected = [
+			'status' => 429,
+			'error' => 'FAT CHANCE',
+			'messages' => [
+				'Nope'
+			]
+		];
 
-    public function testServerError()
-    {
-    	$controller = $this->makeController();
-    	$controller->failServerError('Nope.', 'FAT-CHANCE', 'A custom reason.');
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(429, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+	}
 
-    	$this::assertEquals('A custom reason.', $this->response->getReason());
-    	$this::assertEquals(500, $this->response->getStatusCode());
-    	$this::assertEquals($this->formatter->format([
-    		'status'   => 500,
-		    'error'    => 'FAT-CHANCE',
-		    'messages' => [
-		    	'Nope.'
-		    ]
-	    ]), $this->response->getBody());
-    }
+	public function testServerError()
+	{
+		$controller = $this->makeController();
+		$controller->failServerError('Nope.', 'FAT-CHANCE', 'A custom reason.');
+
+		$this::assertEquals('A custom reason.', $this->response->getReason());
+		$this::assertEquals(500, $this->response->getStatusCode());
+		$this::assertEquals($this->formatter->format([
+					'status' => 500,
+					'error' => 'FAT-CHANCE',
+					'messages' => [
+						'Nope.'
+					]
+				]), $this->response->getBody());
+	}
+
+	public function testValidContentTypes()
+	{
+		$chars = '; charset=UTF-8';
+		$goodMimes = ['text/xml', 'text/html', 'application/json', 'application/xml'];
+		for ($i = 0; $i < count($goodMimes); $i ++ )
+			$this->tryValidContentType($goodMimes[$i], $goodMimes[$i] . $chars);
+	}
+
+	private function tryValidContentType($mimeType, $contentType)
+	{
+		$original = $_SERVER;
+		$_SERVER['CONTENT_TYPE'] = $mimeType;
+
+		$controller = $this->makeController([], 'http://codeigniter.com', ['Accept' => $mimeType]);
+		$this->assertEquals($mimeType, $this->request->getHeaderLine('Accept'), 'Request header...');
+		$this->response->setContentType($contentType);
+		$this->assertEquals($contentType, $this->response->getHeaderLine('Content-Type'), 'Response header pre-response...');
+
+		$_SERVER = $original;
+	}
+
+	public function testValidResponses()
+	{
+		$chars = '; charset=UTF-8';
+		$goodMimes = ['text/xml', 'text/html', 'application/json', 'application/xml'];
+		for ($i = 0; $i < count($goodMimes); $i ++ )
+			$this->tryValidContentType($goodMimes[$i], $goodMimes[$i] . $chars);
+	}
+
+	private function tryValidResponse($mimeType, $contentType)
+	{
+		$original = $_SERVER;
+		$_SERVER['CONTENT_TYPE'] = $mimeType;
+
+		$controller = $this->makeController([], 'http://codeigniter.com', ['Accept' => $mimeType]);
+		$this->assertEquals($mimeType, $this->request->getHeaderLine('Accept'), 'Request header...');
+
+		$this->assertEquals($contentType, $this->response->getHeaderLine('Content-Type'), 'Response header pre-response...');
+		$this->response->setContentType($contentType);
+		$controller->respond('HTML assumed');
+
+		$this->assertEquals(200, $this->response->getStatusCode());
+		$expected = 'HTML assumed';
+		$this->assertEquals($expected, $this->response->getBody());
+
+		$_SERVER = $original;
+	}
+
+	public function testXMLFormatter()
+	{
+		$this->formatter = new XMLFormatter();
+		$controller = $this->makeController();
+
+		$this->assertEquals('CodeIgniter\Format\XMLFormatter', get_class($this->formatter));
+
+		$controller->respondCreated(['id' => 3], 'A Custom Reason');
+		$expected = <<<EOH
+<?xml version="1.0"?>
+<response><id>3</id></response>
+
+EOH;
+		$this->assertEquals($expected, $this->response->getBody());
+	}
+
+	public function testNoFormatterHTML()
+	{
+		$this->formatter = null;
+		$controller = $this->makeController();
+		$controller->respondCreated('A Custom Reason');
+
+		$this->assertEquals('A Custom Reason', $this->response->getBody());
+	}
+
+	public function testNoFormatterJSON()
+	{
+		$this->formatter = null;
+		$controller = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
+		$controller->respondCreated(['id' => 3], 'A Custom Reason');
+
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(201, $this->response->getStatusCode());
+
+		$expected = <<<EOH
+{
+    "id": 3
+}
+EOH;
+		$this->assertEquals($expected, $this->response->getBody());
+	}
+
 }

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -54,4 +54,15 @@ EOH;
 
         $this->assertEquals($expected, $this->xmlFormatter->format($data));
     }
+	
+	public function testStringFormatting() {
+		$data = ['Something'];
+        $expected = <<<EOH
+<?xml version="1.0"?>
+<response><0>Something</0></response>
+
+EOH;
+
+        $this->assertEquals($expected, $this->xmlFormatter->format($data));
+	}
 }

--- a/user_guide_src/source/libraries/api_responses.rst
+++ b/user_guide_src/source/libraries/api_responses.rst
@@ -71,7 +71,7 @@ the following criteria:
 * If $data is an array, it will try to negotiate the content type with what the client asked for, defaulting to JSON
     if nothing else has been specified within Config\API.php, the ``$supportedResponseFormats`` property.
 
-To define the formatter that is used, edit **Config\API.php**. The ``$supportedResponseFormats`` contains a list of
+To define the formatter that is used, edit **Config/Format.php**. The ``$supportedResponseFormats`` contains a list of
 mime types that your application can automatically format the response for. By default, the system knows how to
 format both XML and JSON responses::
 


### PR DESCRIPTION
Enhanced the unit testing for the API package, specifically looking at making sure all the content types were exercised, and fleshed out the XMLFormatter tests. This had some side effects, shown below.

system/Config/Format - added "text/xml" as valid response format, using XMLFormatter
system/API/ResponseTrait - modified format() to just replace "application" with "text" for string data; also provided for using default formatter only if one not already set.
system/HTTP/Response - modified setContentType() to replace existing header, as there should only be one
tests/APIResponseTraitTest - completed, now with 100% code coverage
tests/XMLFormatterTest - added an additional test, for string data handling
user_guide_src/api_responses - updated incorrect folder reference

Note: tests/CodeIgniter/I18n/TimeTest fails from before -> no assertions