### PR TITLE
CLI - trim pipe to validation detect rules

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -215,6 +215,7 @@ class CLI
 			{
 				$extra_output = ' [' .$extra_output_default.', '. implode(', ', $opts) . ']';
 				$validation .= '|in_list['. implode(',', $options) .']';
+				$validation = trim($validation, '|');
 			}
 
 			$default = $options[0];


### PR DESCRIPTION
Avoid this error:

```
An uncaught Exception was encountered

Type:        InvalidArgumentException
Message:      is not a valid rule.
Filename:    ~/CodeIgniter4/system/Validation/Validation.php
Line Number: 238
```

It occurs if the user just press Enter on prompts like `Generate CRUD? [y, n]:`.