### PR TITLE
Refactoring tests

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -113,7 +113,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 
 		$this->assertEquals(201, $this->response->getStatusCode());
 		$this->assertEquals('something', $this->response->getBody());
-		$this->assertTrue(strpos($this->response->getHeaderLine('Content-Type'), 'text/html') === 0);
+		$this->assertStringStartsWith('text/html', $this->response->getHeaderLine('Content-Type'));
 		$this->assertEquals('Created', $this->response->getReason());
 	}
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -150,10 +150,10 @@ class FileLocatorTest extends \CIUnitTestCase
 		$foundFiles = $this->loader->search('index', 'html');
 
 		$expected = rtrim(APPPATH, '/') . '/index.html';
-		$this->assertTrue(in_array($expected, $foundFiles));
+		$this->assertContains($expected, $foundFiles);
 
 		$expected = rtrim(BASEPATH, '/') . '/index.html';
-		$this->assertTrue(in_array($expected, $foundFiles));
+		$this->assertContains($expected, $foundFiles);
 	}
 
 	//--------------------------------------------------------------------
@@ -162,7 +162,7 @@ class FileLocatorTest extends \CIUnitTestCase
 	{
 		$foundFiles = $this->loader->search('Views/Fake.html');
 
-		$this->assertFalse(isset($foundFiles[0]));
+		$this->assertArrayNotHasKey(0, $foundFiles);
 	}
 
 	//--------------------------------------------------------------------
@@ -182,7 +182,7 @@ class FileLocatorTest extends \CIUnitTestCase
 	{
 		$files = $this->loader->listFiles('Config/App.php');
 
-		$this->assertTrue(empty($files));
+		$this->assertEmpty($files);
 	}
 
 	//--------------------------------------------------------------------
@@ -206,7 +206,7 @@ class FileLocatorTest extends \CIUnitTestCase
 	{
 		$files = $this->loader->listFiles('Fake/');
 
-		$this->assertTrue(empty($files));
+		$this->assertEmpty($files);
 	}
 
 	//--------------------------------------------------------------------
@@ -215,7 +215,7 @@ class FileLocatorTest extends \CIUnitTestCase
 	{
 		$files = $this->loader->listFiles('');
 
-		$this->assertTrue(empty($files));
+		$this->assertEmpty($files);
 	}
 
 	public function testFindQNameFromPathSimple()
@@ -230,21 +230,21 @@ class FileLocatorTest extends \CIUnitTestCase
 	{
 		$ClassName = $this->loader->findQualifiedNameFromPath('application/Config/App.php');
 
-		$this->assertEquals(null, $ClassName);
+		$this->assertNull($ClassName);
 	}
 
 	public function testFindQNameFromPathWithFileNotExist()
 	{
 		$ClassName = $this->loader->findQualifiedNameFromPath('modules/blog/Views/index.php');
 
-		$this->assertEquals(null, $ClassName);
+		$this->assertNull($ClassName);
 	}
 
 	public function testFindQNameFromPathWithoutCorrespondingNamespace()
 	{
 		$ClassName = $this->loader->findQualifiedNameFromPath('tests/system/CodeIgniterTest.php');
 
-		$this->assertEquals(null, $ClassName);
+		$this->assertNull($ClassName);
 	}
 
 }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -84,7 +84,7 @@ class CodeIgniterTest extends \CIUnitTestCase
 //		$this->codeigniter->run($routes);
 //		$output = ob_get_clean();
 //
-//		$this->assertTrue(strpos($output, "Can't find a route for") !== false);
+//		$this->assertContains("Can't find a route for", $output);
 //	}
 	//--------------------------------------------------------------------
 

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -43,7 +43,7 @@ class BaseConfigTest extends CIUnitTestCase
 		// empty treated as boolean false
 		$this->assertEquals(false, $config->echo);
 		// 'true' should be treated as boolean true
-		$this->assertEquals(true, $config->foxtrot);
+		$this->assertTrue($config->foxtrot);
 		// numbers should be treated properly
 		$this->assertEquals(18, $config->golf);
 	}
@@ -64,8 +64,8 @@ class BaseConfigTest extends CIUnitTestCase
 		// override config with shortPrefix ENV var
 		$this->assertEquals('hubbahubba', $config->delta);
 		// incorrect env name should not inject property
-		$this->assertFalse(isset($config->notthere));
-		// same ENV var as property, but not namespaced, still over-rides 
+		$this->assertObjectNotHasAttribute('notthere', $config);
+		// same ENV var as property, but not namespaced, still over-rides
 		$this->assertEquals('kazaam', $config->bravo);
 	}
 
@@ -146,7 +146,7 @@ class BaseConfigTest extends CIUnitTestCase
 	{
 		$config = new \RegistrarConfig();
 
-		// no change to unmodified property	
+		// no change to unmodified property
 		$this->assertEquals('bar', $config->foo);
 		// add to an existing array property
 		$this->assertEquals(['baz', 'first', 'second'], $config->bar);

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -59,8 +59,8 @@ class DotEnvTest extends \CIUnitTestCase
 		$dotenv = new DotEnv($this->fixturesFolder, 'commented.env');
 		$dotenv->load();
 		$this->assertEquals('bar', getenv('CFOO'));
-		$this->assertEquals(false, getenv('CBAR'));
-		$this->assertEquals(false, getenv('CZOO'));
+		$this->assertFalse(getenv('CBAR'));
+		$this->assertFalse(getenv('CZOO'));
 		$this->assertEquals('with spaces', getenv('CSPACED'));
 		$this->assertEquals('a value with a # character', getenv('CQUOTES'));
 		$this->assertEquals('a value with a # character & a quote " character inside quotes', getenv('CQUOTESWITHQUOTE'));

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -7,7 +7,7 @@ use Config\App;
  * Exercise our core Controller class.
  * Not a lot of business logic, so concentrate on making sure
  * we can exercise everything without blowing up :-/
- * 
+ *
  * @backupGlobals enabled
  */
 class ControllerTest extends \CIUnitTestCase
@@ -53,7 +53,7 @@ class ControllerTest extends \CIUnitTestCase
 	{
 		// make sure we can instantiate one
 		$this->controller = new Controller($this->request, $this->response);
-		$this->assertTrue($this->controller instanceof Controller);
+		$this->assertInstanceOf(Controller::class, $this->controller);
 	}
 
 	public function testConstructorHTTPS()
@@ -66,7 +66,7 @@ class ControllerTest extends \CIUnitTestCase
 
 			protected $forceHTTPS = 1;
 		};
-		$this->assertTrue($this->controller instanceof Controller);
+		$this->assertInstanceOf(Controller::class, $this->controller);
 		$_SERVER = $original; // restore so code coverage doesn't break
 	}
 
@@ -93,7 +93,7 @@ class ControllerTest extends \CIUnitTestCase
 
 			protected $helpers = ['cookie', 'text'];
 		};
-		$this->assertTrue($this->controller instanceof Controller);
+		$this->assertInstanceOf(Controller::class, $this->controller);
 	}
 
 }

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -57,16 +57,16 @@ class BaseConnectionTest extends \CIUnitTestCase
 		$this->assertSame('last', $db->password);
 		$this->assertSame('dbname', $db->database);
 		$this->assertSame('MockDriver', $db->DBDriver);
-		$this->assertSame(true, $db->pConnect);
-		$this->assertSame(true, $db->DBDebug);
-		$this->assertSame(false, $db->cacheOn);
+		$this->assertTrue($db->pConnect);
+		$this->assertTrue($db->DBDebug);
+		$this->assertFalse($db->cacheOn);
 		$this->assertSame('my/cacheDir', $db->cacheDir);
 		$this->assertSame('utf8', $db->charset);
 		$this->assertSame('utf8_general_ci', $db->DBCollat);
 		$this->assertSame('', $db->swapPre);
-		$this->assertSame(false, $db->encrypt);
-		$this->assertSame(false, $db->compress);
-		$this->assertSame(true, $db->strictOn);
+		$this->assertFalse($db->encrypt);
+		$this->assertFalse($db->compress);
+		$this->assertTrue($db->strictOn);
 		$this->assertSame([], $db->failover);
 	}
 
@@ -125,8 +125,8 @@ class BaseConnectionTest extends \CIUnitTestCase
 
 		$db->initialize();
 
-		$this->assertTrue($db->getConnectStart() > $start);
-		$this->assertTrue($db->getConnectDuration() > 0.0);
+		$this->assertGreaterThan($start, $db->getConnectStart());
+		$this->assertGreaterThan(0.0, $db->getConnectDuration());
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -64,7 +64,7 @@ class InsertTest extends \CIUnitTestCase
 
 		$query = $this->db->getLastQuery();
 
