### PR TITLE
Test to make sure ENVIRONMENT isn't set by other means before attempting to set it.

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -301,14 +301,18 @@ class CodeIgniter
 	 */
 	protected function detectEnvironment()
 	{
-		// running under Continuous Integration server?
-		if (getenv('CI') !== false)
+		// Make sure ENVIRONMENT isn't already set by other means.
+		if (! defined('ENVIRONMENT'))
 		{
-			define('ENVIRONMENT', 'testing');
-		}
-		else
-		{
-			define('ENVIRONMENT', $_SERVER['CI_ENVIRONMENT'] ?? 'production');
+			// running under Continuous Integration server?
+			if (getenv('CI') !== false)
+			{
+				define('ENVIRONMENT', 'testing');
+			}
+			else
+			{
+				define('ENVIRONMENT', $_SERVER['CI_ENVIRONMENT'] ?? 'production');
+			}
 		}
 	}
 


### PR DESCRIPTION
I was migrating for a project from CI-3 to CI-4, but I wanted to be able to switch back and forth. Ran into this method when trying to re-use the server vhost settings, which is what I'll end up doing when the project goes into production later. Thankfully that's a long way off, but yeah, I added code to the index.php that broke your app by using the CI_ENV variable as in older CodeIgniter versions. I figure other people might use other schemas, this allows you to override it without breaking the app.

It is my hope that this will free people up, especially those migrating from other platforms or earlier versions, to utilize their own internal way of determining the application environment, without breaking the way the app does it by default.