### PR TITLE
Use separated test configs for redis & memcached

### DIFF
--- a/application/Config/Cache.php
+++ b/application/Config/Cache.php
@@ -86,6 +86,20 @@ class Cache extends BaseConfig
 
 	/*
 	| -------------------------------------------------------------------------
+	| Memcached test settings
+	| -------------------------------------------------------------------------
+	| This Memcahed server configuration is used when running PHPUnit tests
+	|
+	*/
+	public $testMemcached = [
+		'host'	 => '127.0.0.1',
+		'port'	 => 11211,
+		'weight' => 1,
+		'raw'	 => false,
+	];
+
+	/*
+	| -------------------------------------------------------------------------
 	| Redis settings
 	| -------------------------------------------------------------------------
 	| Your Redis server can be specified below, if you are using
@@ -93,6 +107,20 @@ class Cache extends BaseConfig
 	|
 	*/
 	public $redis = [
+		'host'     => '127.0.0.1',
+		'password' => null,
+		'port'     => 6379,
+		'timeout'  => 0,
+	];
+
+	/*
+	| -------------------------------------------------------------------------
+	| Redis test settings
+	| -------------------------------------------------------------------------
+	| This Redis server configuration is used when running PHPUnit tests
+	|
+	*/
+	public $testRedis = [
 		'host'     => '127.0.0.1',
 		'password' => null,
 		'port'     => 6379,

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -20,7 +20,7 @@ class MemcachedHandlerTest extends \CIUnitTestCase
 	{
 		$this->config = new \Config\Cache();
 
-		$this->memcachedHandler = new MemcachedHandler($this->config->memcached);
+		$this->memcachedHandler = new MemcachedHandler($this->config->testMemcached);
 		if (!$this->memcachedHandler->isSupported()) {
 			$this->markTestSkipped('Not support memcached and memcache');
 		}
@@ -71,8 +71,8 @@ class MemcachedHandlerTest extends \CIUnitTestCase
 		$this->assertFalse($this->memcachedHandler->increment(self::$key1, 10));
 
 		$config = new \Config\Cache();
-		$config->memcached['raw'] = true;
-		$memcachedHandler = new MemcachedHandler($config->memcached);
+		$config->testMemcached['raw'] = true;
+		$memcachedHandler = new MemcachedHandler($config->testMemcached);
 		$memcachedHandler->initialize();
 
 		$memcachedHandler->save(self::$key1, 1);
@@ -90,8 +90,8 @@ class MemcachedHandlerTest extends \CIUnitTestCase
 		$this->assertFalse($this->memcachedHandler->decrement(self::$key1, 1));
 
 		$config = new \Config\Cache();
-		$config->memcached['raw'] = true;
-		$memcachedHandler = new MemcachedHandler($config->memcached);
+		$config->testMemcached['raw'] = true;
+		$memcachedHandler = new MemcachedHandler($config->testMemcached);
 		$memcachedHandler->initialize();
 
 		$memcachedHandler->save(self::$key1, 10);

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -55,7 +55,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 	{
 		$this->config = new \Config\Cache();
 
-		$this->redisHandler = new RedisHandler($this->config->redis);
+		$this->redisHandler = new RedisHandler($this->config->testRedis);
 		if (!$this->redisHandler->isSupported()) {
 			$this->markTestSkipped('Not support redis');
 		}
@@ -77,7 +77,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 
 	public function testDestruct()
 	{
-		$this->redisHandler = new RedisHandler($this->config->redis);
+		$this->redisHandler = new RedisHandler($this->config->testRedis);
 		$this->redisHandler->initialize();
 
 		$this->assertInstanceOf(RedisHandler::class, $this->redisHandler);


### PR DESCRIPTION
use separated configs for testing