### PR TITLE
Enable to get all custom options set for the matched route

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -144,6 +144,13 @@ class RouteCollection implements RouteCollectionInterface
 	];
 
 	/**
+	 * Array of routes options
+	 *
+	 * @var array
+	 */
+	protected $routesOptions = [];
+
+	/**
 	 * The current method that the script is being called by.
 	 *
 	 * @var
@@ -536,6 +543,20 @@ class RouteCollection implements RouteCollectionInterface
 		}
 
 		return $routes;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns one or all routes options
+	 *
+	 * @param  string $from
+	 *
+	 * @return array
+	 */
+	public function getRoutesOptions(string $from = null)
+	{
+		return $from ? $this->routesOptions[$from] ?? [] : $this->routesOptions;
 	}
 
 	//--------------------------------------------------------------------
@@ -1207,6 +1228,8 @@ class RouteCollection implements RouteCollectionInterface
 		{
 			$to = '\\' . ltrim($to, '\\');
 		}
+
+		$this->routesOptions[$from] = $options;
 
 		$name = $options['as'] ?? $from;
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -110,6 +110,13 @@ class Router implements RouterInterface
 	protected $matchedRoute = null;
 
 	/**
+	 * The options set for the matched route.
+	 *
+	 * @var array|null
+	 */
+	protected $matchedRouteOptions = null;
+
+	/**
 	 * The locale that was detected in a route.
 	 * @var string
 	 */
@@ -267,6 +274,18 @@ class Router implements RouterInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns all options set for the matched route
+	 *
+	 * @return array|null
+	 */
+	public function getMatchedRouteOptions()
+	{
+		return $this->matchedRouteOptions;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Sets the value that should be used to match the index.php file. Defaults
 	 * to index.php but this allows you to modify it in case your are using
 	 * something like mod_rewrite to remove the page. This allows you to set
@@ -387,6 +406,8 @@ class Router implements RouterInterface
 
 					$this->matchedRoute = [$key, $val];
 
+					$this->matchedRouteOptions = $this->collection->getRoutesOptions($key);
+
 					return true;
 				}
 				// Are we using the default method for back-references?
@@ -417,6 +438,8 @@ class Router implements RouterInterface
 				$this->setRequest(explode('/', $val));
 
 				$this->matchedRoute = [$key, $val];
+
+				$this->matchedRouteOptions = $this->collection->getRoutesOptions($key);
 
 				return true;
 			}

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -774,4 +774,17 @@ class RouteCollectionTest extends \CIUnitTestCase
 		$this->assertArrayHasKey('testing', $match);
 		$this->assertEquals($match['testing'], '\TestController::index');
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testRoutesOptions()
+	{
+		$routes = $this->getCollector();
+
+		$routes->add('administrator', function() {}, ['as' => 'admin', 'foo' => 'baz']);
+
+		$options = $routes->getRoutesOptions('administrator');
+
+		$this->assertEquals($options, ['as' => 'admin', 'foo' => 'baz']);
+	}
 }

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -236,4 +236,15 @@ class RouterTest extends \CIUnitTestCase
 
     //--------------------------------------------------------------------
 
+    public function testMatchedRouteOptions()
+    {
+    	$this->collection->add('foo', function() {}, ['as' => 'login', 'foo' => 'baz']);
+    	$this->collection->add('baz', function() {}, ['as' => 'admin', 'foo' => 'bar']);
+
+    	$router = new Router($this->collection);
+
+    	$router->handle('foo');
+
+    	$this->assertEquals($router->getMatchedRouteOptions(), ['as' => 'login', 'foo' => 'baz']);
+    }
 }


### PR DESCRIPTION
See: https://forum.codeigniter.com/thread-69894.html

URI: *admin/customers/groups*

```php
// Route
$routes->get('admin/customers/groups', 'Groups::index', [
   'namespace'           => 'App\Controllers\Admin\Customers',
   'as'                  => 'route_name_123',
   'important-setting'   => 'x',
   'important-setting-2' => 'y',
]);
```

```php
// Some place
var_dump(Services::router()->getMatchedRouteOptions());
```

```
APPPATH/Filters/ACL.php:21:
array (size=4)
  'namespace' => string 'App\Controllers\Admin\Customers' (length=31)
  'as' => string 'route_name_123' (length=14)
  'important-setting' => string 'x' (length=1)
  'important-setting-2' => string 'y' (length=1)
```