### PR TITLE
remove string type hint for RouteCollection::addPlaceholder() for $placeholder parameter

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -232,7 +232,7 @@ class RouteCollection implements RouteCollectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function addPlaceholder(string $placeholder, string $pattern = null): RouteCollectionInterface
+	public function addPlaceholder($placeholder, string $pattern = null): RouteCollectionInterface
 	{
 		if ( ! is_array($placeholder))
 		{

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -76,7 +76,7 @@ interface RouteCollectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function addPlaceholder(string $placeholder, string $pattern = null);
+	public function addPlaceholder($placeholder, string $pattern = null);
 
 	//--------------------------------------------------------------------
 


### PR DESCRIPTION
as there is `is_array()` check in body function which means allow both string and array.