### PR TITLE
WIP Attempt Session fix for PHP7.2 headers already sent error

### DIFF
--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -13,10 +13,15 @@ class SessionTest extends \CIUnitTestCase
 
         $_COOKIE = [];
         $_SESSION = [];
-    }
+ 
+   }
 
     public function tearDown()
     {
+		if (session_status() == PHP_SESSION_ACTIVE)
+		{
+			session_write_close();
+		}
 
     }
 


### PR DESCRIPTION
Followed suggestions from #1106 and online search results. No joy :(
Doesn't break under PHP7.1, but still does under PHP7.2.
I even isolated the ini_set calls inside a new safeSet method., to try to "play nice".

Further suggestions?