### PR TITLE
Update to “Controller Filters ”

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -244,7 +244,7 @@ class Filters
 					$path = trim(str_replace('*', '.+', $path), '/ ');
 
 					// Path doesn't match the URI? continue on...
-					if (preg_match('/' . $path . '/', $uri, $match) !== 1)
+					if (preg_match('#' . $path . '#', $uri, $match) !== 1)
 					{
 						continue;
 					}
@@ -282,7 +282,7 @@ class Filters
 					$path = trim(str_replace('*', '.+', $path), '/ ');
 
 					// Path doesn't match the URI? continue on...
-					if (preg_match('/' . $path . '/', $uri, $match) !== 1)
+					if (preg_match('#' . $path . '#', $uri, $match) !== 1)
 					{
 						continue;
 					}
@@ -339,7 +339,7 @@ class Filters
 					$path = str_replace('/*', '*', $path);
 					$path = trim(str_replace('*', '.+', $path), '/ ');
 
-					if (preg_match('/' . $path . '/', $uri) !== 1)
+					if (preg_match('#' . $path . '#', $uri) !== 1)
 					{
 						continue;
 					}
@@ -360,7 +360,7 @@ class Filters
 					$path = str_replace('/*', '*', $path);
 					$path = trim(str_replace('*', '.+', $path), '/ ');
 
-					if (preg_match('/' . $path . '/', $uri) !== 1)
+					if (preg_match('#' . $path . '#', $uri) !== 1)
 					{
 						continue;
 					}


### PR DESCRIPTION
URI multi-level directory will be prompted wrong.
err mes : preg_match(): Unknown modifier 'r'

show demo:
application/Config/Filters.php
`public filters = [
    'foo' => ['before' => ['admin/foo/*']],
    'bar' => ['before' => ['admin/bar/*']]
];`

 If the delimiter appears often inside the pattern, it is a good idea to choose another delimiter in order to increase readability.
http://php.net/manual/en/regexp.reference.delimiters.php