-		$this->assertTrue($query instanceof Query);
+		$this->assertInstanceOf(Query::class, $query);
 
 		$raw = "INSERT INTO \"jobs\" (\"description\", \"id\", \"name\") VALUES (:description0:,:id0:,:name0:)";
 

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -89,7 +89,7 @@ class UpdateTest extends \CIUnitTestCase
 
 		$query = $this->db->getLastQuery();
 
-		$this->assertTrue($query instanceof MockQuery);
+		$this->assertInstanceOf(MockQuery::class, $query);
 
 		$expected = 'UPDATE "jobs" SET "name" = CASE 
 WHEN "id" = :id: THEN :name:

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -70,16 +70,16 @@ class ForgeTest extends \CIDatabaseTestCase
 
 		//Check Field names
 		$fieldsNames = $this->db->getFieldNames('forge_test_fields');
-		$this->assertTrue(in_array('id', $fieldsNames));
-		$this->assertTrue(in_array('username', $fieldsNames));
-		$this->assertTrue(in_array('name', $fieldsNames));
-		$this->assertTrue(in_array('active', $fieldsNames));
+		$this->assertContains('id', $fieldsNames);
+		$this->assertContains('username', $fieldsNames);
+		$this->assertContains('name', $fieldsNames);
+		$this->assertContains('active', $fieldsNames);
 
 
 		$fieldsData = $this->db->getFieldData('forge_test_fields');
 
-		$this->assertTrue(in_array($fieldsData[0]->name, ['id', 'name', 'username', 'active']));
-		$this->assertTrue(in_array($fieldsData[1]->name, ['id', 'name', 'username', 'active']));
+		$this->assertContains($fieldsData[0]->name, ['id', 'name', 'username', 'active']);
+		$this->assertContains($fieldsData[1]->name, ['id', 'name', 'username', 'active']);
 
 		if ($this->db->DBDriver === 'MySQLi')
 		{
@@ -89,8 +89,8 @@ class ForgeTest extends \CIDatabaseTestCase
 
 			$this->assertEquals($fieldsData[0]->max_length, 11);
 
-			$this->assertEquals($fieldsData[0]->default, null);
-			$this->assertEquals($fieldsData[1]->default, null);
+			$this->assertNull($fieldsData[0]->default);
+			$this->assertNull($fieldsData[1]->default);
 
 			$this->assertEquals($fieldsData[0]->primary_key, 1);
 
@@ -104,7 +104,7 @@ class ForgeTest extends \CIDatabaseTestCase
 			$this->assertEquals($fieldsData[1]->type, 'character varying');
 
 			$this->assertEquals($fieldsData[0]->max_length, 32);
-			$this->assertEquals($fieldsData[1]->default, null);
+			$this->assertNull($fieldsData[1]->default);
 
 			$this->assertEquals($fieldsData[1]->max_length, 255);
 		}

--- a/tests/system/Database/Live/FromTest.php
+++ b/tests/system/Database/Live/FromTest.php
@@ -13,7 +13,7 @@ class FromTest extends \CIDatabaseTestCase
 	{
 		$result = $this->db->table('job')->from('misc')->get()->getResult();
 
-		$this->assertEquals(12, count($result));
+		$this->assertCount(12, $result);
 	}
 
 	//--------------------------------------------------------------------
@@ -23,7 +23,7 @@ class FromTest extends \CIDatabaseTestCase
 	{
 	    $result = $this->db->table('job')->from('misc', true)->get()->getResult();
 
-		$this->assertEquals(3, count($result));
+		$this->assertCount(3, $result);
 	}
 
 	//--------------------------------------------------------------------
@@ -32,7 +32,7 @@ class FromTest extends \CIDatabaseTestCase
 	{
 		$result = $this->db->table('job')->from('user')->where('user.id', 1)->get()->getResult();
 
-		$this->assertEquals(4, count($result));
+		$this->assertCount(4, $result);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -17,7 +17,7 @@ class GroupTest extends \CIDatabaseTestCase
 						->get()
 						->getResult();
 
-		$this->assertEquals(4, count($result));
+		$this->assertCount(4, $result);
 	}
 
 	//--------------------------------------------------------------------
@@ -31,7 +31,7 @@ class GroupTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResultArray();
 
-		$this->assertEquals(2, count($result));
+		$this->assertCount(2, $result);
 	}
 
 	//--------------------------------------------------------------------
@@ -45,7 +45,7 @@ class GroupTest extends \CIDatabaseTestCase
 						->get()
 						->getResult();
 
-		$this->assertEquals(2, count($result));
+		$this->assertCount(2, $result);
 	}
 
 	//--------------------------------------------------------------------
@@ -61,7 +61,7 @@ class GroupTest extends \CIDatabaseTestCase
 				->get()
 				->getResult();
 
-		$this->assertEquals(1, count($result));
+		$this->assertCount(1, $result);
 		$this->assertEquals('Richard A Causey', $result[0]->name);
 	}
 
@@ -78,7 +78,7 @@ class GroupTest extends \CIDatabaseTestCase
 				->get()
 				->getResult();
 
-		$this->assertEquals(2, count($result));
+		$this->assertCount(2, $result);
 		$this->assertEquals('Ahmadinejad', $result[0]->name);
 		$this->assertEquals('Chris Martin', $result[1]->name);
 	}
@@ -96,7 +96,7 @@ class GroupTest extends \CIDatabaseTestCase
 				->get()
 				->getResult();
 
-		$this->assertEquals(1, count($result));
+		$this->assertCount(1, $result);
 		$this->assertEquals('Derek Jones', $result[0]->name);
 	}
 
@@ -113,7 +113,7 @@ class GroupTest extends \CIDatabaseTestCase
 				->get()
 				->getResult();
 
-		$this->assertEquals(3, count($result));
+		$this->assertCount(3, $result);
 		$this->assertEquals('Derek Jones', $result[0]->name);
 		$this->assertEquals('Richard A Causey', $result[1]->name);
 		$this->assertEquals('Chris Martin', $result[2]->name);

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -71,7 +71,7 @@ class LikeTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(3, count($jobs));
+		$this->assertCount(3, $jobs);
 		$this->assertEquals('Developer', $jobs[0]->name);
 		$this->assertEquals('Politician', $jobs[1]->name);
 		$this->assertEquals('Musician', $jobs[2]->name);
@@ -86,7 +86,7 @@ class LikeTest extends \CIDatabaseTestCase
 		                 ->get()
 		                 ->getResult();
 
-		$this->assertEquals(3, count($jobs));
+		$this->assertCount(3, $jobs);
 		$this->assertEquals('Politician', $jobs[0]->name);
 		$this->assertEquals('Accountant', $jobs[1]->name);
 		$this->assertEquals('Musician', $jobs[2]->name);
@@ -102,7 +102,7 @@ class LikeTest extends \CIDatabaseTestCase
 		                 ->get()
 		                 ->getResult();
 
-		$this->assertEquals(3, count($jobs));
+		$this->assertCount(3, $jobs);
 		$this->assertEquals('Politician', $jobs[0]->name);
 		$this->assertEquals('Accountant', $jobs[1]->name);
 		$this->assertEquals('Musician', $jobs[2]->name);
@@ -116,8 +116,8 @@ class LikeTest extends \CIDatabaseTestCase
 	    $spaces = $builder->like('value', '   ')->get()->getResult();
 	    $tabs = $builder->like('value', "\t")->get()->getResult();
 
-		$this->assertEquals(1, count($spaces));
-		$this->assertEquals(1, count($tabs));
+		$this->assertCount(1, $spaces);
+		$this->assertCount(1, $tabs);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -16,7 +16,7 @@ class LimitTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(2, count($jobs));
+		$this->assertCount(2, $jobs);
 		$this->assertEquals('Developer', $jobs[0]->name);
 		$this->assertEquals('Politician', $jobs[1]->name);
 	}
@@ -30,7 +30,7 @@ class LimitTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(2, count($jobs));
+		$this->assertCount(2, $jobs);
 		$this->assertEquals('Accountant', $jobs[0]->name);
 		$this->assertEquals('Musician', $jobs[1]->name);
 	}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -59,7 +59,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$job = $model->asArray()->find(4);
 
-		$this->assertTrue(is_array($job));
+		$this->assertInternalType('array', $job);
 	}
 
 	//--------------------------------------------------------------------
@@ -70,7 +70,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$job = $model->asObject()->find(4);
 
-		$this->assertTrue(is_object($job));
+		$this->assertInternalType('object', $job);
 	}
 
 	//--------------------------------------------------------------------
@@ -83,7 +83,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$user = $model->asObject()->find(4);
 
-		$this->assertTrue(empty($user));
+		$this->assertEmpty($user);
 
 		$user = $model->withDeleted()->find(4);
 
@@ -98,7 +98,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$jobs = $model->asObject()->findWhere('id >', 2);
 
