### PR TITLE
Refactor exceptions for late static binding

### DIFF
--- a/system/CLI/Exceptions/CLIException.php
+++ b/system/CLI/Exceptions/CLIException.php
@@ -10,6 +10,6 @@ class CLIException extends \RuntimeException
 	 */
 	public static function forInvalidColor(string $type, string $color)
 	{
-		return new self(lang('CLI.invalidColor', [$type, $color]));
+		return new static(lang('CLI.invalidColor', [$type, $color]));
 	}
 }

--- a/system/Cache/Exceptions/CacheException.php
+++ b/system/Cache/Exceptions/CacheException.php
@@ -7,7 +7,7 @@ class CacheException extends \RuntimeException implements ExceptionInterface
 	 */
 	public static function forInvalidHandlers()
 	{
-		return new self(lang('Cache.invalidHandlers'));
+		return new static(lang('Cache.invalidHandlers'));
 	}
 
 	/**
@@ -15,7 +15,7 @@ class CacheException extends \RuntimeException implements ExceptionInterface
 	 */
 	public static function forNoBackup()
 	{
-		return new self(lang('Cache.noBackup'));
+		return new static(lang('Cache.noBackup'));
 	}
 
 	/**
@@ -23,6 +23,6 @@ class CacheException extends \RuntimeException implements ExceptionInterface
 	 */
 	public static function forHandlerNotFound()
 	{
-		return new self(lang('Cache.handlerNotFound'));
+		return new static(lang('Cache.handlerNotFound'));
 	}
 }

--- a/system/Database/Exceptions/DataException.php
+++ b/system/Database/Exceptions/DataException.php
@@ -11,7 +11,7 @@ class DataException extends \RuntimeException implements ExceptionInterface
 	 */
 	public static function forInvalidMethodTriggered(string $method)
 	{
-		return new self(lang('Database.invalidEvent', [$method]));
+		return new static(lang('Database.invalidEvent', [$method]));
 	}
 
 	/**
@@ -24,7 +24,7 @@ class DataException extends \RuntimeException implements ExceptionInterface
 	 */
 	public static function forEmptyDataset(string $mode)
 	{
-		return new self(lang('Database.emptyDataset', [$mode]));
+		return new static(lang('Database.emptyDataset', [$mode]));
 	}
 
 	/**
@@ -38,11 +38,11 @@ class DataException extends \RuntimeException implements ExceptionInterface
 	 */
 	public static function forInvalidArgument(string $argument)
 	{
-		return new self(lang('Database.invalidArgument', [$argument]));
+		return new static(lang('Database.invalidArgument', [$argument]));
 	}
 
 	public static function forInvalidAllowedFields(string $model)
 	{
-		return new self(lang('Database.invalidAllowedFields', [$model]));
+		return new static(lang('Database.invalidAllowedFields', [$model]));
 	}
 }

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -14,16 +14,16 @@ class ConfigException extends CriticalError
 
 	public static function forMissingMigrationsTable()
 	{
-		throw new self(lang('Migrations.missingTable'));
+		throw new static(lang('Migrations.missingTable'));
 	}
 
 	public static function forInvalidMigrationType(string $type = null)
 	{
-		throw new self(lang('Migrations.invalidType', [$type]));
+		throw new static(lang('Migrations.invalidType', [$type]));
 	}
 
 	public static function forDisabledMigrations()
 	{
-		throw new self(lang('Migrations.disabled'));
+		throw new static(lang('Migrations.disabled'));
 	}
 }

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -12,26 +12,26 @@ class FrameworkException extends \RuntimeException implements ExceptionInterface
 {
 	public static function forEmptyBaseURL(): self
 	{
-		return new self('You have an empty or invalid base URL. The baseURL value must be set in Config\App.php, or through the .env file.');
+		return new static('You have an empty or invalid base URL. The baseURL value must be set in Config\App.php, or through the .env file.');
 	}
 
 	public static function forInvalidFile(string $path)
 	{
-		return new self(lang('Core.invalidFile', [$path]));
+		return new static(lang('Core.invalidFile', [$path]));
 	}
 
 	public static function forCopyError()
 	{
-		return new self(lang('Core.copyError'));
+		return new static(lang('Core.copyError'));
 	}
 
 	public static function forMissingExtension(string $extension)
 	{
-		return new self(lang('Core.missingExtension', [$extension]));
+		return new static(lang('Core.missingExtension', [$extension]));
 	}
 
 	public static function forNoHandlers(string $class)
 	{
-		return new self(lang('Core.noHandlers', [$class]));
+		return new static(lang('Core.noHandlers', [$class]));
 	}
 }

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -10,21 +10,21 @@ class PageNotFoundException extends \OutOfBoundsException implements ExceptionIn
 
 	public static function forPageNotFound()
 	{
-		return new self(lang('HTTP.pageNotFound'));
+		return new static(lang('HTTP.pageNotFound'));
 	}
 
 	public static function forEmptyController()
 	{
-		return new self(lang('HTTP.emptyController'));
+		return new static(lang('HTTP.emptyController'));
 	}
 
 	public static function forControllerNotFound(string $controller, string $method)
 	{
-		return new self(lang('HTTP.controllerNotFound', [$controller, $method]));
+		return new static(lang('HTTP.controllerNotFound', [$controller, $method]));
 	}
 
 	public static function forMethodNotFound(string $method)
 	{
-		return new self(lang('HTTP.methodNotFound', [$method]));
+		return new static(lang('HTTP.methodNotFound', [$method]));
 	}
 }

