### PR TITLE
Enables Pager to use only pre-set queries

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -72,6 +72,13 @@ class Pager implements PagerInterface
 	 */
 	protected $view;
 
+	/**
+	 * List of only permitted queries
+	 *
+	 * @var array
+	 */
+	protected $only = [];
+
 	//--------------------------------------------------------------------
 
 	public function __construct($config, RendererInterface $view)
@@ -295,11 +302,11 @@ class Pager implements PagerInterface
 	/**
 	 * Returns the URI for a specific page for the specified group.
 	 *
-	 * @param int    $page
-	 * @param string $group
-	 * @param bool   $returnObject
+	 * @param int|null $page
+	 * @param string   $group
+	 * @param bool     $returnObject
 	 *
-	 * @return string
+	 * @return string|\CodeIgniter\HTTP\URI
 	 */
 	public function getPageURI(int $page = null, string $group = 'default', $returnObject = false)
 	{
@@ -307,7 +314,18 @@ class Pager implements PagerInterface
 
 		$uri = $this->groups[$group]['uri'];
 
-		$uri->addQuery('page', $page);
+		if ($this->only)
+		{
+			$query = array_intersect_key($_GET, array_flip($this->only));
+
+			$query['page'] = $page;
+
+			$uri->setQueryArray($query);
+		}
+		else
+		{
+			$uri->addQuery('page', $page);
+		}
 
 		return $returnObject === true ? $uri : (string) $uri;
 	}
@@ -415,6 +433,22 @@ class Pager implements PagerInterface
 		$newGroup['previous'] = $this->getPreviousPageURI($group);
 
 		return $newGroup;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Sets only allowed queries on pagination links.
+	 *
+	 * @param array $queries
+	 *
+	 * @return Pager
+	 */
+	public function only(array $queries):Pager
+	{
+		$this->only = $queries;
+
+		return $this;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -268,7 +268,7 @@ class PagerTest extends \CIUnitTestCase
 
 		$this->assertEquals((string)$expected, $this->pager->getNextPageURI('foo'));
 	}
- 
+
 	//--------------------------------------------------------------------
 
 	public function testGetPreviousURIWithQueryStringUsesCurrentURI()
@@ -283,6 +283,37 @@ class PagerTest extends \CIUnitTestCase
 		$this->pager->store('foo', $_GET['page']+1, 12, 70);
 
 		$this->assertEquals((string)$expected, $this->pager->getPreviousPageURI('foo'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testGetOnlyQueries()
+	{
+		$_GET = [
+			'page'     => 2,
+			'search'   => 'foo',
+			'order'    => 'asc',
+			'hello'    => 'xxx',
+			'category' => 'baz',
+		];
+		$onlyQueries = ['search', 'order'];
+
+		$this->pager->store('default', $_GET['page'], 10, 100);
+
+		$uri = current_url(true);
+
+		$this->assertEquals(
+			$this->pager->only($onlyQueries)->getPreviousPageURI(),
+			(string)$uri->setQuery('search=foo&order=asc&page=1')
+		);
+		$this->assertEquals(
+			$this->pager->only($onlyQueries)->getNextPageURI(),
+			(string)$uri->setQuery('search=foo&order=asc&page=3')
+		);
+		$this->assertEquals(
+			$this->pager->only($onlyQueries)->getPageURI(4),
+			(string)$uri->setQuery('search=foo&order=asc&page=4')
+		);
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -103,6 +103,23 @@ sections.
 
     <?= $pager->makeLinks($page, $perPage, $total, 'template_name') ?>
 
+Paginating with Only Expected Queries
+=====================================
+
+By default all GET queries are shown in the pagination links.
+
+For example, when accessing the URL *http://domain.tld?search=foo&order=asc&hello=i+am+here&page=2*, the page 3 link can be generated, along with the other links, as follows::
+
+    echo $pager->links();
+    // Page 3 link: http://domain.tld?search=foo&order=asc&hello=i+am+here&page=3
+
+The ``only()`` method allows you to limit this just to queries already expected::
+
+    echo $pager->only(['search', 'order'])->links();
+    // Page 3 link: http://domain.tld?search=foo&order=asc&page=3
+
+The *page* query is enabled by default. And ``only()`` acts in all pagination links.
+
 *********************
 Customizing the Links
 *********************


### PR DESCRIPTION
This prevent the insertion of unexpected queries into pagination links.

Usage:

**URI**: _/?search=foo&order=asc&hello=i+am+here&helloAgain=i+am+here+too_

```php
echo $pager->links();
// Page 2 link: /?search=foo&order=asc&hello=i%2Bam%2Bhere&helloAgain=i%2Bam%2Bhere%2Btoo&page=2

echo $pager->only(['search', 'order'])->links();
// Page 2 link: /?search=foo&order=asc&page=2
```

The `page` query is enabled by default.
