### PR TITLE
Escape Forge createTable() attributes

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -528,7 +528,7 @@ class Forge
 		{
 			if (is_string($key))
 			{
-				$sql .= ' ' . strtoupper($key) . ' ' . $attributes[$key];
+				$sql .= ' ' . strtoupper($key) . ' ' . $this->db->escape($attributes[$key]);
 			}
 		}
 

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -55,7 +55,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @var    string
 	 */
 	protected $dropConstraintStr = 'ALTER TABLE %s DROP FOREIGN KEY %s';
-        
+
 	/**
 	 * CREATE TABLE keys flag
 	 *
@@ -109,18 +109,18 @@ class Forge extends \CodeIgniter\Database\Forge
 		{
 			if (is_string($key))
 			{
-				$sql .= ' ' . strtoupper($key) . ' = ' . $attributes[$key];
+				$sql .= ' ' . strtoupper($key) . ' = ' . $this->db->escape($attributes[$key]);
 			}
 		}
 
 		if ( ! empty($this->db->charset) && ! strpos($sql, 'CHARACTER SET') && ! strpos($sql, 'CHARSET'))
 		{
-			$sql .= ' DEFAULT CHARACTER SET = ' . $this->db->charset;
+			$sql .= ' DEFAULT CHARACTER SET = ' . $this->db->escape($this->db->charset);
 		}
 
 		if ( ! empty($this->db->DBCollat) && ! strpos($sql, 'COLLATE'))
 		{
-			$sql .= ' COLLATE = ' . $this->db->DBCollat;
+			$sql .= ' COLLATE = ' . $this->db->escape($this->db->DBCollat);
 		}
 
 		return $sql;

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -77,6 +77,19 @@ class Forge extends \CodeIgniter\Database\Forge
 	//--------------------------------------------------------------------
 
 	/**
+	 * CREATE TABLE attributes
+	 *
+	 * @param	array	$attributes	Associative array of table attributes
+	 * @return	string
+	 */
+	protected function _createTableAttributes($attributes)
+	{
+		return '';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * ALTER TABLE
 	 *
 	 * @param    string $alter_type ALTER type

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -37,6 +37,24 @@ class ForgeTest extends \CIDatabaseTestCase
 		$this->assertTrue($exist);
 	}
 
+	public function testCreateTableWithAttributes()
+	{
+		$this->forge->dropTable('forge_test_attributes', true);
+
+		$this->forge->addField('id');
+
+		$attributes = [
+			'comment' => "Forge's Test"
+		];
+
+		$this->forge->createTable('forge_test_attributes', false, $attributes);
+
+		$exist = $this->db->tableExists('forge_test_attributes');
+		$this->forge->dropTable('forge_test_attributes', true, true);
+
+		$this->assertTrue($exist);
+	}
+
 	public function testAddFields()
 	{
 


### PR DESCRIPTION
Table comment could not be set like it:

```php
$this->forge->createTable('forge_test_table', false, ['COMMENT' => "Forge's Test"]);
```