### PR TITLE
returned different type from entity class

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -347,10 +347,8 @@ class Entity
 				{
 					$value = unserialize($value);
 				}
-				else
-				{
-					$value = (object)$value;
-				}
+
+				$value = (array)$value;
 				break;
 			case 'datetime':
 				return new \DateTime($value);

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -319,6 +319,31 @@ class EntityTest extends \CIUnitTestCase
 	{
 		$entity = $this->getCastEntity();
 
+		$entity->setSeventh(['foo' => 'bar']);
+
+		$check = $this->getPrivateProperty($entity, 'seventh');
+		$this->assertEquals(['foo' => 'bar'], $check);
+
+		$this->assertEquals(['foo' => 'bar'], $entity->seventh);
+	}
+
+	public function testCastArrayByStringSerialize()
+	{
+		$entity = $this->getCastEntity();
+
+		$entity->seventh = 'foobar';
+
+		// Should be a serialized string now...
+		$check = $this->getPrivateProperty($entity, 'seventh');
+		$this->assertEquals(serialize('foobar'), $check);
+
+		$this->assertEquals(['foobar'], $entity->seventh);
+	}
+
+	public function testCastArrayByArraySerialize()
+	{
+		$entity = $this->getCastEntity();
+
 		$entity->seventh = ['foo' => 'bar'];
 
 		// Should be a serialized string now...
@@ -412,6 +437,11 @@ class EntityTest extends \CIUnitTestCase
 				'dates' => [],
 				'datamap' => []
 			];
+
+			public function setSeventh($seventh) {
+				$this->seventh = $seventh;
+			}
+
 		};
 	}
 }


### PR DESCRIPTION
foo property in `Entity class` returned object type data when I write the following code

```php
$foo_entity = new class extends CodeIgniter\Entity {
    protected $foo;
    protected $_options = [
        'casts' => ['foo' => 'array'],
        'datas' => [],
        'datamap' => []
    ];
    public function setFoo($value) {
          $this->foo = $value;
    }
}
$foo_entity->setFoo(['foo' => 'bar']); // set no serialize array
return is_array($foo_entity->foo); // false
```

Fixed this because the type is different.

Also with this fix the following implementation also returns array.

```php
$foo_entity = new class extends CodeIgniter\Entity {
    protected $foo;
    protected $_options = [
        'casts' => ['foo' => 'array'],
        'datas' => [],
        'datamap' => []
    ];
}
$foo_entity->foo = 'bar'; // inject string
return is_array($foo_entity->foo); // true
```