### PR TITLE
complement the missing HTTP status codes

### DIFF
--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -60,6 +60,8 @@ interface ResponseInterface
 	// Informational
 	const HTTP_CONTINUE = 100;
 	const HTTP_SWITCHING_PROTOCOLS = 101;
+	const HTTP_PROCESSING = 102;
+	const HTTP_EARLY_HINTS = 103;
 	// Success
 	const HTTP_OK = 200;
 	const HTTP_CREATED = 201;


### PR DESCRIPTION
According to [Hypertext Transfer Protocol (HTTP) Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml),complement the missing HTTP status codes