### PR TITLE
Added URL instance property for CLIRequest class

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -55,6 +55,13 @@ use Config\App;
 class CLIRequest extends Request
 {
 
+        /**
+	 * A \CodeIgniter\HTTPLite\URI instance.
+	 *
+	 * @var URI
+	 */
+	public $uri;
+        
 	/**
 	 * Stores the segments of our cli "URI" command.
 	 *
@@ -68,20 +75,23 @@ class CLIRequest extends Request
 	 */
 	protected $options = [];
 
+        
 	//--------------------------------------------------------------------
 
 	/**
 	 * Constructor
 	 *
 	 * @param App $config
+         * @param URI $uri
 	 */
-	public function __construct(App $config)
+	public function __construct(App $config, $uri = null)
 	{
 		parent::__construct($config);
 
 		// Don't terminate the script when the cli's tty goes away
 		ignore_user_abort(true);
-
+                
+                $this->uri = $uri;
 		$this->parseCommand();
 	}
 


### PR DESCRIPTION
In the **Services.php** file, the **URL** instance is passed to **CLIRequest** constructor but it not in use in the CLIRequest class. Consequently calling ```$this->request->url``` in the controller throws an exception when you access the app from command line ```$ php index.php [controller]```. This is in the Services.php file under system config
```
/**
	 * The CLI Request class provides for ways to interact with
	 * a command line request.
	 *
	 * @param \Config\App $config
	 * @param bool        $getShared
	 *
	 * @return \CodeIgniter\HTTP\CLIRequest
	 */
	public static function clirequest(\Config\App $config = null, $getShared = true)
	{
		if ($getShared)
		{
			return self::getSharedInstance('clirequest', $config);
		}

		if (! is_object($config))
		{
			$config = new \Config\App();
		}

		return new \CodeIgniter\HTTP\CLIRequest(
			$config, new \CodeIgniter\HTTP\URI()
		);
	}
```
