### PR TITLE
Fix for current_url() function

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -113,7 +113,7 @@ if ( ! function_exists('base_url'))
 		}
 		else
 		{
-			$url = \CodeIgniter\Services::request()->uri;
+			$url = \CodeIgniter\Services::request($config, false)->uri;
 			$url->setPath('/');
 		}
 


### PR DESCRIPTION
If site_url() or base_url() functions are called before the current_url() function, it can change the expected value.