### PR TITLE
Add error key to API RT fail messages 

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -140,7 +140,7 @@ trait ResponseTrait
 	{
 		if ( ! is_array($messages))
 		{
-			$messages = [$messages];
+			$messages = ['error' => $messages];
 		}
 
 		$response = [

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -139,7 +139,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 500,
 			'error' => 'WHAT!',
 			'messages' => [
-				'Failure to Launch'
+				'error' => 'Failure to Launch'
 			]
 		];
 
@@ -177,7 +177,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 401,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -195,7 +195,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 403,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -213,7 +213,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 404,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -231,7 +231,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 400,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -249,7 +249,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 409,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -267,7 +267,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 410,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -285,7 +285,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 			'status' => 429,
 			'error' => 'FAT CHANCE',
 			'messages' => [
-				'Nope'
+				'error' => 'Nope'
 			]
 		];
 
@@ -305,7 +305,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 					'status' => 500,
 					'error' => 'FAT-CHANCE',
 					'messages' => [
-						'Nope.'
+						'error' => 'Nope.'
 					]
 				]), $this->response->getBody());
 	}


### PR DESCRIPTION
Avoid xml error (index 0 - Ex: <0>message</0>)

```
<?xml version="1.0"?>
<response><status>404</status><error>404</error><messages><0>Not Found</0></messages></response>
```

![captura de tela de 2017-11-08 15-16-31](https://user-images.githubusercontent.com/3011423/32563247-e4519940-c497-11e7-98fd-7e7ea68dd17c.png)

![captura de tela de 2017-11-08 15-19-05](https://user-images.githubusercontent.com/3011423/32563350-32f20396-c498-11e7-885a-1ff3319fa71d.png)

