### PR TITLE
Set CI_ENVIRONMENT before return false if REQUEST_URI is /index.php

### DIFF
--- a/rewrite.php
+++ b/rewrite.php
@@ -8,6 +8,10 @@
  * functionality so the site will operate as normal.
  */
 
+// If we're serving the site locally, then we need
+// to let the application know that we're in development mode
+$_SERVER['CI_ENVIRONMENT'] = 'development';
+
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
 $path = __DIR__.'/public/'.ltrim($uri,'/');
@@ -21,9 +25,4 @@ if ($uri !== '/' && (is_file($path) || is_dir($path)))
 
 // Otherwise, we'll load the index file and let
 // the framework handle the request from here.
-
-// If we're serving the site locally, then we need
-// to let the application know that we're in development mode
-$_SERVER['CI_ENVIRONMENT'] = 'development';
-
 require_once __DIR__.'/public/index.php';


### PR DESCRIPTION
Accessing http://localhost:8080/index.php the `$_SERVER['CI_ENVIRONMENT']` was not set.

Fix https://github.com/bcit-ci/CodeIgniter4/issues/834#issuecomment-345431577