--- a/system/Files/Exceptions/FileException.php
+++ b/system/Files/Exceptions/FileException.php
@@ -7,7 +7,7 @@ class FileException extends \RuntimeException implements ExceptionInterface
 
 	public static function forUnableToMove(string $from = null, string $to = null, string $error = null)
 	{
-		return new self(lang('Files.cannotMove', [$from, $to, $error]));
+		return new static(lang('Files.cannotMove', [$from, $to, $error]));
 	}
 
 }

--- a/system/Files/Exceptions/FileNotFoundException.php
+++ b/system/Files/Exceptions/FileNotFoundException.php
@@ -6,6 +6,6 @@ class FileNotFoundException extends \RuntimeException implements ExceptionInterf
 {
 	public static function forFileNotFound(string $path)
 	{
-		return new self(lang('Files.fileNotFound', [$path]));
+		return new static(lang('Files.fileNotFound', [$path]));
 	}
 }

--- a/system/Filters/Exceptions/FilterException.php
+++ b/system/Filters/Exceptions/FilterException.php
@@ -7,11 +7,11 @@ class FilterException extends ConfigException implements ExceptionInterface
 {
 	public static function forNoAlias(string $alias)
 	{
-		return new self(lang('Filters.noFilter', [$alias]));
+		return new static(lang('Filters.noFilter', [$alias]));
 	}
 
 	public static function forIncorrectInterface(string $class)
 	{
-		return new self(lang('Filters.incorrectInterface', [$class]));
+		return new static(lang('Filters.incorrectInterface', [$class]));
 	}
 }

