### PR TITLE
Fixed: dropTable() of forge   wouldn't work if your 'DBPrefix'  is empty  

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -489,7 +489,7 @@ class Forge
 		}
 
 		// If the prefix is already starting the table name, remove it...
-		if (strpos($table_name, $this->db->DBPrefix) === 0)
+		if (! empty($this->db->DBPrefix) && strpos($table_name, $this->db->DBPrefix) === 0)
 		{
 			$table_name = substr($table_name, strlen($this->db->DBPrefix));
 		}


### PR DESCRIPTION
on line [492](https://github.com/bcit-ci/CodeIgniter4/blob/f14d09144633c61f4646320852e9c8253525cf82/system/Database/Forge.php#L492) it try to remove dbprefix from table name without checking if dbprefix is used or not. so if you didn't set  dbprefix ,  strpos()  used on that line throws error ( empty needle).