### PR TITLE
toolbar cannot be initialized correctly.

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -237,7 +237,7 @@
 				<?php foreach ($cookies as $name => $value) : ?>
 					<tr>
 						<td><?= $name ?></td>
-						<td><?= $value ?></td>
+						<td><?= is_array($value) ? var_dump($value) : $value ?></td>
 					</tr>
 				<?php endforeach ?>
 				</tbody>


### PR DESCRIPTION
setcookie() is arrays will cause ‘Array to string conversion’ to be wrong.
toolbar cannot be initialized correctly.

Example, Home Controller add code:
`setcookie("cookie[three]", "cookiethree");
setcookie("cookie[two]", "cookietwo");
setcookie("cookie[one]", "cookieone");`