### PR TITLE
Prevent remove_invisible_characters from removing url encoded characters from db drivers like statements (that don't need escaping)

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1400,7 +1400,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 */
 	protected function _escapeString(string $str): string
 	{
-		return str_replace("'", "''", remove_invisible_characters($str));
+		return str_replace("'", "''", remove_invisible_characters($str, false));
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -195,7 +195,7 @@ class GDHandler extends BaseHandler
 	 *
 	 * @return bool|\CodeIgniter\Images\Handlers\GDHandler
 	 */
-	public function _crops()
+	public function _crop()
 	{
 		return $this->process('crop');
 	}


### PR DESCRIPTION
In CI3, escapeString passed false to remove_invisible_characters. CI4 doesn't. This removes characters if they fall within %0[0-8bcef] and %1[0-9a-f]. Beginning of LIKE binds start with %. Drivers should use their own _escapeString function (document?). SQLSRV doesn't necessarily need to be escaped. 