### PR TITLE
Update PHPDoc params of redirect with setFlashdata

### DIFF
--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -140,8 +140,8 @@ class RedirectResponse extends Response
 	/**
 	 * Adds a key and message to the session as Flashdata.
 	 *
-	 * @param string $key
-	 * @param string $message
+	 * @param string       $key
+	 * @param string|array $message
 	 *
 	 * @return $this
 	 */

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -591,7 +591,7 @@ class Session implements SessionInterface
 	 * flashdata property, with $value containing the property value.
 	 *
 	 * @param array|string $data  Property identifier or associative array of properties
-	 * @param null         $value Property value if $data is a scalar
+	 * @param string|array $value Property value if $data is a scalar
 	 */
 	public function setFlashdata($data, $value = null)
 	{


### PR DESCRIPTION
Allow IDE's to know that is possible pass an array

```
return \redirect()->with('msg', ['type' => 'warning', 'content' => 'foo']);
```