### PR TITLE
Let the browser know that the toolbarloader is a javascript file

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -241,6 +241,9 @@ class Toolbar
 		// simply returning the loading script
 		if ($request->getGet('debugbar') !== null)
 		{
+			// Let the browser know that we are sending javascript
+			header('Content-Type: application/javascript');
+
 			ob_start();
 			include(BASEPATH.'Debug/Toolbar/toolbarloader.js.php');
 			$output = ob_get_contents();


### PR DESCRIPTION
Not sure if can fix the #834 

Before:

![captura de tela de 2017-11-23 19-48-38](https://user-images.githubusercontent.com/3011423/33189160-56964be0-d087-11e7-87e1-d20181446449.png)


Now:

![captura de tela de 2017-11-23 19-48-47](https://user-images.githubusercontent.com/3011423/33189162-59660d4c-d087-11e7-8f7f-67c7fdef61da.png)

