### PR TITLE
Fixes PostgreSql Forge trying to create UNSIGNED fields

### DIFF
--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -128,6 +128,25 @@ class Forge extends \CodeIgniter\Database\Forge
 		return $sqls;
 	}
 
+        //--------------------------------------------------------------------
+
+	/**
+	 * Process column
+	 *
+	 * @param	array	$field
+	 * @return	string
+	 */
+	protected function _processColumn($field)
+	{
+		return $this->db->escapeIdentifiers($field['name'])
+				. ' ' . $field['type'] . $field['length']
+				. $field['default']
+				. $field['null']
+				. $field['auto_increment']
+				. $field['unique'];
+	}
+
+        
 	//--------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
Overridden method _processColumn($field)

$field['unsigned'] was left out for Postgre as it's not supported

#719 