### PR TITLE
Auto escape old input data

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -716,12 +716,13 @@ if (! function_exists('old'))
 	 * Provides access to "old input" that was set in the session
 	 * during a redirect()->withInput().
 	 *
-	 * @param string $key
-	 * @param null   $default
+	 * @param string       $key
+	 * @param null         $default
+	 * @param string|bool  $escape
 	 *
 	 * @return mixed|null
 	 */
-	function old(string $key, $default=null)
+	function old(string $key, $default = null, $escape = 'html')
 	{
 		$request = Services::request();
 
@@ -740,7 +741,7 @@ if (! function_exists('old'))
 			$value = unserialize($value);
 		}
 
-		return esc($value);
+		return $escape === false ? $value : esc($value, $escape);
 	}
 }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -740,7 +740,7 @@ if (! function_exists('old'))
 			$value = unserialize($value);
 		}
 
-		return $value;
+		return esc($value);
 	}
 }
 

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -78,10 +78,11 @@ Service Accessors
 
 	For more information, see the :doc:`Localization </libraries/localization>` page.
 
-.. php:function:: old( $key[, $default] )
+.. php:function:: old( $key[, $default = null, [, $escape = 'html' ]] )
 
 	:param string $key: The name of the old form data to check for.
 	:param mixed  $default: The default value to return if $key doesn't exist.
+	:param mixed  $escape: An `escape <#esc>`_ context or false to disable it.
 	:returns: The value of the defined key, or the default value.
 	:rtype: mixed
 
@@ -100,7 +101,7 @@ Service Accessors
 		// In the view
 		<input type="email" name="email" value="<?= old('email') ?>">
 
-	.. :note:: If you are using the form helper, this feature is built-in. You only
+.. note:: If you are using the :doc:`form helper </helpers/form_helper>`, this feature is built-in. You only
 		need to use this function when not using the form helper.
 
 .. php:function:: session( [$key] )


### PR DESCRIPTION
Prevents XSS. 

Otherwise, if the developer must use `esc(old('field_name'))` I think we need to [update the docs about this function](https://bcit-ci.github.io/CodeIgniter4/general/common_functions.html#old).