-		$this->assertEquals(2, count($jobs));
+		$this->assertCount(2, $jobs);
 		$this->assertEquals('Accountant', $jobs[0]->name);
 		$this->assertEquals('Musician',   $jobs[1]->name);
 	}
@@ -111,7 +111,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$jobs = $model->asArray()->findWhere(['id' => 1]);
 
-		$this->assertEquals(1, count($jobs));
+		$this->assertCount(1, $jobs);
 		$this->assertEquals('Developer', $jobs[0]['name']);
 	}
 
@@ -125,11 +125,11 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$user = $model->findWhere('id >', '2');
 
-		$this->assertEquals(1, count($user));
+		$this->assertCount(1, $user);
 
 		$user = $model->withDeleted()->findWhere('id >', 2);
 
-		$this->assertEquals(2, count($user));
+		$this->assertCount(2, $user);
 	}
 
 	//--------------------------------------------------------------------
@@ -140,7 +140,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$users = $model->findAll();
 
-		$this->assertEquals(4, count($users));
+		$this->assertCount(4, $users);
 	}
 
 	//--------------------------------------------------------------------
@@ -151,7 +151,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$users = $model->findAll(2);
 
-		$this->assertEquals(2, count($users));
+		$this->assertCount(2, $users);
 		$this->assertEquals('Derek Jones', $users[0]->name);
 	}
 
@@ -163,7 +163,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$users = $model->findAll(2, 2);
 
-		$this->assertEquals(2, count($users));
+		$this->assertCount(2, $users);
 		$this->assertEquals('Richard A Causey', $users[0]->name);
 	}
 
@@ -177,11 +177,11 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$user = $model->findAll();
 
-		$this->assertEquals(3, count($user));
+		$this->assertCount(3, $user);
 
 		$user = $model->withDeleted()->findAll();
 
-		$this->assertEquals(4, count($user));
+		$this->assertCount(4, $user);
 	}
 
 	//--------------------------------------------------------------------
@@ -374,7 +374,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$users = $model->withDeleted()->findAll();
 
-		$this->assertEquals(3, count($users));
+		$this->assertCount(3, $users);
 	}
 
 	//--------------------------------------------------------------------
@@ -387,7 +387,7 @@ class ModelTest extends \CIDatabaseTestCase
 
 		$users = $model->onlyDeleted()->findAll();
 
-		$this->assertEquals(1, count($users));
+		$this->assertCount(1, $users);
 	}
 
 	//--------------------------------------------------------------------
@@ -433,7 +433,7 @@ class ModelTest extends \CIDatabaseTestCase
             'description' => 'some great marketing stuff'
         ];
 
-        $this->assertTrue(is_numeric($model->skipValidation(true)->insert($data)));
+        $this->assertInternalType('numeric', $model->skipValidation(true)->insert($data));
     }
 
     //--------------------------------------------------------------------
@@ -444,7 +444,7 @@ class ModelTest extends \CIDatabaseTestCase
 
         $entity = $model->where('name', 'Developer')->first();
 
-        $this->assertTrue($entity instanceof SimpleEntity);
+        $this->assertInstanceOf(SimpleEntity::class, $entity);
         $this->assertEquals('Developer', $entity->name);
         $this->assertEquals('Awesome job, but sometimes makes you bored', $entity->description);
 
@@ -452,7 +452,7 @@ class ModelTest extends \CIDatabaseTestCase
         $entity->created_at = '2017-07-15';
 
         $date = $this->getPrivateProperty($entity, 'created_at');
-        $this->assertTrue($date instanceof Time);
+        $this->assertInstanceOf(Time::class, $date);
 
         $this->assertTrue($model->save($entity));
 
@@ -533,4 +533,3 @@ class ModelTest extends \CIDatabaseTestCase
 		$this->assertTrue($model->hasToken('afterDelete'));
 	}
 }
-

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -16,7 +16,7 @@ class OrderTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(4, count($jobs));
+		$this->assertCount(4, $jobs);
 		$this->assertEquals('Accountant', $jobs[0]->name);
 		$this->assertEquals('Developer', $jobs[1]->name);
 		$this->assertEquals('Musician', $jobs[2]->name);
@@ -32,7 +32,7 @@ class OrderTest extends \CIDatabaseTestCase
 		                 ->get()
 		                 ->getResult();
 
-		$this->assertEquals(4, count($jobs));
+		$this->assertCount(4, $jobs);
 		$this->assertEquals('Accountant', $jobs[3]->name);
 		$this->assertEquals('Developer', $jobs[2]->name);
 		$this->assertEquals('Musician', $jobs[1]->name);
@@ -49,7 +49,7 @@ class OrderTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(4, count($users));
+		$this->assertCount(4, $users);
 		$this->assertEquals('Ahmadinejad', $users[0]->name);
 		$this->assertEquals('Chris Martin', $users[1]->name);
 		$this->assertEquals('Richard A Causey', $users[2]->name);

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -22,7 +22,7 @@ class PreparedQueryTest extends \CIDatabaseTestCase
 			]);
 		});
 
-		$this->assertTrue($query instanceof BasePreparedQuery);
+		$this->assertInstanceOf(BasePreparedQuery::class, $query);
 
 		$ec = $this->db->escapeChar;
 		$pre = $this->db->DBPrefix;

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -25,7 +25,7 @@ class PretendTest extends \CIDatabaseTestCase
 					->table('user')
 					->get();
 
-		$this->assertTrue($result instanceof Query);
+		$this->assertInstanceOf(Query::class, $result);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -28,9 +28,9 @@ class SelectTest extends \CIDatabaseTestCase
 	{
 		$row = $this->db->table('job')->select('name')->get()->getRowArray();
 
-		$this->assertFalse(array_key_exists('id', $row));
+		$this->assertArrayNotHasKey('id', $row);
 		$this->assertArrayHasKey('name', $row);
-		$this->assertFalse(array_key_exists('description', $row));
+		$this->assertArrayNotHasKey('description', $row);
 	}
 
 	//--------------------------------------------------------------------
@@ -39,7 +39,7 @@ class SelectTest extends \CIDatabaseTestCase
 	{
 		$row = $this->db->table('job')->select('name, description')->get()->getRowArray();
 
-		$this->assertFalse(array_key_exists('id', $row));
+		$this->assertArrayNotHasKey('id', $row);
 		$this->assertArrayHasKey('name', $row);
 		$this->assertArrayHasKey('description', $row);
 	}
@@ -122,7 +122,7 @@ class SelectTest extends \CIDatabaseTestCase
 	{
 	    $users = $this->db->table('user')->select('country')->distinct()->get()->getResult();
 
-		$this->assertEquals(3, count($users));
+		$this->assertCount(3, $users);
 	}
 
 	//--------------------------------------------------------------------
@@ -131,7 +131,7 @@ class SelectTest extends \CIDatabaseTestCase
 	{
 		$users = $this->db->table('user')->select('country')->distinct(false)->get()->getResult();
 
-		$this->assertEquals(4, count($users));
+		$this->assertCount(4, $users);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -71,7 +71,7 @@ class UpdateTest extends \CIDatabaseTestCase
 			}
 		}
 
-		$this->assertEquals(2, count($rows));
+		$this->assertCount(2, $rows);
 	}
 
 	//--------------------------------------------------------------------
@@ -148,7 +148,7 @@ class UpdateTest extends \CIDatabaseTestCase
 			}
 		}
 
-		$this->assertEquals(2, count($rows));
+		$this->assertCount(2, $rows);
 	}
 
 	//--------------------------------------------------------------------
@@ -173,7 +173,7 @@ class UpdateTest extends \CIDatabaseTestCase
 			}
 		}
 
-		$this->assertEquals(2, count($rows));
+		$this->assertCount(2, $rows);
 	}
 
 	//--------------------------------------------------------------------
@@ -197,7 +197,7 @@ class UpdateTest extends \CIDatabaseTestCase
 			}
 		}
 
-		$this->assertEquals(2, count($rows));
+		$this->assertCount(2, $rows);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -23,7 +23,7 @@ class WhereTest extends \CIDatabaseTestCase
 	{
 	    $jobs = $this->db->table('job')->where('id !=', 1)->get()->getResult();
 
-		$this->assertEquals(3, count($jobs));
+		$this->assertCount(3, $jobs);
 	}
 
 	//--------------------------------------------------------------------
@@ -35,7 +35,7 @@ class WhereTest extends \CIDatabaseTestCase
 	        'name !=' => 'Accountant'
 	    ])->get()->getResult();
 
-		$this->assertEquals(1, count($jobs));
+		$this->assertCount(1, $jobs);
 
 		$job = current($jobs);
 		$this->assertEquals('Musician', $job->name);
@@ -49,7 +49,7 @@ class WhereTest extends \CIDatabaseTestCase
 		                    ->get()
 		                    ->getResult();
 
-		$this->assertEquals(1, count($jobs));
+		$this->assertCount(1, $jobs);
 
 		$job = current($jobs);
 		$this->assertEquals('Musician', $job->name);
