### PR TITLE
Respond Error Pages by Accept Header - Closes #863

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -220,16 +220,18 @@ class Services
 	 *  - set_error_handler
 	 *  - register_shutdown_function
 	 *
-	 * @param \Config\Exceptions $config
-	 * @param bool               $getShared
+	 * @param \Config\Exceptions                $config
+	 * @param \CodeIgniter\HTTP\IncomingRequest $request
+	 * @param \CodeIgniter\HTTP\Response        $response
+	 * @param bool                              $getShared
 	 *
 	 * @return \CodeIgniter\Debug\Exceptions
 	 */
-	public static function exceptions(\Config\Exceptions $config = null, $getShared = true)
+	public static function exceptions(\Config\Exceptions $config = null, \CodeIgniter\HTTP\IncomingRequest $request = null, \CodeIgniter\HTTP\Response $response = null, $getShared = true)
 	{
 		if ($getShared)
 		{
-			return self::getSharedInstance('exceptions', $config);
+			return self::getSharedInstance('exceptions', $config, $request, $response);
 		}
 
 		if (empty($config))
@@ -237,7 +239,17 @@ class Services
 			$config = new \Config\Exceptions();
 		}
 
-		return (new \CodeIgniter\Debug\Exceptions($config));
+		if (empty($request))
+		{
+			$request = static::request();
+		}
+
+		if (empty($response))
+		{
+			$response = static::response();
+		}
+
+		return (new \CodeIgniter\Debug\Exceptions($config, $request, $response));
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -147,7 +147,7 @@ class Exceptions
 
 			if (strpos($this->request->getHeaderLine('accept'), 'text/html') === false)
 			{
-				$this->respond($this->collectVars($exception, $statusCode), $statusCode)->send();
+				$this->respond(ENVIRONMENT === 'development' ? $this->collectVars($exception, $statusCode) : '', $statusCode)->send();
 
 				exit($exitCode);
 			}

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -81,9 +81,11 @@ class Exceptions
 	/**
 	 * Constructor.
 	 *
-	 * @param \Config\Exceptions $config
+	 * @param \Config\Exceptions                $config
+	 * @param \CodeIgniter\HTTP\IncomingRequest $request
+	 * @param \CodeIgniter\HTTP\Response        $response
 	 */
-	public function __construct(\Config\Exceptions $config)
+	public function __construct(\Config\Exceptions $config, \CodeIgniter\HTTP\IncomingRequest $request, \CodeIgniter\HTTP\Response $response)
 	{
 		$this->ob_level = ob_get_level();
 
@@ -91,8 +93,8 @@ class Exceptions
 
 		$this->config = $config;
 
-		$this->request  = Services::request();
-		$this->response = Services::response();
+		$this->request  = $request;
+		$this->response = $response;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -28,13 +28,13 @@ class ServicesTest extends \CIUnitTestCase
 
 	public function testNewExceptions()
 	{
-		$actual = Services::exceptions(new Exceptions());
+		$actual = Services::exceptions(new Exceptions(), Services::request(), Services::response());
 		$this->assertInstanceOf(\CodeIgniter\Debug\Exceptions::class, $actual);
 	}
 
 	public function testNewExceptionsWithNullConfig()
 	{
-		$actual = Services::exceptions(null, false);
+		$actual = Services::exceptions(null, null, null, false);
 		$this->assertInstanceOf(\CodeIgniter\Debug\Exceptions::class, $actual);
 	}
 

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -4,7 +4,7 @@ class ExceptionsTest extends \CIUnitTestCase
 {
 	public function testNew()
 	{
-		$actual = new Exceptions(new \Config\Exceptions(), new \CodeIgniter\HTTP\IncomingRequest(), new \CodeIgniter\HTTP\Response());
+		$actual = new Exceptions(new \Config\Exceptions(), \Config\Services::request(), \Config\Services::response());
 		$this->assertInstanceOf(Exceptions::class, $actual);
 	}
 }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -4,7 +4,7 @@ class ExceptionsTest extends \CIUnitTestCase
 {
 	public function testNew()
 	{
-		$actual = new Exceptions(new \Config\Exceptions());
+		$actual = new Exceptions(new \Config\Exceptions(), new \CodeIgniter\HTTP\IncomingRequest(), new \CodeIgniter\HTTP\Response());
 		$this->assertInstanceOf(Exceptions::class, $actual);
 	}
 }


### PR DESCRIPTION
Responding the [collectVars()](https://github.com/bcit-ci/CodeIgniter4/blob/8320ca777addbd900fd6cff032a90985d288ff19/system/Debug/Exceptions.php#L271) via the API ResponseTrait.

Maybe already [cleanPath()](https://github.com/bcit-ci/CodeIgniter4/blob/8320ca777addbd900fd6cff032a90985d288ff19/system/Debug/Exceptions.php#L330)'s in the collectVars, so we can get ready for all outputs, including the CLI. Also adjusting the `$_SERVER`, `$_SESSION`, `Request`, `Response`...