### PR TITLE
php 7.2 fix Request::getIPAddress() error count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -131,7 +131,7 @@ class Request extends Message implements RequestInterface
 
 			if ($spoof)
 			{
-				for ($i = 0, $c = count($this->proxyIPs); $i < $c; $i ++ )
+				for ($i = 0, $c = count($proxy_ips); $i < $c; $i ++ )
 				{
 					// Check if we have an IP address or a subnet
 					if (strpos($proxy_ips[$i], '/') === FALSE)


### PR DESCRIPTION
There is `$this->proxyIPs` check not an array, which next collected into `$proxy_ips` as an `explode()` of comma separated ip address into array.