@@ -65,7 +65,7 @@ class WhereTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(3, count($jobs));
+		$this->assertCount(3, $jobs);
 		$this->assertEquals('Developer', $jobs[0]->name);
 		$this->assertEquals('Politician', $jobs[1]->name);
 		$this->assertEquals('Musician', $jobs[2]->name);
@@ -81,7 +81,7 @@ class WhereTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(2, count($jobs));
+		$this->assertCount(2, $jobs);
 		$this->assertEquals('Developer', $jobs[0]->name);
 		$this->assertEquals('Politician', $jobs[1]->name);
 	}
@@ -95,7 +95,7 @@ class WhereTest extends \CIDatabaseTestCase
 		                ->get()
 		                ->getResult();
 
-		$this->assertEquals(2, count($jobs));
+		$this->assertCount(2, $jobs);
 		$this->assertEquals('Politician', $jobs[0]->name);
 		$this->assertEquals('Accountant', $jobs[1]->name);
 	}
@@ -112,7 +112,7 @@ class WhereTest extends \CIDatabaseTestCase
 		                 ->get()
 		                 ->getResult();
 
-		$this->assertEquals(2, count($jobs));
+		$this->assertCount(2, $jobs);
 		$this->assertEquals('Developer', $jobs[0]->name);
 		$this->assertEquals('Musician', $jobs[1]->name);
 	}

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -26,7 +26,7 @@ class TimerTest extends \CIUnitTestCase
 
 		$timers = $timer->getTimers();
 
-		$this->assertTrue(count($timers) === 1, "No timers were stored.");
+		$this->assertCount(1, $timers, "No timers were stored.");
 		$this->assertArrayHasKey('test1', $timers, 'No "test1" array found.');
 		$this->assertArrayHasKey('start', $timers['test1'], 'No "start" value found.');
 		$this->assertArrayHasKey('end', $timers['test1'], 'No "end" value found.');

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -45,8 +45,8 @@ class EntityTest extends \CIUnitTestCase
 	{
 	    $entity = $this->getEntity();
 
-	    $this->assertTrue(isset($entity->default));
 	    $this->assertFalse(isset($entity->foo));
+	    $this->assertObjectHasAttribute('default', $entity);
 	}
 
 	public function testFill()
@@ -61,7 +61,7 @@ class EntityTest extends \CIUnitTestCase
 
 	    $this->assertEquals(123, $entity->foo);
 	    $this->assertEquals('bar:234:bar', $entity->bar);
-	    $this->assertTrue(! isset($entity->baz));
+	    $this->assertObjectNotHasAttribute('baz', $entity);
 	}
 
 	public function testDataMappingConvertsOriginalName()
@@ -103,8 +103,8 @@ class EntityTest extends \CIUnitTestCase
 		// maps to 'foo'
 		$entity->bar = 'here';
 
-		$this->assertTrue(isset($entity->foo));
-		$this->assertFalse(isset($entity->bar));
+		$this->assertObjectHasAttribute('foo', $entity);
+		$this->assertObjectNotHasAttribute('bar', $entity);
 	}
 
 	public function testUnsetWorksWithMapping()
@@ -132,7 +132,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $entity->created_at;
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
 	}
 
@@ -145,7 +145,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $entity->created_at;
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals(date('Y-m-d H:i:s', $stamp), $time->format('Y-m-d H:i:s'));
 	}
 
@@ -157,7 +157,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $entity->created_at;
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
@@ -169,7 +169,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $entity->created_at;
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
@@ -181,7 +181,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
 	}
 
@@ -194,7 +194,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals(date('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
@@ -207,7 +207,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
@@ -220,7 +220,7 @@ class EntityTest extends \CIUnitTestCase
 
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
@@ -229,7 +229,7 @@ class EntityTest extends \CIUnitTestCase
 		$entity = $this->getCastEntity();
 
 		$entity->first = 3.1;
-		$this->assertTrue(is_integer($entity->first));
+		$this->assertInternalType('integer', $entity->first);
 		$this->assertEquals(3, $entity->first);
 
 		$entity->first = 3.6;
@@ -241,11 +241,11 @@ class EntityTest extends \CIUnitTestCase
 		$entity = $this->getCastEntity();
 
 		$entity->second = 3;
-		$this->assertTrue(is_float($entity->second));
+		$this->assertInternalType('float', $entity->second);
 		$this->assertEquals(3.0, $entity->second);
 
 		$entity->second = '3.6';
-		$this->assertTrue(is_float($entity->second));
+		$this->assertInternalType('float', $entity->second);
 		$this->assertEquals(3.6, $entity->second);
 	}
 
@@ -254,11 +254,11 @@ class EntityTest extends \CIUnitTestCase
 		$entity = $this->getCastEntity();
 
 		$entity->third = 3;
-		$this->assertTrue(is_double($entity->third));
+		$this->assertInternalType('double', $entity->third);
 		$this->assertSame(3.0, $entity->third);
 
 		$entity->third = '3.6';
-		$this->assertTrue(is_double($entity->third));
+		$this->assertInternalType('double', $entity->third);
 		$this->assertSame(3.6, $entity->third);
 	}
 
@@ -267,7 +267,7 @@ class EntityTest extends \CIUnitTestCase
 		$entity = $this->getCastEntity();
 
 		$entity->fourth = 3.1415;
-		$this->assertTrue(is_string($entity->fourth));
+		$this->assertInternalType('string', $entity->fourth);
 		$this->assertSame('3.1415', $entity->fourth);
 	}
 
@@ -276,12 +276,12 @@ class EntityTest extends \CIUnitTestCase
 		$entity = $this->getCastEntity();
 
 		$entity->fifth = 1;
-		$this->assertTrue(is_bool($entity->fifth));
-		$this->assertSame(true, $entity->fifth);
+		$this->assertInternalType('bool', $entity->fifth);
+		$this->assertTrue($entity->fifth);
 
 		$entity->fifth = 0;
-		$this->assertTrue(is_bool($entity->fifth));
-		$this->assertSame(false, $entity->fifth);
+		$this->assertInternalType('bool', $entity->fifth);
+		$this->assertFalse($entity->fifth);
 	}
 
 	public function testCastObject()
@@ -291,7 +291,7 @@ class EntityTest extends \CIUnitTestCase
 		$data = ['foo' => 'bar'];
 
 		$entity->sixth = $data;
-		$this->assertTrue(is_object($entity->sixth));
+		$this->assertInternalType('object', $entity->sixth);
 		$this->assertEquals((object)$data, $entity->sixth);
 	}
 
@@ -311,7 +311,7 @@ class EntityTest extends \CIUnitTestCase
 		$date = 'March 12, 2017';
 
 		$entity->ninth = $date;
-		$this->assertTrue(is_integer($entity->ninth));
+		$this->assertInternalType('integer', $entity->ninth);
 		$this->assertEquals(strtotime($date), $entity->ninth);
 	}
 

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -124,7 +124,7 @@ class EventsTest extends \CIUnitTestCase
 		$this->assertTrue($result);
 
 		$result = false;
-		$this->assertTrue( Events::removeListener('foo', $callback) );
+		$this->assertTrue(Events::removeListener('foo', $callback));
 
 		Events::trigger('foo');
 		$this->assertFalse($result);
@@ -147,8 +147,8 @@ class EventsTest extends \CIUnitTestCase
 		$this->assertTrue($result);
 
 		$result = false;
-		$this->assertTrue( Events::removeListener('foo', $callback) );
-		$this->assertFalse( Events::removeListener('foo', $callback) );
+		$this->assertTrue(Events::removeListener('foo', $callback));
+		$this->assertFalse(Events::removeListener('foo', $callback));
 
 		Events::trigger('foo');
 		$this->assertFalse($result);
@@ -171,7 +171,7 @@ class EventsTest extends \CIUnitTestCase
 		$this->assertTrue($result);
 
 		$result = false;
