### PR TITLE
[CS] Remove unused imports

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -41,7 +41,6 @@ use Config\Cache;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Debug\Timer;
 use CodeIgniter\Events\Events;
-use CodeIgniter\Config\DotEnv;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\Router\RouteCollectionInterface;

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -36,7 +36,6 @@
  * @filesource
  */
 use Config\Services;
-use Psr\Log\LoggerAwareTrait;
 
 require __DIR__.'/CustomExceptions.php';
 

--- a/tests/_support/Config/MockLogger.php
+++ b/tests/_support/Config/MockLogger.php
@@ -1,7 +1,5 @@
 <?php namespace Config;
 
-use CodeIgniter\Config\BaseConfig;
-use Psr\Log\LogLevel;
 
 class MockLogger
 {

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\API;
 
-use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Controller;
 use CodeIgniter\Format\JSONFormatter;
 use CodeIgniter\Format\XMLFormatter;

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -1,8 +1,6 @@
 <?php namespace CodeIgniter\Autoloader;
 
 use Config\MockAutoload;
-use PHPUnit\Framework\TestCase;
-use org\bovigo\vfs\vfsStream;
 
 class FileLocatorTest extends \CIUnitTestCase
 {

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter;
 
-use CodeIgniter\HTTP;
 use Config\App;
 
 /**

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\Database;
 
-use CodeIgniter\Database\MockConnection;
 
 class BaseConnectionTest extends \CIUnitTestCase
 {

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -1,6 +1,5 @@
 <?php namespace Builder;
 
-use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\MockConnection;
 
 class AliasTest extends \CIUnitTestCase

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -1,6 +1,5 @@
 <?php namespace Builder;
 
-use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\MockConnection;
 
 class DeleteTest extends \CIUnitTestCase

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -1,6 +1,5 @@
 <?php namespace Builder;
 
-use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Database\MockConnection;
 

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\Database\Builder;
 
-use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\MockConnection;
 
 class PrefixTest extends \CIUnitTestCase

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -1,6 +1,5 @@
 <?php namespace Builder;
 
-use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\MockConnection;
 
 class WhereTest extends \CIUnitTestCase

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Database\BaseResult;
 
 /**
  * @group DatabaseLive

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter;
 
-use CodeIgniter\Entity;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\ReflectionHelper;
 

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\Filters;
 
-use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\Config\Services;
 
 require __DIR__.'/fixtures/InvalidClass.php';

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -3,8 +3,6 @@
 include BASEPATH.'../vendor/autoload.php';
 
 use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamWrapper;
-use org\bovigo\vfs\vfsStreamDirectory;
 
 class FilesystemHelperTest extends \CIUnitTestCase
 {

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\HTTP;
 
-use Config\App;
 
 final class InflectorHelperTest extends \CIUnitTestCase
 {

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -5,7 +5,6 @@ namespace CodeIgniter\Helpers;
 use Config\App;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Config\Services;
-use CodeIgniter\HTTP\MockIncomingRequest;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/Log/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/ChromeLoggerHandlerTest.php
@@ -1,10 +1,6 @@
 <?php namespace CodeIgniter\Log\Handlers;
 
 use Config\MockLogger as LoggerConfig;
-use Psr\Log\LogLevel;
-use CodeIgniter\Log\Handlers\TestHandler;
-use CodeIgniter\Events\Events;
-use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Services;
 
 class ChromeLoggerHandlerTest extends \CIUnitTestCase

--- a/tests/system/Log/FileHandlerTest.php
+++ b/tests/system/Log/FileHandlerTest.php
@@ -1,8 +1,6 @@
 <?php namespace CodeIgniter\Log\Handlers;
 
 use Config\MockLogger as LoggerConfig;
-use Psr\Log\LogLevel;
-use CodeIgniter\Log\Handlers\TestHandler;
 
 class FileHandlerTest extends \CIUnitTestCase
 {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\Router;
 
-use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Autoloader\MockFileLocator;
 
 /**

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1,6 +1,5 @@
 <?php namespace CodeIgniter\Validation;
 
-use Config\Database;
 
 class ValidationTest extends \CIUnitTestCase
 {


### PR DESCRIPTION
I've cleaned up some unused imports :put_litter_in_its_place: 

[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me find them.