### PR TITLE
Debugbar $_GET array values

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -155,7 +155,7 @@ class Toolbar
 
 		foreach ($request->getGet() as $name => $value)
 		{
-			$data['vars']['get'][esc($name)] = esc($value);
+			$data['vars']['get'][esc($name)] = is_array($value) ? esc(print_r($value, true)) : esc($value);
 		}
 
 		foreach ($request->getPost() as $name => $value)


### PR DESCRIPTION
Missing array test in debug toolbar for array values in $_GET