-		$this->assertFalse( Events::removeListener('bar', $callback) );
+		$this->assertFalse(Events::removeListener('bar', $callback));
 
 		Events::trigger('foo');
 		$this->assertTrue($result);

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -34,7 +34,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('GET', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -48,7 +48,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('DELETE', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -62,7 +62,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('HEAD', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -76,7 +76,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('OPTIONS', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -90,7 +90,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('PATCH', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -104,7 +104,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('POST', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -118,7 +118,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('PUT', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -132,7 +132,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -146,7 +146,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
 		$this->assertEquals('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
 	}
 
@@ -158,22 +158,22 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_URL]));
+		$this->assertArrayHasKey(CURLOPT_URL, $options);
 		$this->assertEquals('http://example.com', $options[CURLOPT_URL]);
 
-		$this->assertTrue(isset($options[CURLOPT_RETURNTRANSFER]));
-		$this->assertEquals(true, $options[CURLOPT_RETURNTRANSFER]);
+		$this->assertArrayHasKey(CURLOPT_RETURNTRANSFER, $options);
+		$this->assertTrue($options[CURLOPT_RETURNTRANSFER]);
 
-		$this->assertTrue(isset($options[CURLOPT_HEADER]));
-		$this->assertEquals(true, $options[CURLOPT_HEADER]);
+		$this->assertArrayHasKey(CURLOPT_HEADER, $options);
+		$this->assertTrue($options[CURLOPT_HEADER]);
 
-		$this->assertTrue(isset($options[CURLOPT_FRESH_CONNECT]));
-		$this->assertEquals(true, $options[CURLOPT_FRESH_CONNECT]);
+		$this->assertArrayHasKey(CURLOPT_FRESH_CONNECT, $options);
+		$this->assertTrue($options[CURLOPT_FRESH_CONNECT]);
 
-		$this->assertTrue(isset($options[CURLOPT_TIMEOUT_MS]));
+		$this->assertArrayHasKey(CURLOPT_TIMEOUT_MS, $options);
 		$this->assertEquals(0.0, $options[CURLOPT_TIMEOUT_MS]);
 
-		$this->assertTrue(isset($options[CURLOPT_CONNECTTIMEOUT_MS]));
+		$this->assertArrayHasKey(CURLOPT_CONNECTTIMEOUT_MS, $options);
 		$this->assertEquals(150 * 1000, $options[CURLOPT_CONNECTTIMEOUT_MS]);
 	}
 
@@ -187,10 +187,10 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_USERPWD]));
+		$this->assertArrayHasKey(CURLOPT_USERPWD, $options);
 		$this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
 
-		$this->assertTrue(isset($options[CURLOPT_HTTPAUTH]));
+		$this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
 		$this->assertEquals(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
 	}
 
@@ -204,10 +204,10 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_USERPWD]));
+		$this->assertArrayHasKey(CURLOPT_USERPWD, $options);
 		$this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
 
-		$this->assertTrue(isset($options[CURLOPT_HTTPAUTH]));
+		$this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
 		$this->assertEquals(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
 	}
 
@@ -221,10 +221,10 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_USERPWD]));
+		$this->assertArrayHasKey(CURLOPT_USERPWD, $options);
 		$this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
 
-		$this->assertTrue(isset($options[CURLOPT_HTTPAUTH]));
+		$this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
 		$this->assertEquals(CURLAUTH_DIGEST, $options[CURLOPT_HTTPAUTH]);
 	}
 
@@ -240,7 +240,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_SSLCERT]));
+		$this->assertArrayHasKey(CURLOPT_SSLCERT, $options);
 		$this->assertEquals($file, $options[CURLOPT_SSLCERT]);
 	}
 
@@ -256,10 +256,10 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_SSLCERT]));
+		$this->assertArrayHasKey(CURLOPT_SSLCERT, $options);
 		$this->assertEquals($file, $options[CURLOPT_SSLCERT]);
 
-		$this->assertTrue(isset($options[CURLOPT_SSLCERTPASSWD]));
+		$this->assertArrayHasKey(CURLOPT_SSLCERTPASSWD, $options);
 		$this->assertEquals('password', $options[CURLOPT_SSLCERTPASSWD]);
 	}
 
@@ -273,10 +273,10 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_VERBOSE]));
+		$this->assertArrayHasKey(CURLOPT_VERBOSE, $options);
 		$this->assertEquals(1, $options[CURLOPT_VERBOSE]);
 
-		$this->assertTrue(isset($options[CURLOPT_STDERR]));
+		$this->assertArrayHasKey(CURLOPT_STDERR, $options);
 	}
 
 	//--------------------------------------------------------------------
@@ -289,11 +289,11 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_FOLLOWLOCATION]));
+		$this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
 		$this->assertEquals(0, $options[CURLOPT_FOLLOWLOCATION]);
 
-		$this->assertFalse(isset($options[CURLOPT_MAXREDIRS]));
-		$this->assertFalse(isset($options[CURLOPT_REDIR_PROTOCOLS]));
+		$this->assertArrayNotHasKey(CURLOPT_MAXREDIRS, $options);
+		$this->assertArrayNotHasKey(CURLOPT_REDIR_PROTOCOLS, $options);
 	}
 
 	//--------------------------------------------------------------------
@@ -306,12 +306,12 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_FOLLOWLOCATION]));
+		$this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
 		$this->assertEquals(1, $options[CURLOPT_FOLLOWLOCATION]);
 
-		$this->assertTrue(isset($options[CURLOPT_MAXREDIRS]));
+		$this->assertArrayHasKey(CURLOPT_MAXREDIRS, $options);
 		$this->assertEquals(5, $options[CURLOPT_MAXREDIRS]);
-		$this->assertTrue(isset($options[CURLOPT_REDIR_PROTOCOLS]));
+		$this->assertArrayHasKey(CURLOPT_REDIR_PROTOCOLS, $options);
 		$this->assertEquals(CURLPROTO_HTTP|CURLPROTO_HTTPS, $options[CURLOPT_REDIR_PROTOCOLS]);
 	}
 
@@ -325,11 +325,11 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertTrue(isset($options[CURLOPT_FOLLOWLOCATION]));
+		$this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
 		$this->assertEquals(1, $options[CURLOPT_FOLLOWLOCATION]);
 
-		$this->assertTrue(isset($options[CURLOPT_MAXREDIRS]));
-		$this->assertTrue(isset($options[CURLOPT_REDIR_PROTOCOLS]));
+		$this->assertArrayHasKey(CURLOPT_MAXREDIRS, $options);
+		$this->assertArrayHasKey(CURLOPT_REDIR_PROTOCOLS, $options);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -32,10 +32,10 @@ class FileCollectionTest extends \CIUnitTestCase
 
 		$collection = new FileCollection();
 		$files      = $collection->all();
-		$this->assertEquals(1, count($files));
+		$this->assertCount(1, $files);
 
 		$file = array_shift($files);
-		$this->assertTrue($file instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file);
 
 		$this->assertEquals('someFile.txt', $file->getName());
 		$this->assertEquals(124, $file->getSize());
@@ -57,14 +57,14 @@ class FileCollectionTest extends \CIUnitTestCase
 
 		$collection = new FileCollection();
 		$files      = $collection->all();
-		$this->assertEquals(1, count($files));
+		$this->assertCount(1, $files);
 		$this->assertEquals('userfile', key($files));
 
 		$files = array_shift($files);
-		$this->assertEquals(2, count($files));
+		$this->assertCount(2, $files);
 
 		$file = $files[0];
-		$this->assertTrue($file instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file);
 
 		$this->assertEquals('fileA.txt', $file->getName());
 		$this->assertEquals('/tmp/fileA.txt', $file->getTempName());
@@ -97,11 +97,11 @@ class FileCollectionTest extends \CIUnitTestCase
 
 		$collection = new FileCollection();
 		$files      = $collection->all();
-		$this->assertEquals(2, count($files));
+		$this->assertCount(2, $files);
 		$this->assertEquals('userfile1', key($files));
 
 		$file = array_shift($files);
-		$this->assertTrue($file instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file);
 
 		$this->assertEquals('fileA.txt', $file->getName());
 		$this->assertEquals('/tmp/fileA.txt', $file->getTempName());
@@ -110,7 +110,7 @@ class FileCollectionTest extends \CIUnitTestCase
 		$this->assertEquals(124, $file->getSize());
 
 		$file = array_pop($files);
-		$this->assertTrue($file instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file);
 
 		$this->assertEquals('fileB.txt', $file->getName());
 		$this->assertEquals('/tmp/fileB.txt', $file->getTempName());
@@ -154,13 +154,13 @@ class FileCollectionTest extends \CIUnitTestCase
 
 		$collection = new FileCollection();
 		$files      = $collection->all();
-		$this->assertEquals(1, count($files));
+		$this->assertCount(1, $files);
 		$this->assertEquals('userfile', key($files));
 
-		$this->assertTrue(isset($files['userfile']['foo']['bar']));
+		$this->assertArrayHasKey('bar', $files['userfile']['foo']);
 
 		$file = $files['userfile']['foo']['bar'];
-		$this->assertTrue($file instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file);
 
 		$this->assertEquals('fileA.txt', $file->getName());
 		$this->assertEquals('/tmp/fileA.txt', $file->getTempName());
@@ -255,7 +255,7 @@ class FileCollectionTest extends \CIUnitTestCase
 		$this->assertTrue($collection->hasFile('userfile.foo'));
 		$this->assertTrue($collection->hasFile('userfile.foo.bar'));
 	}
-        
+
 	//--------------------------------------------------------------------
 
 	public function testErrorString()
