### PR TITLE
Fix number_helper functions localization

### DIFF
--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -58,29 +58,36 @@ if ( ! function_exists('number_to_size'))
 			return false;
 		}
 
+		// ignore sub part
+		$genralLocale = $locale;
+		if( ! empty($locale) && ( $underscorePos = strpos( $locale, '_' )))
+		{
+			$genralLocale = substr( $locale, 0, $underscorePos );
+		}
+
 		if ($num >= 1000000000000)
 		{
 			$num = round($num / 1099511627776, $precision);
-			$unit = lang('Number.terabyteAbbr');
+			$unit = lang('Number.terabyteAbbr', [], $genralLocale);
 		}
 		elseif ($num >= 1000000000)
 		{
 			$num = round($num / 1073741824, $precision);
-			$unit = lang('Number.gigabyteAbbr');
+			$unit = lang('Number.gigabyteAbbr', [], $genralLocale);
 		}
 		elseif ($num >= 1000000)
 		{
 			$num = round($num / 1048576, $precision);
-			$unit = lang('Number.megabyteAbbr');
+			$unit = lang('Number.megabyteAbbr', [], $genralLocale);
 		}
 		elseif ($num >= 1000)
 		{
 			$num = round($num / 1024, $precision);
-			$unit = lang('Number.kilobyteAbbr');
+			$unit = lang('Number.kilobyteAbbr', [], $genralLocale);
 		}
 		else
 		{
-			$unit = lang('Number.bytes');
+			$unit = lang('Number.bytes', [], $genralLocale);
 		}
 
 		return format_number($num, $precision, $locale, ['after' => ' ' . $unit]);
@@ -123,29 +130,36 @@ if ( ! function_exists('number_to_amount'))
 
 		$suffix = '';
 
+		// ignore sub part
+		$genralLocale = $locale;
+		if( ! empty($locale) && ( $underscorePos = strpos( $locale, '_' )))
+		{
+			$genralLocale = substr( $locale, 0, $underscorePos );
+		}
+
 		if ($num > 1000000000000000)
 		{
-			$suffix = lang('Number.quadrillion');
+			$suffix = lang('Number.quadrillion', [], $genralLocale);
 			$num = round(($num / 1000000000000000), $precision);
 		}
 		elseif ($num > 1000000000000)
 		{
-			$suffix = lang('Number.trillion');
+			$suffix = lang('Number.trillion', [], $genralLocale);
 			$num = round(($num / 1000000000000), $precision);
 		}
 		else if ($num > 1000000000)
 		{
-			$suffix = lang('Number.billion');
+			$suffix = lang('Number.billion', [], $genralLocale);
 			$num = round(($num / 1000000000), $precision);
 		}
 		else if ($num > 1000000)
 		{
-			$suffix = lang('Number.million');
+			$suffix = lang('Number.million', [], $genralLocale);
 			$num = round(($num / 1000000), $precision);
 		}
 		else if ($num > 1000)
 		{
-			$suffix = lang('Number.thousand');
+			$suffix = lang('Number.thousand', [], $genralLocale);
 			$num = round(($num / 1000), $precision);
 		}
 

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -31,37 +31,37 @@ class numberHelperTest extends \CIUnitTestCase
 
     public function test_number_to_size()
     {
-        $this->assertEquals('456 Bytes', number_to_size(456));
+        $this->assertEquals('456 Bytes', number_to_size(456, 1, 'en_US'));
     }
 
     public function test_kb_format()
     {
-        $this->assertEquals('4.5 KB', number_to_size(4567));
+        $this->assertEquals('4.5 KB', number_to_size(4567, 1, 'en_US'));
     }
 
     public function test_kb_format_medium()
     {
-        $this->assertEquals('44.6 KB', number_to_size(45678));
+        $this->assertEquals('44.6 KB', number_to_size(45678, 1, 'en_US'));
     }
 
     public function test_kb_format_large()
     {
-        $this->assertEquals('446.1 KB', number_to_size(456789));
+        $this->assertEquals('446.1 KB', number_to_size(456789, 1, 'en_US'));
     }
 
     public function test_mb_format()
     {
-        $this->assertEquals('3.3 MB', number_to_size(3456789));
+        $this->assertEquals('3.3 MB', number_to_size(3456789, 1, 'en_US'));
     }
 
     public function test_gb_format()
     {
-        $this->assertEquals('1.8 GB', number_to_size(1932735283.2));
+        $this->assertEquals('1.8 GB', number_to_size(1932735283.2, 1, 'en_US'));
     }
 
     public function test_tb_format()
     {
-        $this->assertEquals('112,283.3 TB', number_to_size(123456789123456789));
+        $this->assertEquals('112,283.3 TB', number_to_size(123456789123456789, 1, 'en_US'));
     }
 
     public function test_thousands()


### PR DESCRIPTION
Use locale in number helper functions for text localization ( ignore sub part )
Set NumberHelperTest to use 'en'
