### PR TITLE
Fix creating migration namespace

### DIFF
--- a/system/Commands/Database/CreateMigration.php
+++ b/system/Commands/Database/CreateMigration.php
@@ -116,7 +116,7 @@ class CreateMigration extends BaseCommand
 			CLI::error(lang('Migrations.badCreateName'));
 			return;
 		}
-		$namespace = CLI::getOption('n');
+		$ns = CLI::getOption('n');
 		$homepath = APPPATH;
 
 		if ( ! empty($ns))


### PR DESCRIPTION
When creating migration by command line, the namespace always get default "App" because we set wrong variable