@@ -279,7 +279,7 @@ class FileCollectionTest extends \CIUnitTestCase
 	}
 
     //--------------------------------------------------------------------
-        
+
         public function testFileReturnsValidSingleFile() {
             $_FILES = [
                         'userfile' => [
@@ -293,12 +293,12 @@ class FileCollectionTest extends \CIUnitTestCase
 
                 $collection = new FileCollection();
                 $file = $collection->getFile('userfile');
-                $this->assertTrue($file instanceof UploadedFile);
+                $this->assertInstanceOf(UploadedFile::class, $file);
 
                 $this->assertEquals('someFile.txt', $file->getName());
                 $this->assertEquals(124, $file->getSize());
         }
-        
+
     //--------------------------------------------------------------------
 
         public function testFileNoExistSingleFile() {
@@ -316,9 +316,9 @@ class FileCollectionTest extends \CIUnitTestCase
                 $file = $collection->getFile('fileuser');
                 $this->AssertNull($file);
         }
-        
+
     //--------------------------------------------------------------------
-        
+
         public function testFileReturnValidMultipleFiles() {
             $_FILES = [
 			'userfile' => [
@@ -329,28 +329,28 @@ class FileCollectionTest extends \CIUnitTestCase
 				'error' => 0
 			]
 		];
-            
+
 		$collection = new FileCollection();
 
 		$file_1 = $collection->getFile('userfile.0');
-		$this->assertTrue($file_1 instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file_1);
 		$this->assertEquals('fileA.txt', $file_1->getName());
 		$this->assertEquals('/tmp/fileA.txt', $file_1->getTempName());
 		$this->assertEquals('txt', $file_1->getClientExtension());
 		$this->assertEquals('text/plain', $file_1->getClientMimeType());
 		$this->assertEquals(124, $file_1->getSize());
-                
+
 		$file_2 = $collection->getFile('userfile.1');
-		$this->assertTrue($file_2 instanceof UploadedFile);
+		$this->assertInstanceOf(UploadedFile::class, $file_2);
 		$this->assertEquals('fileB.txt', $file_2->getName());
 		$this->assertEquals('/tmp/fileB.txt', $file_2->getTempName());
 		$this->assertEquals('txt', $file_2->getClientExtension());
 		$this->assertEquals('text/csv', $file_2->getClientMimeType());
 		$this->assertEquals(248, $file_2->getSize());
     }
-        
+
     //--------------------------------------------------------------------
-        
+
     public function testFileWithMultipleFilesNestedName() {
         $_FILES = [
 			'my-form' => [
@@ -381,11 +381,11 @@ class FileCollectionTest extends \CIUnitTestCase
 				],
 			]
 		];
-        
+
         $collection = new FileCollection();
 
         $file_1 = $collection->getFile('my-form.details.avatars.0');
-        $this->assertTrue($file_1 instanceof UploadedFile);
+        $this->assertInstanceOf(UploadedFile::class, $file_1);
         $this->assertEquals('fileA.txt', $file_1->getName());
 		$this->assertEquals('/tmp/fileA.txt', $file_1->getTempName());
 		$this->assertEquals('txt', $file_1->getClientExtension());
@@ -393,7 +393,7 @@ class FileCollectionTest extends \CIUnitTestCase
 		$this->assertEquals(125, $file_1->getSize());
 
         $file_2 = $collection->getFile('my-form.details.avatars.1');
-        $this->assertTrue($file_2 instanceof UploadedFile);
+        $this->assertInstanceOf(UploadedFile::class, $file_2);
         $this->assertEquals('fileB.txt', $file_2->getName());
 		$this->assertEquals('/tmp/fileB.txt', $file_2->getTempName());
 		$this->assertEquals('txt', $file_2->getClientExtension());
@@ -436,7 +436,7 @@ class FileCollectionTest extends \CIUnitTestCase
         is_dir($destination) || mkdir($destination, 0777, true);
 
         foreach ($collection->all() as $file) {
-            $this->assertTrue($file instanceof UploadedFile);
+            $this->assertInstanceOf(UploadedFile::class, $file);
             $file->move($destination, $file->getName(), false);
         }
 
@@ -496,7 +496,7 @@ class FileCollectionTest extends \CIUnitTestCase
         is_dir($destination) || mkdir($destination, 0777, true);
 
         foreach ($collection->all() as $file) {
-            $this->assertTrue($file instanceof UploadedFile);
+            $this->assertInstanceOf(UploadedFile::class, $file);
             $file->move($destination, $file->getName(), true);
         }
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -26,7 +26,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$_REQUEST['TEST'] = 5;
 
 		$this->assertEquals(5, $this->request->getVar('TEST'));
-		$this->assertEquals(null, $this->request->getVar('TESTY'));
+		$this->assertNull($this->request->getVar('TESTY'));
 	}
 
 	//--------------------------------------------------------------------
@@ -36,7 +36,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$_GET['TEST'] = 5;
 
 		$this->assertEquals(5, $this->request->getGet('TEST'));
-		$this->assertEquals(null, $this->request->getGEt('TESTY'));
+		$this->assertNull($this->request->getGEt('TESTY'));
 	}
 
 	//--------------------------------------------------------------------
@@ -46,7 +46,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$_POST['TEST'] = 5;
 
 		$this->assertEquals(5, $this->request->getPost('TEST'));
-		$this->assertEquals(null, $this->request->getPost('TESTY'));
+		$this->assertNull($this->request->getPost('TESTY'));
 	}
 
 	//--------------------------------------------------------------------
@@ -82,7 +82,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$_SERVER['TEST'] = 5;
 
 		$this->assertEquals(5, $this->request->getServer('TEST'));
-		$this->assertEquals(null, $this->request->getServer('TESTY'));
+		$this->assertNull($this->request->getServer('TESTY'));
 	}
 
 	//--------------------------------------------------------------------
@@ -92,7 +92,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$_ENV['TEST'] = 5;
 
 		$this->assertEquals(5, $this->request->getEnv('TEST'));
-		$this->assertEquals(null, $this->request->getEnv('TESTY'));
+		$this->assertNull($this->request->getEnv('TESTY'));
 	}
 
 	//--------------------------------------------------------------------
@@ -102,7 +102,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$_COOKIE['TEST'] = 5;
 
 		$this->assertEquals(5, $this->request->getCookie('TEST'));
-		$this->assertEquals(null, $this->request->getCookie('TESTY'));
+		$this->assertNull($this->request->getCookie('TESTY'));
 	}
 
 	//--------------------------------------------------------------------
@@ -200,8 +200,8 @@ class IncomingRequestTest extends \CIUnitTestCase
         $result = $this->request->getPost();
 
         $this->assertEquals($_POST, $result);
-        $this->assertTrue(is_array($result['ANNOUNCEMENTS']));
-        $this->assertEquals(2, count($result['ANNOUNCEMENTS']));
+        $this->assertInternalType('array', $result['ANNOUNCEMENTS']);
+        $this->assertCount(2, $result['ANNOUNCEMENTS']);
     }
 
     //--------------------------------------------------------------------
@@ -388,7 +388,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 		];
 
 		$request = new IncomingRequest(new App(), new URI(), $json);
-		
+
 		$this->assertEquals($expected, $request->getJSON(true));
 	}
 

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -34,10 +34,10 @@ class MessageTest extends \CIUnitTestCase
 		$headers = $this->message->getHeaders();
 
 		// Content-Type is likely set...
-		$this->assertTrue(count($headers) >= 2);
+		$this->assertGreaterThanOrEqual(2, count($headers));
 
-		$this->assertTrue($headers['Host']->getValue() == 'daisyduke.com');
-		$this->assertTrue($headers['Referer']->getValue() == 'RoscoePekoTrain.com');
+		$this->assertSame('daisyduke.com', $headers['Host']->getValue());
+		$this->assertSame('RoscoePekoTrain.com', $headers['Referer']->getValue());
 	}
 
 	//--------------------------------------------------------------------
@@ -48,7 +48,7 @@ class MessageTest extends \CIUnitTestCase
 
 		$header = $this->message->getHeader('Host');
 
-		$this->assertTrue($header instanceof Header);
+		$this->assertInstanceOf(Header::class, $header);
 		$this->assertEquals('daisyduke.com', $header->getValue());
 	}
 
@@ -174,43 +174,43 @@ class MessageTest extends \CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
-        
+
 	public function  testSetHeaderReplacingHeader()
 
 	{
        		$this->message->setHeader('Accept', 'json');
-        	
+
                 $this->assertEquals('json', $this->message->getHeaderLine('Accept'));
 	}
 
-        
+
         public function testSetHeaderDuplicateSettings()
         {
         	$this->message->setHeader('Accept', 'json');
         	$this->message->setHeader('Accept', 'xml');
-       		
+
                 $this->assertEquals('xml', $this->message->getHeaderLine('Accept'));
         }
