### PR TITLE
Fixed a bug where you can not change the path freely

### DIFF
--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -22,7 +22,7 @@ $_SERVER['CI_ENVIRONMENT'] = 'development';
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
 // Front Controller path - expected to be in the default folder
-$fcpath = realpath(__DIR__ . '/../../../public') . DIRECTORY_SEPARATOR;
+$fcpath = FCPATH;
 
 // Full path
 $path = $fcpath . ltrim($uri, '/');


### PR DESCRIPTION
I wanted to move the `public` directory, but I could not move it.

Since `rewrite.php` before modification depends on the installed directory, it is necessary to create `Serve` class in application and solve it.

This is very troublesome and if spark defines the `FCPATH` constant we thought that you do not have to define $fcpath in rewrite.php.

I think this is the experimentally implemented content at the next PR, but the current situation has arisen.

#996 