### PR TITLE
Forward localization TimeDifference::humanize & fix Time tests

### DIFF
--- a/system/I18n/TimeDifference.php
+++ b/system/I18n/TimeDifference.php
@@ -205,7 +205,7 @@ class TimeDifference
 		return $time->fieldDifference($this->testTime, \IntlCalendar::FIELD_SECOND);
 	}
 
-	public function humanize(): string
+	public function humanize( string $locale = null ): string
 	{
 		$current = clone($this->currentTime);
 
@@ -219,43 +219,43 @@ class TimeDifference
 
 		if ($years !== 0)
 		{
-			$phrase = lang('Time.years', [abs($years)]);
+			$phrase = lang('Time.years', [abs($years)], $locale);
 			$before = $years < 0;
 		}
 		else if ($months !== 0)
 		{
-			$phrase = lang('Time.months', [abs($months)]);
+			$phrase = lang('Time.months', [abs($months)], $locale);
 			$before = $months < 0;
 		}
 		else if ($days !== 0 && (abs($days) >= 7))
 		{
 			$weeks = ceil($days / 7);
-			$phrase = lang('Time.weeks', [abs($weeks)]);
+			$phrase = lang('Time.weeks', [abs($weeks)], $locale);
 			$before = $days < 0;
 		}
 		else if ($days !== 0)
 		{
-			$phrase = lang('Time.days', [abs($days)]);
+			$phrase = lang('Time.days', [abs($days)], $locale);
 			$before = $days < 0;
 		}
 		else if ($hours !== 0)
 		{
-			$phrase = lang('Time.hours', [abs($hours)]);
+			$phrase = lang('Time.hours', [abs($hours)], $locale);
 			$before = $hours < 0;
 		}
 		else if ($minutes !== 0)
 		{
-			$phrase = lang('Time.minutes', [abs($minutes)]);
+			$phrase = lang('Time.minutes', [abs($minutes)], $locale);
 			$before = $minutes < 0;
 		}
 		else
 		{
-			return lang('Time.now');
+			return lang('Time.now', [], $locale);
 		}
 
 		return $before
-			? lang('Time.ago', [$phrase])
-			: lang('Time.inFuture', [$phrase]);
+			? lang('Time.ago', [$phrase], $locale)
+			: lang('Time.inFuture', [$phrase], $locale);
 	}
 
 	/**

--- a/system/Language/en/Time.php
+++ b/system/Language/en/Time.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-	'invalidMonth' => 'Hours must be between 0 and 12.',
+	'invalidMonth' => 'Months must be between 0 and 12.',
 	'invalidDay' => 'Days must be between 0 and 31.',
 	'invalidHours' => 'Hours must be between 0 and 23.',
 	'invalidMinutes' => 'Minutes must be between 0 and 59.',

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -42,7 +42,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 
 		$diff = $current->difference('March 9, 2016 12:00:00', 'America/Chicago');
 
-		$this->assertEquals('1 year ago', $diff->humanize());
+		$this->assertEquals('1 year ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeYearsPlural()
@@ -50,7 +50,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('March 9, 2014 12:00:00', 'America/Chicago');
 
-		$this->assertEquals('3 years ago', $diff->humanize());
+		$this->assertEquals('3 years ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeYearsForward()
@@ -58,7 +58,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('January 1, 2017', 'America/Chicago');
 		$diff = $current->difference('January 1, 2018 12:00:00', 'America/Chicago');
 
-		$this->assertEquals('in 1 year', $diff->humanize());
+		$this->assertEquals('in 1 year', $diff->humanize('en'));
 	}
 
 	public function testHumanizeMonthsSingle()
@@ -66,7 +66,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('February 9, 2017', 'America/Chicago');
 
-		$this->assertEquals('1 month ago', $diff->humanize());
+		$this->assertEquals('1 month ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeMonthsPlural()
@@ -74,7 +74,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 1, 2017', 'America/Chicago');
 		$diff = $current->difference('January 1, 2017', 'America/Chicago');
 
-		$this->assertEquals('2 months ago', $diff->humanize());
+		$this->assertEquals('2 months ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeMonthsForward()
@@ -82,7 +82,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 1, 2017', 'America/Chicago');
 		$diff = $current->difference('May 1, 2017', 'America/Chicago');
 
-		$this->assertEquals('in 1 month', $diff->humanize());
+		$this->assertEquals('in 1 month', $diff->humanize('en'));
 	}
 
 	public function testHumanizeDaysSingle()
@@ -90,7 +90,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('March 9, 2017', 'America/Chicago');
 
-		$this->assertEquals('1 day ago', $diff->humanize());
+		$this->assertEquals('1 day ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeDaysPlural()
@@ -98,7 +98,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('March 8, 2017', 'America/Chicago');
 
-		$this->assertEquals('2 days ago', $diff->humanize());
+		$this->assertEquals('2 days ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeDaysForward()
@@ -106,7 +106,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('March 11, 2017', 'America/Chicago');
 
-		$this->assertEquals('in 1 day', $diff->humanize());
+		$this->assertEquals('in 1 day', $diff->humanize('en'));
 	}
 
 	public function testHumanizeHoursSingle()
@@ -114,7 +114,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017 12:00', 'America/Chicago');
 		$diff = $current->difference('March 10, 2017 11:00', 'America/Chicago');
 
-		$this->assertEquals('1 hour ago', $diff->humanize());
+		$this->assertEquals('1 hour ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeHoursPlural()
@@ -122,7 +122,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017 12:00', 'America/Chicago');
 		$diff = $current->difference('March 10, 2017 10:00', 'America/Chicago');
 
-		$this->assertEquals('2 hours ago', $diff->humanize());
+		$this->assertEquals('2 hours ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeHoursForward()
@@ -130,7 +130,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017 12:00', 'America/Chicago');
 		$diff = $current->difference('March 10, 2017 13:00', 'America/Chicago');
 
-		$this->assertEquals('in 1 hour', $diff->humanize());
+		$this->assertEquals('in 1 hour', $diff->humanize('en'));
 	}
 
 	public function testHumanizeMinutesSingle()
@@ -138,7 +138,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017 12:30', 'America/Chicago');
 		$diff = $current->difference('March 10, 2017 12:29', 'America/Chicago');
 
-		$this->assertEquals('1 minute ago', $diff->humanize());
+		$this->assertEquals('1 minute ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeMinutesPlural()
@@ -146,7 +146,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017 12:30', 'America/Chicago');
 		$diff = $current->difference('March 10, 2017 12:28', 'America/Chicago');
 
-		$this->assertEquals('2 minutes ago', $diff->humanize());
+		$this->assertEquals('2 minutes ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeMinutesForward()
@@ -154,7 +154,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017 12:30', 'America/Chicago');
 		$diff = $current->difference('March 10, 2017 12:31', 'America/Chicago');
 
-		$this->assertEquals('in 1 minute', $diff->humanize());
+		$this->assertEquals('in 1 minute', $diff->humanize('en'));
 	}
 
 	public function testHumanizeWeeksSingle()
@@ -162,7 +162,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('March 2, 2017', 'America/Chicago');
 
-		$this->assertEquals('1 week ago', $diff->humanize());
+		$this->assertEquals('1 week ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeWeeksPlural()
@@ -170,7 +170,7 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 30, 2017', 'America/Chicago');
 		$diff = $current->difference('March 15, 2017', 'America/Chicago');
 
-		$this->assertEquals('2 weeks ago', $diff->humanize());
+		$this->assertEquals('2 weeks ago', $diff->humanize('en'));
 	}
 
 	public function testHumanizeWeeksForward()
@@ -178,6 +178,6 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$current = Time::parse('March 10, 2017', 'America/Chicago');
 		$diff = $current->difference('March 18, 2017', 'America/Chicago');
 
-		$this->assertEquals('in 1 week', $diff->humanize());
+		$this->assertEquals('in 1 week', $diff->humanize('en'));
 	}
 }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -14,7 +14,7 @@ class TimeTest extends \CIUnitTestCase
 
 	public function testNewTimeNow()
 	{
-		$time = new Time();
+		$time = new Time(null, 'America/Chicago');
 
 		$formatter = new IntlDateFormatter(
 			'en_US',
@@ -97,7 +97,7 @@ class TimeTest extends \CIUnitTestCase
 	public function testParse()
 	{
 		$time = Time::parse('next Tuesday', 'America/Chicago');
-		$time1 = new \DateTime();
+		$time1 = new \DateTime('now', new \DateTimeZone('America/Chicago'));
 		$time1->modify('next Tuesday');
 
 		$this->assertEquals($time->getTimestamp(), $time1->getTimestamp());


### PR DESCRIPTION
use localization in humanize
set some missing TimeZones in TimeTest.php
fix Time localization file ( correct invalidmonth string )
  