### PR TITLE
CLI::getWidth return 0 for unittest testWrap

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -474,7 +474,7 @@ class CLI
 	 */
 	public static function getWidth(int $default = 80): int
 	{
-		if (static::isWindows())
+		if (static::isWindows() || (int) shell_exec('tput cols') == 0)
 		{
 			return $default;
 		}


### PR DESCRIPTION
If tput cols returns 0, the default value should be returned. This caused, among other things, an error for the test "testWrap" (system / CLI / CLITest.php), since the console width can not be 0 in the normal case