--- a/system/Format/Exceptions/FormatException.php
+++ b/system/Format/Exceptions/FormatException.php
@@ -6,12 +6,12 @@ class FormatException extends \RuntimeException implements ExceptionInterface
 {
 	public static function forInvalidJSON(string $error = null)
 	{
-		return new self(lang('Format.invalidJSON', [$error]));
+		return new static(lang('Format.invalidJSON', [$error]));
 	}
 
 	public static function forMissingExtension()
 	{
-		return new self(lang('Format.missingExtension'));
+		return new static(lang('Format.missingExtension'));
 	}
 
 }

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -12,7 +12,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forMissingCurl()
 	{
-		return new self(lang('HTTP.missingCurl'));
+		return new static(lang('HTTP.missingCurl'));
 	}
 
 	/**
@@ -24,7 +24,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forSSLCertNotFound(string $cert)
 	{
-		return new self(lang('HTTP.sslCertNotFound', [$cert]));
+		return new static(lang('HTTP.sslCertNotFound', [$cert]));
 	}
 
 	/**
@@ -36,7 +36,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forInvalidSSLKey(string $key)
 	{
-		return new self(lang('HTTP.invalidSSLKey', [$key]));
+		return new static(lang('HTTP.invalidSSLKey', [$key]));
 	}
 
 	/**
@@ -49,7 +49,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forCurlError(string $errorNum, string $error)
 	{
-		return new self(lang('HTTP.curlError', [$errorNum, $error]));
+		return new static(lang('HTTP.curlError', [$errorNum, $error]));
 	}
 
 	/**
@@ -61,7 +61,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forInvalidNegotiationType(string $type)
 	{
-		return new self(lang('HTTP.invalidNegotiationType', [$type]));
+		return new static(lang('HTTP.invalidNegotiationType', [$type]));
 	}
 
 	/**
@@ -73,7 +73,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forInvalidHTTPProtocol(string $protocols)
 	{
-		return new self(lang('HTTP.invalidHTTPProtocol', [$protocols]));
+		return new static(lang('HTTP.invalidHTTPProtocol', [$protocols]));
 	}
 
 	/**
@@ -83,7 +83,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forEmptySupportedNegotiations()
 	{
-		return new self(lang('HTTP.emptySupportedNegotiations'));
+		return new static(lang('HTTP.emptySupportedNegotiations'));
 	}
 
 	/**
@@ -95,7 +95,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forInvalidRedirectRoute(string $route)
 	{
-		return new self(lang('HTTP.invalidRoute', [$route]));
+		return new static(lang('HTTP.invalidRoute', [$route]));
 	}
 
 	/**
@@ -105,7 +105,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forMissingResponseStatus()
 	{
-		return new self(lang('HTTP.missingResponseStatus'));
+		return new static(lang('HTTP.missingResponseStatus'));
 	}
 
 	/**
@@ -117,7 +117,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forInvalidStatusCode(int $code)
 	{
-		return new self(lang('HTTP.invalidStatusCode', [$code]));
+		return new static(lang('HTTP.invalidStatusCode', [$code]));
 	}
 
 	/**
@@ -129,7 +129,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forUnkownStatusCode(int $code)
 	{
-		return new self(lang('HTTP.unknownStatusCode', [$code]));
+		return new static(lang('HTTP.unknownStatusCode', [$code]));
 	}
 
 	/**
@@ -141,7 +141,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forUnableToParseURI(string $uri)
 	{
-		return new self(lang('HTTP.cannotParseURI', [$uri]));
+		return new static(lang('HTTP.cannotParseURI', [$uri]));
 	}
 
 	/**
@@ -153,7 +153,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forURISegmentOutOfRange(int $segment)
 	{
-		return new self(lang('HTTP.segmentOutOfRange', [$segment]));
+		return new static(lang('HTTP.segmentOutOfRange', [$segment]));
 	}
 
 	/**
@@ -165,7 +165,7 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forInvalidPort(int $port)
 	{
-		return new self(lang('HTTP.invalidPort', [$port]));
+		return new static(lang('HTTP.invalidPort', [$port]));
 	}
 
 	/**
@@ -175,6 +175,6 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	 */
 	public static function forMalformedQueryString()
 	{
-		return new self(lang('HTTP.malformedQueryString'));
+		return new static(lang('HTTP.malformedQueryString'));
 	}
 }

--- a/system/I18n/Exceptions/I18nException.php
+++ b/system/I18n/Exceptions/I18nException.php
@@ -7,26 +7,26 @@ class I18nException extends FrameworkException implements ExceptionInterface
 {
 	public static function forInvalidMonth(string $month)
 	{
-		return new self(lang('Time.invalidMonth', [$month]));
+		return new static(lang('Time.invalidMonth', [$month]));
 	}
 
 	public static function forInvalidDay(string $day)
 	{
-		return new self(lang('Time.invalidDay', [$day]));
+		return new static(lang('Time.invalidDay', [$day]));
 	}
 
 	public static function forInvalidHour(string $hour)
 	{
-		return new self(lang('Time.invalidHour', [$hour]));
+		return new static(lang('Time.invalidHour', [$hour]));
 	}
 
 	public static function forInvalidMinutes(string $minutes)
 	{
-		return new self(lang('Time.invalidMinutes', [$minutes]));
+		return new static(lang('Time.invalidMinutes', [$minutes]));
 	}
 
 	public static function forInvalidSeconds(string $seconds)
 	{
-		return new self(lang('Time.invalidSeconds', [$seconds]));
+		return new static(lang('Time.invalidSeconds', [$seconds]));
 	}
 }

