### PR TITLE
update invalidDay and invalidMonth start check, use 1 instead of 0

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -615,7 +615,7 @@ class Time extends DateTime
 	 */
 	public function setMonth($value)
 	{
-		if ($value < 1 || $value > 12)
+		if (is_numeric($value) && $value < 1 || $value > 12)
 		{
 			throw I18nException::forInvalidMonth($value);
 		}

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -615,7 +615,7 @@ class Time extends DateTime
 	 */
 	public function setMonth($value)
 	{
-		if ($value < 0 || $value > 12)
+		if ($value < 1 || $value > 12)
 		{
 			throw I18nException::forInvalidMonth($value);
 		}
@@ -639,7 +639,7 @@ class Time extends DateTime
 	 */
 	public function setDay($value)
 	{
-		if ($value < 0 || $value > 31)
+		if ($value < 1 || $value > 31)
 		{
 			throw I18nException::forInvalidDay($value);
 		}

--- a/system/Language/en/Time.php
+++ b/system/Language/en/Time.php
@@ -10,12 +10,12 @@
  * @link         https://codeigniter.com
  * @since        Version 3.0.0
  * @filesource
- * 
+ *
  * @codeCoverageIgnore
  */
 return [
-	'invalidMonth'   => 'Months must be between 0 and 12. Given: {0}',
-	'invalidDay'     => 'Days must be between 0 and 31. Given: {0}',
+	'invalidMonth'   => 'Months must be between 1 and 12. Given: {0}',
+	'invalidDay'     => 'Days must be between 1 and 31. Given: {0}',
 	'invalidHours'   => 'Hours must be between 0 and 23. Given: {0}',
 	'invalidMinutes' => 'Minutes must be between 0 and 59. Given: {0}',
 	'invalidSeconds' => 'Seconds must be between 0 and 59. Given: {0}',


### PR DESCRIPTION
while it is practically valid to have day = 0 and month = 0, I think it is better to use start month and start day as 1 instead of 0 to avoid confusion to use last previous month last day.

ref: https://3v4l.org/MGrJY