### PR TITLE
Fix Email lang typo

### DIFF
--- a/system/Language/en/Email.php
+++ b/system/Language/en/Email.php
@@ -24,7 +24,7 @@ return [
 	'sent'                 => 'Your message has been successfully sent using the following protocol: {0, string}',
 	'noSocket'             => 'Unable to open a socket to Sendmail. Please check settings.',
 	'noHostname'           => 'You did not specify a SMTP hostname.',
-	'SMYPError'            => 'The following SMTP error was encountered: {0}',
+	'SMTPError'            => 'The following SMTP error was encountered: {0}',
 	'noSMTPAuth'           => 'Error: You must assign a SMTP username and password.',
 	'failedSMTPLogin'      => 'Failed to send AUTH LOGIN command. Error: {0}',
 	'SMTPAuthUsername'     => 'Failed to authenticate username. Error: {0}',


### PR DESCRIPTION
```
Searching 243 files for "SMYPError"

/CodeIgniter4/system/Language/en/Email.php:
   25  	'noSocket'             => 'Unable to open a socket to Sendmail. Please check settings.',
   26  	'noHostname'           => 'You did not specify a SMTP hostname.',
   27: 	'SMYPError'            => 'The following SMTP error was encountered: {0}',
   28  	'noSMTPAuth'           => 'Error: You must assign a SMTP username and password.',
   29  	'failedSMTPLogin'      => 'Failed to send AUTH LOGIN command. Error: {0}',

1 match in 1 file
```

```
Searching 243 files for "SMTPError"

/CodeIgniter4/system/Email/Email.php:
 2093  		if (strpos($reply, '250') !== 0)
 2094  		{
 2095: 			$this->setErrorMessage(lang('email.SMTPError', [$reply]));
 2096  
 2097  			return false;
 ....
 2139  		if (! is_resource($this->SMTPConnect))
 2140  		{
 2141: 			$this->setErrorMessage(lang('email.SMTPError', [$errno.' '.$errstr]));
 2142  
 2143  			return false;
 ....
 2156  			if ($crypto !== true)
 2157  			{
 2158: 				$this->setErrorMessage(lang('email.SMTPError', $this->getSMTPData()));
 2159  
 2160  				return false;
 ....
 2230  		if ((int)self::substr($reply, 0, 3) !== $resp)
 2231  		{
 2232: 			$this->setErrorMessage(lang('email.SMTPError', [$reply]));
 2233  
 2234  			return false;

4 matches in 1 file
```