--- a/system/Images/Exceptions/ImageException.php
+++ b/system/Images/Exceptions/ImageException.php
@@ -7,36 +7,36 @@ class ImageException extends FrameworkException implements ExceptionInterface
 {
 	public static function forMissingAngle()
 	{
-		return new self(lang('Images.rotationAngleRequired'));
+		return new static(lang('Images.rotationAngleRequired'));
 	}
 
 	public static function forInvalidDirection(string $dir = null)
 	{
-		return new self(lang('Images.invalidDirection', [$dir]));
+		return new static(lang('Images.invalidDirection', [$dir]));
 	}
 
 	public static function forEXIFUnsupported()
 	{
-		return new self(lang('Images.exifNotSupported'));
+		return new static(lang('Images.exifNotSupported'));
 	}
 
 	public static function forInvalidImageCreate(string $extra = null)
 	{
-		return new self(lang('Images.unsupportedImagecreate').' '.$extra);
+		return new static(lang('Images.unsupportedImagecreate').' '.$extra);
 	}
 
 	public static function forSaveFailed()
 	{
-		return new self(lang('Images.saveFailed'));
+		return new static(lang('Images.saveFailed'));
 	}
 
 	public static function forInvalidImageLibraryPath(string $path = null)
 	{
-		return new self(lang('Images.libPathInvalid', [$path]));
+		return new static(lang('Images.libPathInvalid', [$path]));
 	}
 
 	public static function forImageProcessFailed()
 	{
-		return new self(lang('Images.imageProcessFailed'));
+		return new static(lang('Images.imageProcessFailed'));
 	}
 }