-                
+
         public function testSetHeaderArrayValues()
         {
         	$this->message->setHeader('Accept', ['json', 'html', 'xml']);
-      		
+
                 $this->assertEquals('json, html, xml', $this->message->getHeaderLine('Accept'));
         }
-        
+
 	//--------------------------------------------------------------------
 
 	public function testPopulateHeadersWithoutContentType()
 	{
-		// fail path, if the CONTENT_TYPE doesn't exist 
+		// fail path, if the CONTENT_TYPE doesn't exist
 		$original = $_SERVER;
 		$_SERVER = ['HTTP_ACCEPT_LANGUAGE' => 'en-us,en;q=0.50'];
 		$original_env = getenv("CONTENT_TYPE");
 		putenv("CONTENT_TYPE");
 
 		$this->message->populateHeaders();
-		
+
 		$this->assertNull($this->message->getHeader('content-type'));
 		putenv("CONTENT_TYPE=$original_env");
 		$this->message->removeHeader('accept-language');
@@ -218,7 +218,7 @@ class MessageTest extends \CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
-	
+
 	public function testPopulateHeadersWithoutHTTP()
 	{
 		// fail path, if arguement does't have the HTTP_*
@@ -227,14 +227,14 @@ class MessageTest extends \CIUnitTestCase
 
 
 		$this->message->populateHeaders();
-		
+
 		$this->assertNull($this->message->getHeader('user-agent'));
 		$this->assertNull($this->message->getHeader('request-method'));
 		$_SERVER = $original; // restore so code coverage doesn't break
 	}
 
 	//--------------------------------------------------------------------
-	
+
 	public function testPopulateHeadersKeyNotExists()
 	{
 		// Success path, if array key is not exists, assign empty string to it's value
@@ -249,7 +249,7 @@ class MessageTest extends \CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
-	
+
 	public function testPopulateHeaders()
 	{
 		// success path

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -62,7 +62,7 @@ class RedirectResponseTest extends \CIUnitTestCase
 		$returned = $response->withInput();
 
 		$this->assertSame($response, $returned);
-		$this->assertTrue(array_key_exists('_ci_old_input', $_SESSION));
+		$this->assertArrayHasKey('_ci_old_input', $_SESSION);
 		$this->assertEquals('bar', $_SESSION['_ci_old_input']['get']['foo']);
 		$this->assertEquals('baz', $_SESSION['_ci_old_input']['post']['bar']);
 	}
@@ -81,7 +81,7 @@ class RedirectResponseTest extends \CIUnitTestCase
 
 		$response->withInput();
 
-		$this->assertTrue(array_key_exists('_ci_validation_errors', $_SESSION));
+		$this->assertArrayHasKey('_ci_validation_errors', $_SESSION);
 	}
 
 	public function testWith()
@@ -93,6 +93,6 @@ class RedirectResponseTest extends \CIUnitTestCase
 		$returned = $response->with('foo', 'bar');
 
 		$this->assertSame($response, $returned);
-		$this->assertTrue(array_key_exists('foo', $_SESSION));
+		$this->assertArrayHasKey('foo', $_SESSION);
 	}
 }

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -14,7 +14,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testSingular()
 	{
-		$strings = 
+		$strings =
 		[
 			'matrices'  => 'matrix',
 			'oxen'      => 'ox',
@@ -55,7 +55,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testPlural()
 	{
-		$strings = 
+		$strings =
 		[
 			'searches'  => 'search',
 			'matrices'  => 'matrix',
@@ -95,7 +95,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testCamelize()
 	{
-		$strings = 
+		$strings =
 		[
 			'hello from codeIgniter 4' => 'helloFromCodeIgniter4',
 			'hello_world'              => 'helloWorld'
@@ -112,7 +112,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testUnderscore()
 	{
-		$strings = 
+		$strings =
 		[
 			'Hello From CodeIgniter 4' => 'Hello_From_CodeIgniter_4',
 			'hello world'              => 'hello_world'
@@ -143,7 +143,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testIsCountable()
 	{
-		$words = 
+		$words =
 		[
 			'tip'        => 'advice',
 			'fight'      => 'bravery',
@@ -155,8 +155,8 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 		foreach ($words as $countable => $unCountable)
 		{
-			$this->assertEquals(is_countable($countable), true);
-			$this->assertEquals(is_countable($unCountable), false);
+			$this->assertTrue(is_countable($countable));
+			$this->assertFalse(is_countable($unCountable));
 		}
 	}
 
@@ -164,7 +164,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testDasherize()
 	{
-		$strings = 
+		$strings =
 		[
 			'hello_world'              => 'hello-world',
 			'Hello_From_CodeIgniter_4' => 'Hello-From-CodeIgniter-4'
@@ -181,7 +181,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testOrdinal()
 	{
-		$suffixes = 
+		$suffixes =
 		[
 			'st' => 1,
 			'nd' => 2,
@@ -195,7 +195,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 			'th' => 24
 		];
 
-		foreach ($suffixes as $suffix => $number) 
+		foreach ($suffixes as $suffix => $number)
 		{
 			$ordinal = ordinal($number);
 			$this->assertEquals($suffix, $ordinal);
@@ -206,7 +206,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 
 	public function testOrdinalize()
 	{
-		$suffixedNumbers = 
+		$suffixedNumbers =
 		[
 			'1st'  => 1,
 			'2nd'  => 2,
@@ -220,7 +220,7 @@ final class InflectorHelperTest extends \CIUnitTestCase
 			'24th' => 24
 		];
 
-		foreach ($suffixedNumbers as $suffixed => $number) 
+		foreach ($suffixedNumbers as $suffixed => $number)
 		{
 			$ordinalized = ordinalize($number);
 			$this->assertEquals($suffixed, $ordinalized);

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -329,7 +329,7 @@ class URLHelperTest extends \CIUnitTestCase
 
 		$url = current_url(true);
 
-		$this->assertTrue($url instanceof URI);
+		$this->assertInstanceOf(URI::class, $url);
 		$this->assertEquals('http://example.com/public', (string) $url);
 	}
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -82,7 +82,7 @@ class TimeTest extends \CIUnitTestCase
 
 		$obj = $time->toDateTime();
 
-		$this->assertTrue($obj instanceof \DateTime);
+		$this->assertInstanceOf(\DateTime::class, $obj);
 	}
 
 	public function testNow()
@@ -90,7 +90,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::now();
 		$time1 = new \DateTime();
 
-		$this->assertTrue($time instanceof Time);
+		$this->assertInstanceOf(Time::class, $time);
 		$this->assertEquals($time->getTimestamp(), $time1->getTimestamp());
 	}
 
@@ -231,7 +231,7 @@ class TimeTest extends \CIUnitTestCase
 		Time::setTestNow();
 		$this->assertEquals(date('Y-m-d H:i:s', time()), Time::now()->toDateTimeString());
 	}
-	
+
 	//--------------------------------------------------------------------
 
 	public function testGetYear()
@@ -348,7 +348,7 @@ class TimeTest extends \CIUnitTestCase
 	{
 		$instance = Time::now()->getTimezone();
 
-		$this->assertTrue($instance instanceof \DateTimeZone);
+		$this->assertInstanceOf(\DateTimeZone::class, $instance);
 	}
 
 	public function testGetTimezonename()
@@ -362,7 +362,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setYear(2015);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2015-05-10 00:00:00', $time2->toDateTimeString());
 	}
@@ -372,7 +372,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setMonth(4);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-04-10 00:00:00', $time2->toDateTimeString());
 	}
@@ -382,7 +382,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setMonth('April');
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-04-10 00:00:00', $time2->toDateTimeString());
 	}
@@ -392,7 +392,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setMonth('Feb');
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-02-10 00:00:00', $time2->toDateTimeString());
 	}
@@ -402,7 +402,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setDay(15);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-05-15 00:00:00', $time2->toDateTimeString());
 	}
@@ -412,7 +412,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setHour(15);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-05-10 15:00:00', $time2->toDateTimeString());
 	}
@@ -422,7 +422,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setMinute(30);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-05-10 00:30:00', $time2->toDateTimeString());
 	}
@@ -432,7 +432,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017');
 		$time2 = $time->setSecond(20);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-05-10 00:00:20', $time2->toDateTimeString());
 	}
@@ -532,7 +532,7 @@ class TimeTest extends \CIUnitTestCase
 		$time = Time::parse('May 10, 2017', 'America/Chicago');
 		$time2 = $time->setTimezone('Europe/London');
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('America/Chicago', $time->getTimezoneName());
 		$this->assertEquals('Europe/London', $time2->getTimezoneName());
@@ -544,7 +544,7 @@ class TimeTest extends \CIUnitTestCase
 		$stamp = strtotime('April 1, 2017');
 		$time2 = $time->setTimestamp($stamp);
 
-		$this->assertTrue($time2 instanceof Time);
+		$this->assertInstanceOf(Time::class, $time2);
 		$this->assertNotSame($time, $time2);
 		$this->assertEquals('2017-04-01 00:00:00', $time2->toDateTimeString());
 	}

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -8,7 +8,7 @@ class GDHandlerTest extends \CIUnitTestCase
 	{
 		$image = new Image(ROOTPATH.$this->path);
 
-		$this->assertTrue(is_array($image->getProperties(true)));
+		$this->assertInternalType('array', $image->getProperties(true));
 	}
 
 }

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -64,7 +64,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -81,7 +81,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(0, count($logs));
+		$this->assertCount(0, $logs);
 	}
 
 	//--------------------------------------------------------------------
