### PR TITLE
Clean up environment variable value

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -101,7 +101,7 @@ class BaseConfig
 					elseif ($value === 'true')
 						$value = true;
 
-					$this->$property = $value;
+					$this->$property = trim($value, '\'"');
 				}
 			}
 		}


### PR DESCRIPTION
While using backslash within single or double quotes in .env, its need to trim quotes. Details in #994 