### PR TITLE
Flattens an image's transparencies (GD/ImageMagick) & ImageMagick CLI bug fix

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -35,9 +35,9 @@
  * @since      Version 3.0.0
  * @filesource
  */
+use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Image;
 use CodeIgniter\Images\ImageHandlerInterface;
-use CodeIgniter\Images\Exceptions\ImageException;
 
 abstract class BaseHandler implements ImageHandlerInterface
 {
@@ -248,6 +248,40 @@ abstract class BaseHandler implements ImageHandlerInterface
 
 		return $this;
 	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Flattens transparencies, default white background
+	 *
+	 * @param int $red
+	 * @param int $green
+	 * @param int $blue
+	 *
+	 * @return mixed
+	 */
+	public function flatten(int $red = 255, int $green = 255, int $blue = 255)
+	{
+		$this->width = $this->image->origWidth;
+		$this->height = $this->image->origHeight;
+
+		return $this->_flatten();
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Handler-specific method to flattening an image's transparencies.
+	 *
+	 * @param int $red
+	 * @param int $green
+	 * @param int $blue
+	 *
+	 * @return mixed
+	 * @internal param int $angle
+	 *
+	 */
+	protected abstract function _flatten(int $red = 255, int $green = 255, int $blue = 255);
 
 	//--------------------------------------------------------------------
 

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -125,9 +125,9 @@ class GDHandler extends BaseHandler
 		}
 		$dest = $create($this->width, $this->height);
 
-		$white = imagecolorallocate($dest, $red, $green, $blue);
+		$matte = imagecolorallocate($dest, $red, $green, $blue);
 
-		imagefilledrectangle($dest, 0, 0, $this->width, $this->height, $white);
+		imagefilledrectangle($dest, 0, 0, $this->width, $this->height, $matte);
 		imagecopy($dest, $src, 0, 0, 0, 0, $this->width, $this->height);
 
 		// Kill the file handles

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -98,6 +98,50 @@ class GDHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Flattens transparencies
+	 *
+	 * @param int $red
+	 * @param int $green
+	 * @param int $blue
+	 *
+	 * @return $this
+	 */
+	public function _flatten(int $red = 255, int $green = 255, int $blue = 255) {
+
+		if ( ! ($src = $this->createImage()))
+		{
+			return false;
+		}
+
+		if (function_exists('imagecreatetruecolor'))
+		{
+			$create = 'imagecreatetruecolor';
+			$copy = 'imagecopyresampled';
+		}
+		else
+		{
+			$create = 'imagecreate';
+			$copy = 'imagecopyresized';
+		}
+		$dest = $create($this->width, $this->height);
+
+		$white = imagecolorallocate($dest, $red, $green, $blue);
+
+		imagefilledrectangle($dest, 0, 0, $this->width, $this->height, $white);
+		imagecopy($dest, $src, 0, 0, 0, 0, $this->width, $this->height);
+
+		// Kill the file handles
+		imagedestroy($src);
+
+		$this->resource = $dest;
+
+		return $this;
+
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Flips an image along it's vertical or horizontal axis.
 	 *
 	 * @param string $direction

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -72,7 +72,14 @@ class ImageMagickHandler extends BaseHandler
 		$source = ! empty($this->resource) ? $this->resource : $this->image->getPathname();
 		$destination = $this->getResourcePath();
 
-		$action = $maintainRatio === true ? ' -resize ' . $this->width . 'x' . $this->height . ' "' . $source . '" "' . $destination . '"' : ' -resize ' . $this->width . 'x' . $this->height . '\! "' . $source . '" "' . $destination . '"';
+		//todo FIX THIS HANDLER PROPERLY
+
+		$escape = "\\";
+		if (strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN') {
+			$escape = "";
+		}
+
+		$action = $maintainRatio === true ? ' -resize ' . $this->width . 'x' . $this->height . ' "' . $source . '" "' . $destination . '"' : ' -resize ' . $this->width . 'x' . $this->height . "{$escape}! \"" . $source . '" "' . $destination . '"';
 
 		$this->process($action);
 
@@ -116,6 +123,31 @@ class ImageMagickHandler extends BaseHandler
 		$destination = $this->getResourcePath();
 
 		$action = ' ' . $angle . ' "' . $source . '" "' . $destination . '"';
+
+		$this->process($action);
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Flattens transparencies, default white background
+	 *
+	 * @param int $red
+	 * @param int $green
+	 * @param int $blue
+	 *
+	 * @return $this
+	 */
+	public function _flatten(int $red = 255, int $green = 255, int $blue = 255){
+
+		$flatten =  "-background RGB({$red},{$green},{$blue}) -flatten";
+
+		$source = ! empty($this->resource) ? $this->resource : $this->image->getPathname();
+		$destination = $this->getResourcePath();
+
+		$action = ' ' . $flatten . ' "' . $source . '" "' . $destination . '"';
 
 		$this->process($action);
 

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -77,6 +77,18 @@ interface ImageHandlerInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Flattens transparencies, default white background
+	 *
+	 * @param int $red
+	 * @param int $green
+	 * @param int $blue
+	 *
+	 * @return mixed
+	 */
+	public function flatten(int $red = 255, int $green = 255, int $blue = 255);
+	//--------------------------------------------------------------------
+
+	/**
 	 * Reads the EXIF information from the image and modifies the orientation
 	 * so that displays correctly in the browser.
 	 *

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -95,6 +95,7 @@ There are six available processing methods:
 
 -  $image->crop()
 -  $image->fit()
+-  $image->flatten()
 -  $image->flip()
 -  $image->resize()
 -  $image->rotate()
@@ -177,6 +178,34 @@ This provides a much simpler way to crop that will always maintain the aspect ra
     Services::image('imagick')
         ->withFile('/path/to/image/mypic.jpg')
         ->fit(100, 150, 'left')
+        ->save('path/to/new/image.jpg');
+
+Flattening Images
+-----------------
+
+The ``flatten()`` method aims to add a background color behind transparent images (PNG) and convert RGBA pixels to RGB pixels
+
+
+- Specify a background color when converting from transparent images to jpgs.
+
+::
+
+    flatten(int $red = 255, int $green = 255, int $blue = 255)
+
+- **$red** is the red value of the background.
+- **$green** is the green value of the background.
+- **$blue** is the blue value of the background.
+
+::
+
+    Services::image('imagick')
+        ->withFile('/path/to/image/mypic.png')
+        ->flatten()
+        ->save('path/to/new/image.jpg');
+
+    Services::image('imagick')
+        ->withFile('/path/to/image/mypic.png')
+        ->flatten(25,25,112)
         ->save('path/to/new/image.jpg');
 
 Flipping Images


### PR DESCRIPTION
Added a function that flattens an image's transparencies (PNG > JPG) and defaults to a white background instead of black (similar to Photoshop) and fixes ImageMagick CLI in Windows (at least Win10/8/2012/2012r2) escaping. 