@@ -98,7 +98,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -117,7 +117,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -136,7 +136,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -155,7 +155,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -173,7 +173,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -193,7 +193,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -214,7 +214,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -231,7 +231,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -248,7 +248,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -265,7 +265,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -282,7 +282,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -299,7 +299,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -316,7 +316,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -333,7 +333,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 
@@ -350,7 +350,7 @@ class LoggerTest extends \CIUnitTestCase
 
 		$logs = TestHandler::getLogs();
 
-		$this->assertEquals(1, count($logs));
+		$this->assertCount(1, $logs);
 		$this->assertEquals($expected, $logs[0]);
 	}
 }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -237,7 +237,7 @@ class RouteCollectionTest extends \CIUnitTestCase
 		$routes = $this->getCollector();
 		$routes->setTranslateURIDashes(true);
 
-		$this->assertEquals(true, $routes->shouldTranslateURIDashes());
+		$this->assertTrue($routes->shouldTranslateURIDashes());
 	}
 
 	//--------------------------------------------------------------------
@@ -247,7 +247,7 @@ class RouteCollectionTest extends \CIUnitTestCase
 		$routes = $this->getCollector();
 		$routes->setAutoRoute(true);
 
-		$this->assertEquals(true, $routes->shouldAutoRoute());
+		$this->assertTrue($routes->shouldAutoRoute());
 	}
 
 	//--------------------------------------------------------------------
@@ -772,7 +772,7 @@ class RouteCollectionTest extends \CIUnitTestCase
 
 		$match = $routes->getRoutes();
 
-		$this->assertTrue(array_key_exists('testing', $match));
+		$this->assertArrayHasKey('testing', $match);
 		$this->assertEquals($match['testing'], '\TestController::index');
 	}
 }

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -154,7 +154,7 @@ class RouterTest extends \CIUnitTestCase
 
 		$expects = call_user_func_array($closure, $router->params());
 
-		$this->assertTrue(is_callable($router->controllerName()));
+		$this->assertInternalType('callable', $router->controllerName());
 		$this->assertEquals($expects, '123-alpha');
 	}
 

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -59,7 +59,7 @@ class SessionTest extends \CIUnitTestCase
         $session->start();
 
         $this->assertTrue($session->didRegenerate);
-        $this->assertTrue($_SESSION['__ci_last_regenerate'] > $time+90);
+        $this->assertGreaterThan($time + 90 ,$_SESSION['__ci_last_regenerate']);
     }
 
     public function testCanSetSingleValue()
@@ -84,7 +84,7 @@ class SessionTest extends \CIUnitTestCase
 
         $this->assertEquals('bar', $_SESSION['foo']);
         $this->assertEquals('baz', $_SESSION['bar']);
-        $this->assertFalse(isset($_SESSION['__ci_vars']));
+        $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
     }
 
     public function testGetSimpleKey()
@@ -153,7 +153,7 @@ class SessionTest extends \CIUnitTestCase
         $_SESSION['foo'] = 'bar';
         $session->remove('foo');
 
-        $this->assertFalse(isset($_SESSION['foo']));
+        $this->assertArrayNotHasKey('foo', $_SESSION);
         $this->assertFalse($session->has('foo'));
     }
 
@@ -171,8 +171,8 @@ class SessionTest extends \CIUnitTestCase
 
         $session->remove(['foo', 'bar']);
 
-        $this->assertFalse(isset($_SESSION['foo']));
-        $this->assertFalse(isset($_SESSION['bar']));
+        $this->assertArrayNotHasKey('foo', $_SESSION);
+        $this->assertArrayNotHasKey('bar', $_SESSION);
     }
 
     public function testSetMagicMethod()
@@ -182,7 +182,7 @@ class SessionTest extends \CIUnitTestCase
 
         $session->foo = 'bar';
 
-        $this->assertTrue(isset($_SESSION['foo']));
+        $this->assertArrayHasKey('foo', $_SESSION);
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
@@ -260,7 +260,7 @@ class SessionTest extends \CIUnitTestCase
         $session->set('bar', 'baz');
 
         $this->assertTrue($session->has('foo'));
-        $this->assertTrue(isset($_SESSION['__ci_vars']['foo']));
+        $this->assertArrayHasKey('foo', $_SESSION['__ci_vars']);
 
         $session->unmarkFlashdata('foo');
 
@@ -280,8 +280,8 @@ class SessionTest extends \CIUnitTestCase
 
         $keys = $session->getFlashKeys();
 
-        $this->assertTrue(in_array('foo', $keys));
-        $this->assertFalse(in_array('bar', $keys));
+        $this->assertContains('foo', $keys);
+        $this->assertNotContains('bar', $keys);
     }
 
     public function testSetTempDataWorks()
@@ -290,7 +290,7 @@ class SessionTest extends \CIUnitTestCase
         $session->start();
 
         $session->setTempdata('foo', 'bar', 300);
-        $this->assertTrue((time() + 300) >= $_SESSION['__ci_vars']['foo']);
+        $this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
     }
 
     public function testSetTempDataArrayMultiTTL()
@@ -306,9 +306,9 @@ class SessionTest extends \CIUnitTestCase
             'baz' => 100
         ]);
 
-        $this->assertTrue(($time + 300) <= $_SESSION['__ci_vars']['foo']);
-        $this->assertTrue(($time + 400) <= $_SESSION['__ci_vars']['bar']);
-        $this->assertTrue(($time + 100) <= $_SESSION['__ci_vars']['baz']);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 300);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 400);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
     }
 
     public function testSetTempDataArraySingleTTL()
@@ -320,9 +320,9 @@ class SessionTest extends \CIUnitTestCase
 
         $session->setTempdata(['foo', 'bar', 'baz'], null, 200);
 
-        $this->assertTrue(($time + 200) <= $_SESSION['__ci_vars']['foo']);
-        $this->assertTrue(($time + 200) <= $_SESSION['__ci_vars']['bar']);
-        $this->assertTrue(($time + 200) <= $_SESSION['__ci_vars']['baz']);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 200);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 200);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 200);
     }
 
     /**

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -443,13 +443,13 @@ class ParserTest extends \CIUnitTestCase
 
         $setParsers = $this->getPrivateProperty($parser, 'plugins');
 
-        $this->assertTrue(array_key_exists('first', $setParsers));
+        $this->assertArrayHasKey('first', $setParsers);
 
         $parser->removePlugin('first');
 
         $setParsers = $this->getPrivateProperty($parser, 'plugins');
 
-        $this->assertFalse(array_key_exists('first', $setParsers));
+        $this->assertArrayNotHasKey('first', $setParsers);
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -136,7 +136,7 @@ class ViewTest extends \CIUnitTestCase
 		$view->setVar('testString', 'Hello World');
 		$expected = '<h1>Hello World</h1>';
 
-		$this->assertTrue(strpos($view->render('simple'), $expected) !== false);
+		$this->assertContains($expected, $view->render('simple'));
 	}
 
 	//--------------------------------------------------------------------
@@ -172,7 +172,7 @@ class ViewTest extends \CIUnitTestCase
 		$view->setVar('testString', 'Hello World');
 		$view->render('simple', null,false);
 
-		$this->assertTrue(empty($view->getData()));
+		$this->assertEmpty($view->getData());
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
I've refactored several tests, using:
- `assertCount` instead of `count` function;
- `assertStringStartsWith` instead of `strpos` function;
- `assertContains` instead of `in_array` and `strpos` functions;
- `assertEmpty` instead of `empty` function;
- `assertArrayHasKey`, `assertArrayNotHasKey` instead of `isset` and `array_key_exists` functions;
- `assertObjectHasAttribute` and `assertObjectNotHasAttribute` instead of `isset` function;
- `assertInstanceOf` instead of `instaceof` operator;
- `assertTrue` instead of strict comparison with `true` keyword;
- `assertFalse` instead of strict comparison with `false` keyword;
- `assertNull` instead of comparison with `null` keyword;
- `assertInternalType` instead of `is_*` functions;
- `assertGreaterThan`, `assertGreaterThanOrEqual` and `assertLessThanOrEqual` for mathematical comparisons;
- `assertSame` instead of comparisons `==`.