### PR TITLE
activate coverage-clover logging at phpunit config to get clover.xml which read by coveralls.phar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ before_script:
   - composer install --prefer-source
 
 after_success:
-  - travis_retry php tests/bin/coveralls.phar
+  - travis_retry php tests/bin/coveralls.phar -v

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,6 +33,6 @@
     </filter>
 
     <logging>
-        <!--<log type="coverage-clover" target="build/logs/clover.xml"/>-->
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
looking at previous travis build, the coveralls command got the following error: 

```
$ travis_retry php tests/bin/coveralls.phar
                                                                                 
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  coverage_clover XML file is not readable                                       
                                                                                 
coveralls:v1:jobs [-c|--config [CONFIG]] [--dry-run] [--exclude-no-stmt] [-e|--env [ENV]] [-x|--coverage_clover COVERAGE_CLOVER] [-r|--root_dir [ROOT_DIR]]
The command "php tests/bin/coveralls.phar" failed. Retrying, 2 of 3.
                                                                                 
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  coverage_clover XML file is not readable                                       
                                                                                 
coveralls:v1:jobs [-c|--config [CONFIG]] [--dry-run] [--exclude-no-stmt] [-e|--env [ENV]] [-x|--coverage_clover COVERAGE_CLOVER] [-r|--root_dir [ROOT_DIR]]
The command "php tests/bin/coveralls.phar" failed. Retrying, 3 of 3.
                                                                                 
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  coverage_clover XML file is not readable                                       
                                                                                 
coveralls:v1:jobs [-c|--config [CONFIG]] [--dry-run] [--exclude-no-stmt] [-e|--env [ENV]] [-x|--coverage_clover COVERAGE_CLOVER] [-r|--root_dir [ROOT_DIR]]
The command "php tests/bin/coveralls.phar" failed 3 times.
```

It try to read `build/logs/clover.xml` which not exists, which should be generated when phpunit run