### PR TITLE
Views hints ordering

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -376,6 +376,7 @@ var ciDebugBar = {
 				while( nodeList[i].childNodes.length !== 1 )
 				{
 					nodeList[i].parentNode.insertBefore( nodeList[i].childNodes[1], nodeList[i].parentNode.childNodes[index].nextSibling  );
+					index++;
 				}
 
 				nodeList[i].parentNode.removeChild( nodeList[i] );

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -99,6 +99,13 @@ class View implements RendererInterface
 	 */
 	protected $saveData;
 
+	/**
+	 * Number of loaded views
+	 *
+	 * @var int
+	 */
+	protected $viewsCount = 0;
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -204,7 +211,10 @@ class View implements RendererInterface
 							$file = str_replace(constant($path), $path.'/', $file);
 						}
 					}
-					$output = '<!-- DEBUG-VIEW START ' . $file . ' -->' . $output . '<!-- DEBUG-VIEW ENDED ' . $file . ' -->';
+					$file = ++$this->viewsCount . ' ' . $file;
+					$output = '<!-- DEBUG-VIEW START ' . $file . ' -->' . PHP_EOL
+						. $output . PHP_EOL
+						. '<!-- DEBUG-VIEW ENDED ' . $file . ' -->' . PHP_EOL;
 				}
 			}
 		}

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -59,22 +59,27 @@ class ParserPluginTest extends \CIUnitTestCase
 
 	public function testValidationErrors()
 	{
-		
+
 		$this->validator->setError("email","Invalid email address");
-		
+
 		$template = '{+ validation_errors field=email +}';
 
-		$this->assertEquals($this->validator->showError('email'), $this->parser->renderString($template));
+		$this->assertEquals($this->setHints($this->validator->showError('email')), $this->setHints($this->parser->renderString($template)));
 	}
 
 	public function testValidationErrorsList()
 	{
-		
+
 		$this->validator->setError("email","Invalid email address");
 		$this->validator->setError("username","User name must be unique");
 		$template = '{+ validation_errors +}';
 
-		$this->assertEquals($this->validator->listErrors(), $this->parser->renderString($template));
+		$this->assertEquals($this->setHints($this->validator->listErrors()), $this->setHints($this->parser->renderString($template)));
+	}
+
+	public function setHints($output)
+	{
+		return preg_replace('/(<!-- DEBUG-VIEW+) (\w+) (\d+)/', '${1}', $output);
 	}
 
 }


### PR DESCRIPTION
# What was happening

This is a page when views hints is activated first time

![captura de tela de 2017-10-26 04-07-45](https://user-images.githubusercontent.com/3011423/32055902-e2306f70-ba41-11e7-8954-c5462dab144f.png)


When the Views label was clicked to hide the hints the order of nodes was modified.

![captura de tela de 2017-10-26 04-07-49](https://user-images.githubusercontent.com/3011423/32055917-ea83e24c-ba41-11e7-9260-233ad3aced87.png)


When a view was loaded more then one time the hints surrounded only the last view with same filepath.

![captura de tela de 2017-10-26 03-53-45](https://user-images.githubusercontent.com/3011423/32055952-1044e12a-ba42-11e7-885f-60a7abef4849.png)


# What this PR do

Now views hints use a number to identify the view and all are surrounded

![captura de tela de 2017-10-26 04-08-24](https://user-images.githubusercontent.com/3011423/32055966-17c70dec-ba42-11e7-89d4-1784ea6ec67a.png)

And the order is no more modified when the hints are hidden

![captura de tela de 2017-10-26 04-08-27](https://user-images.githubusercontent.com/3011423/32055971-1e64cbe4-ba42-11e7-98b3-c804043b9d28.png)
