### PR TITLE
Validation - Get the label from corresponding fields - Fixes #946

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -682,7 +682,7 @@ class Validation implements ValidationInterface
 		}
 
 		$message = str_replace('{field}', $label ?? $field, $message);
-		$message = str_replace('{param}', $param, $message);
+		$message = str_replace('{param}', $this->rules[$param]['label'] ?? $param, $message);
 
 		return $message;
 	}


### PR DESCRIPTION
```php
public function index()
{
	$rules = [
		'new_password'         => [
			'label' => 'New Password',
			'rules' => [
				'required',
				'min_length[5]',
			],
		],
		'confirm_new_password' => [
			'label' => 'Confirm New Password',
			'rules' => [					
				'differs[new_password]',
				//'required_without[new_password]',
				//'required_with[new_password]',
				//'matches[new_password]',
			],
		],
		'confirm_new_password2' => 'required|matches[new_password]',
	];

	if ($this->validate($rules) === false)
	{
		var_dump($this->validator->getErrors());
		exit;
	}

	echo 'Ok';
}
```