### PR TITLE
Avoid json encode-decode if format is application/json

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -358,8 +358,12 @@ trait ResponseTrait
 			$this->formatter = $config->getFormatter($format);
 		}
 
-		// Recursively convert objects into associative arrays
-		$data = json_decode(json_encode($data), true);
+		if ($format !== 'application/json')
+		{
+			// Recursively convert objects into associative arrays
+			// Conversion not required for JSONFormatter
+			$data = json_decode(json_encode($data), true);
+		}
 
 		return $this->formatter->format($data);
 	}


### PR DESCRIPTION
Since [JSONFormatter](https://github.com/bcit-ci/CodeIgniter4/blob/6d659bb12a2af0182e6837c1f5bc781ac4481f78/system/Format/JSONFormatter.php#L54) uses the `json_encode()` it seems like it's not enough to do this twice.