--- a/system/Log/Exceptions/LogException.php
+++ b/system/Log/Exceptions/LogException.php
@@ -7,7 +7,7 @@ class LogException extends FrameworkException implements ExceptionInterface
 {
 	public static function forInvalidLogLevel(string $level)
 	{
-		return new self(lang('Log.invalidLogLevel', [$level]));
+		return new static(lang('Log.invalidLogLevel', [$level]));
 	}
 
 

--- a/system/Pager/Exceptions/PagerException.php
+++ b/system/Pager/Exceptions/PagerException.php
@@ -7,11 +7,11 @@ class PagerException extends FrameworkException implements ExceptionInterface
 {
 	public static function forInvalidTemplate(string $template=null)
 	{
-		return new self(lang('Pager.invalidTemplate', [$template]));
+		return new static(lang('Pager.invalidTemplate', [$template]));
 	}
 
 	public static function forInvalidPaginationGroup(string $group = null)
 	{
-		return new self(lang('Pager.invalidPaginationGroup', [$group]));
+		return new static(lang('Pager.invalidPaginationGroup', [$group]));
 	}
 }

--- a/system/Router/Exceptions/RouterException.php
+++ b/system/Router/Exceptions/RouterException.php
@@ -7,11 +7,11 @@ class RouterException extends FrameworkException implements ExceptionInterface
 {
 	public static function forInvalidParameterType()
 	{
-		return new self(lang('Router.invalidParameterType'));
+		return new static(lang('Router.invalidParameterType'));
 	}
 
 	public static function forMissingDefaultRoute()
 	{
-		return new self(lang('Router.missingDefaultRoute'));
+		return new static(lang('Router.missingDefaultRoute'));
 	}
 }

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -7,6 +7,6 @@ class SecurityException extends FrameworkException implements ExceptionInterface
 {
 	public static function forDisallowedAction()
 	{
-		return new self(lang('HTTP.disallowedAction'), 403);
+		return new static(lang('HTTP.disallowedAction'), 403);
 	}
 }

--- a/system/Session/Exceptions/SessionException.php
+++ b/system/Session/Exceptions/SessionException.php
@@ -7,26 +7,26 @@ class SessionException extends FrameworkException implements ExceptionInterface
 {
 	public static function forMissingDatabaseTable()
 	{
-		return new self(lang('Session.missingDatabaseTable'));
+		return new static(lang('Session.missingDatabaseTable'));
 	}
 
 	public static function forInvalidSavePath(string $path = null)
 	{
-		return new self(lang('Session.invalidSavePath', [$path]));
+		return new static(lang('Session.invalidSavePath', [$path]));
 	}
 
 	public static function forWriteProtectedSavePath(string $path = null)
 	{
-		return new self(lang('Session.writeProtectedSavePath', [$path]));
+		return new static(lang('Session.writeProtectedSavePath', [$path]));
 	}
 
 	public static function forEmptySavepath()
 	{
-		return new self(lang('Session.emptySavePath'));
+		return new static(lang('Session.emptySavePath'));
 	}
 
 	public static function forInvalidSavePathFormat(string $path)
 	{
-		return new self(lang('Session.invalidSavePathFormat', [$path]));
+		return new static(lang('Session.invalidSavePathFormat', [$path]));
 	}
 }

--- a/system/Validation/Exceptions/ValidationException.php
+++ b/system/Validation/Exceptions/ValidationException.php
@@ -7,26 +7,26 @@ class ValidationException extends FrameworkException implements ExceptionInterfa
 {
 	public static function forRuleNotFound(string $rule = null)
 	{
-		return new self(lang('Validation.ruleNotFound', [$rule]));
+		return new static(lang('Validation.ruleNotFound', [$rule]));
 	}
 
 	public static function forGroupNotFound(string $group = null)
 	{
-		return new self(lang('Validation.groupNotFound', [$group]));
+		return new static(lang('Validation.groupNotFound', [$group]));
 	}
 
 	public static function forGroupNotArray(string $group = null)
 	{
-		return new self(lang('Validation.groupNotArray', [$group]));
+		return new static(lang('Validation.groupNotArray', [$group]));
 	}
 
 	public static function forInvalidTemplate(string $template = null)
 	{
-		return new self(lang('Validation.invalidTemplate', [$template]));
+		return new static(lang('Validation.invalidTemplate', [$template]));
 	}
 
 	public static function forNoRuleSets()
 	{
-		return new self(lang('Validation.noRuleSets'));
+		return new static(lang('Validation.noRuleSets'));
 	}
 }

--- a/system/View/Exceptions/ViewException.php
+++ b/system/View/Exceptions/ViewException.php
@@ -7,31 +7,31 @@ class ViewException extends FrameworkException implements ExceptionInterface
 {
 	public static function forInvalidCellMethod(string $class, string $method)
 	{
-		return new self(lang('View.invalidCellMethod', ['class' => $class, 'method' => $method]));
+		return new static(lang('View.invalidCellMethod', ['class' => $class, 'method' => $method]));
 	}
 
 	public static function forMissingCellParameters(string $class, string $method)
 	{
-		return new self(lang('View.missingCellParameters', ['class' => $class, 'method' => $method]));
+		return new static(lang('View.missingCellParameters', ['class' => $class, 'method' => $method]));
 	}
 
 	public static function forInvalidCellParameter(string $key)
 	{
-		return new self(lang('View.invalidCellParameter', [$key]));
+		return new static(lang('View.invalidCellParameter', [$key]));
 	}
 
 	public static function forNoCellClass()
 	{
-		return new self(lang('View.noCellClass'));
+		return new static(lang('View.noCellClass'));
 	}
 
 	public static function forInvalidCellClass(string $class = null)
 	{
-		return new self(lang('View.invalidCellClass', [$class]));
+		return new static(lang('View.invalidCellClass', [$class]));
 	}
 
 	public static function forTagSyntaxError(string $output)
 	{
-		return new self(lang('View.tagSyntaxError', [$output]));
+		return new static(lang('View.tagSyntaxError', [$output]));
 	}
 }


### PR DESCRIPTION
Change "new self" to "new static", resulting in tended behavior of catching "module" exceptions rather than needing multiple catch clauses for different kinds of exceptions.