### PR TITLE
fixed `getSegment`

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -466,7 +466,7 @@ class URI
 			throw new \InvalidArgumentException('Request URI segment is our of range.');
 		}
 
-		return $this->segments[$number];
+		return $this->segments[$number] ?? '';
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
fixed issue with returning error which the segment is not the one been checked. instead returns just empty