### PR TITLE
Run session tests in separate processes - fix for #1106

### DIFF
--- a/application/Config/Boot/testing.php
+++ b/application/Config/Boot/testing.php
@@ -19,7 +19,7 @@ ini_set('display_errors', 1);
 | backtraces along with the other error information. If you would
 | prefer to not see this, set this value to false.
 */
-define('SHOW_DEBUG_BACKTRACE', true);
+defined('SHOW_DEBUG_BACKTRACE') or define('SHOW_DEBUG_BACKTRACE', true);
 
 /*
 |--------------------------------------------------------------------------
@@ -30,4 +30,4 @@ define('SHOW_DEBUG_BACKTRACE', true);
 | release of the framework.
 */
 
-define('CI_DEBUG', 1);
+defined('CI_DEBUG') or define('CI_DEBUG', 1);

--- a/application/Config/Boot/testing.php
+++ b/application/Config/Boot/testing.php
@@ -19,7 +19,7 @@ ini_set('display_errors', 1);
 | backtraces along with the other error information. If you would
 | prefer to not see this, set this value to false.
 */
-defined('SHOW_DEBUG_BACKTRACE') or define('SHOW_DEBUG_BACKTRACE', true);
+define('SHOW_DEBUG_BACKTRACE', true);
 
 /*
 |--------------------------------------------------------------------------
@@ -30,4 +30,4 @@ defined('SHOW_DEBUG_BACKTRACE') or define('SHOW_DEBUG_BACKTRACE', true);
 | release of the framework.
 */
 
-defined('CI_DEBUG') or define('CI_DEBUG', 1);
+define('CI_DEBUG', 1);

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -925,7 +925,7 @@ if ( ! function_exists('set_radio'))
 
 		// Unchecked checkbox and radio inputs are not even submitted by browsers ...
 		$result = '';
-		if ($request->getPost())
+		if (!empty($request->getPost()) || !empty(old($field)))
 		{
 			$result = ($input === $value) ? ' checked="checked"' : '';
 		}

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -925,7 +925,7 @@ if ( ! function_exists('set_radio'))
 
 		// Unchecked checkbox and radio inputs are not even submitted by browsers ...
 		$result = '';
-		if (!empty($request->getPost()) || !empty(old($field)))
+		if (!empty($input = $request->getPost($field)) || !empty($input = old($field)))
 		{
 			$result = ($input === $value) ? ' checked="checked"' : '';
 		}

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -157,7 +157,7 @@ class CommomFunctionsTest extends \CIUnitTestCase
 	// ------------------------------------------------------------------------
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testSessionInstance()
@@ -166,7 +166,7 @@ class CommomFunctionsTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testSessionVariable()
@@ -176,7 +176,7 @@ class CommomFunctionsTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testSessionVariableNotThere()

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -156,17 +156,29 @@ class CommomFunctionsTest extends \CIUnitTestCase
 
 	// ------------------------------------------------------------------------
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testSessionInstance()
 	{
 		$this->assertInstanceOf(CodeIgniter\Session\Session::class, session());
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testSessionVariable()
 	{
 		$_SESSION['notbogus'] = 'Hi there';
 		$this->assertEquals('Hi there', session('notbogus'));
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testSessionVariableNotThere()
 	{
 		$_SESSION['bogus'] = 'Hi there';

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use CodeIgniter\Session\Handlers\FileHandler;
 use Config\App;
 use Config\Autoload;
 use CodeIgniter\Config\Services;
@@ -8,8 +9,11 @@ use CodeIgniter\HTTP\RequestResponse;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
+use Config\Logger;
 use Tests\Support\Autoloader\MockFileLocator;
 use Tests\Support\HTTP\MockIncomingRequest;
+use Tests\Support\Log\TestLogger;
+use Tests\Support\Session\MockSession;
 
 /**
  * @backupGlobals enabled
@@ -162,6 +166,8 @@ class CommomFunctionsTest extends \CIUnitTestCase
 	 */
 	public function testSessionInstance()
 	{
+		$this->injectSessionMock();
+
 		$this->assertInstanceOf(CodeIgniter\Session\Session::class, session());
 	}
 
@@ -171,7 +177,10 @@ class CommomFunctionsTest extends \CIUnitTestCase
 	 */
 	public function testSessionVariable()
 	{
+		$this->injectSessionMock();
+
 		$_SESSION['notbogus'] = 'Hi there';
+
 		$this->assertEquals('Hi there', session('notbogus'));
 	}
 
@@ -181,6 +190,8 @@ class CommomFunctionsTest extends \CIUnitTestCase
 	 */
 	public function testSessionVariableNotThere()
 	{
+		$this->injectSessionMock();
+
 		$_SESSION['bogus'] = 'Hi there';
 		$this->assertEquals(null, session('notbogus'));
 	}
@@ -243,8 +254,13 @@ class CommomFunctionsTest extends \CIUnitTestCase
 
 	// ------------------------------------------------------------------------
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function testOldInput()
 	{
+		$this->injectSessionMock();
 		// setup from RedirectResponseTest...
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
@@ -285,6 +301,29 @@ class CommomFunctionsTest extends \CIUnitTestCase
 		$this->assertEquals('/', slash_item('cookiePath')); // slash already there
 		$this->assertEquals('', slash_item('cookieDomain')); // empty, so untouched
 		$this->assertEquals('en/', slash_item('defaultLocale')); // slash appended
+	}
+
+	protected function injectSessionMock()
+	{
+		$defaults = [
+			'sessionDriver' => 'CodeIgniter\Session\Handlers\FileHandler',
+			'sessionCookieName' => 'ci_session',
+			'sessionExpiration' => 7200,
+			'sessionSavePath' => null,
+			'sessionMatchIP' => false,
+			'sessionTimeToUpdate' => 300,
+			'sessionRegenerateDestroy' => false,
+			'cookieDomain' => '',
+			'cookiePrefix' => '',
+			'cookiePath' => '/',
+			'cookieSecure' => false,
+		];
+
+		$config = (object)$defaults;
+
+		$session = new MockSession(new FileHandler($config), $config);
+		$session->setLogger(new TestLogger(new Logger()));
+		\CodeIgniter\Config\BaseService::injectMock('session', $session);
 	}
 
 }

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -129,18 +129,30 @@ class ServicesTest extends \CIUnitTestCase
 		$this->assertInstanceOf(\CodeIgniter\View\Cell::class, $actual);
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testNewSession()
 	{
 		$actual = Services::session($this->config);
 		$this->assertInstanceOf(\CodeIgniter\Session\Session::class, $actual);
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testNewSessionWithNullConfig()
 	{
 		$actual = Services::session(null, false);
 		$this->assertInstanceOf(\CodeIgniter\Session\Session::class, $actual);
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testCallStatic()
 	{
 		// __callStatic should kick in for this but fail

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -130,7 +130,7 @@ class ServicesTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testNewSession()
@@ -140,7 +140,7 @@ class ServicesTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testNewSessionWithNullConfig()
@@ -150,7 +150,7 @@ class ServicesTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testCallStatic()

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -53,7 +53,7 @@ class RedirectResponseTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testWithInput()
@@ -73,7 +73,7 @@ class RedirectResponseTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testWithValidationErrors()
@@ -94,7 +94,7 @@ class RedirectResponseTest extends \CIUnitTestCase
 	}
 
 	/**
-	 * @runTestsInSeparateProcesses
+	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function testWith()

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -52,6 +52,10 @@ class RedirectResponseTest extends \CIUnitTestCase
 		$this->assertEquals('http://example.com/foo', $response->getHeaderLine('Location'));
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testWithInput()
 	{
 		$_SESSION = [];
@@ -68,6 +72,10 @@ class RedirectResponseTest extends \CIUnitTestCase
 		$this->assertEquals('baz', $_SESSION['_ci_old_input']['post']['bar']);
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testWithValidationErrors()
 	{
 		$_SESSION = [];
@@ -85,6 +93,10 @@ class RedirectResponseTest extends \CIUnitTestCase
 		$this->assertArrayHasKey('_ci_validation_errors', $_SESSION);
 	}
 
+	/**
+	 * @runTestsInSeparateProcesses
+	 * @preserveGlobalState disabled
+	 */
 	public function testWith()
 	{
 		$_SESSION = [];

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -756,6 +756,10 @@ EOH;
 	}
 
 	// ------------------------------------------------------------------------
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function testSetRadio()
 	{
 		$_SESSION = [
@@ -771,6 +775,10 @@ EOH;
 		unset($_SESSION['_ci_old_input']);
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function testSetRadioFromPost()
 	{
 		$_POST['bar'] = 'baz';

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -5,6 +5,10 @@ use Tests\Support\Log\TestLogger;
 use Tests\Support\Session\MockSession;
 use CodeIgniter\Session\Handlers\FileHandler;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class SessionTest extends \CIUnitTestCase
 {
     public function setUp()
@@ -45,9 +49,6 @@ class SessionTest extends \CIUnitTestCase
         return $session;
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testSessionSetsRegenerateTime()
     {
         $session = $this->getInstance();
@@ -56,9 +57,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertTrue(isset($_SESSION['__ci_last_regenerate']) && ! empty($_SESSION['__ci_last_regenerate']));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testWillRegenerateSessionAutomatically()
     {
         $session = $this->getInstance();
@@ -71,9 +69,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertGreaterThan($time + 90 ,$_SESSION['__ci_last_regenerate']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testCanSetSingleValue()
     {
         $session = $this->getInstance();
@@ -84,9 +79,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testCanSetArray()
     {
         $session = $this->getInstance();
@@ -102,9 +94,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetSimpleKey()
     {
         $session = $this->getInstance();
@@ -115,9 +104,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $session->get('foo'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetReturnsNullWhenNotFound()
     {
     	$_SESSION = [];
@@ -128,9 +114,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertNull($session->get('foo'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetReturnsAllWithNoKeys()
 	{
 		$_SESSION = [
@@ -147,9 +130,6 @@ class SessionTest extends \CIUnitTestCase
 		$this->assertTrue(array_key_exists('bar', $result));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetAsProperty()
     {
         $session = $this->getInstance();
@@ -160,9 +140,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $session->foo);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetAsNormal()
     {
         $session = $this->getInstance();
@@ -173,9 +150,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testHasReturnsTrueOnSuccess()
     {
         $session = $this->getInstance();
@@ -186,9 +160,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertTrue($session->has('foo'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testHasReturnsFalseOnNotFound()
     {
         $session = $this->getInstance();
@@ -199,9 +170,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse($session->has('bar'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testRemoveActuallyRemoves()
     {
         $session = $this->getInstance();
@@ -214,9 +182,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse($session->has('foo'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testHasReturnsCanRemoveArray()
     {
         $session = $this->getInstance();
@@ -235,9 +200,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertArrayNotHasKey('bar', $_SESSION);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testSetMagicMethod()
     {
         $session = $this->getInstance();
@@ -249,9 +211,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testCanFlashData()
     {
         $session = $this->getInstance();
@@ -274,9 +233,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse($session->has('foo'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testCanFlashArray()
     {
         $session = $this->getInstance();
@@ -293,9 +249,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testKeepFlashData()
     {
         $session = $this->getInstance();
@@ -323,9 +276,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testUnmarkFlashDataRemovesData()
     {
         $session = $this->getInstance();
@@ -345,9 +295,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetFlashKeysOnlyReturnsFlashKeys()
     {
         $session = $this->getInstance();
@@ -362,9 +309,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertNotContains('bar', $keys);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testSetTempDataWorks()
     {
         $session = $this->getInstance();
@@ -374,9 +318,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testSetTempDataArrayMultiTTL()
     {
         $session = $this->getInstance();
@@ -395,9 +336,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testSetTempDataArraySingleTTL()
     {
         $session = $this->getInstance();
@@ -414,7 +352,6 @@ class SessionTest extends \CIUnitTestCase
 
     /**
      * @group single
-     * @runInSeparateProcess
      */
     public function testGetTestDataReturnsAll()
     {
@@ -432,9 +369,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals($data, $session->getTempdata());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetTestDataReturnsSingle()
     {
         $session = $this->getInstance();
@@ -450,9 +384,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $session->getTempdata('foo'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testRemoveTempDataActuallyDeletes()
     {
         $session = $this->getInstance();
@@ -469,9 +400,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testUnMarkTempDataSingle()
     {
         $session = $this->getInstance();
@@ -488,9 +416,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testUnMarkTempDataArray()
     {
         $session = $this->getInstance();
@@ -507,9 +432,6 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals([], $session->getTempdata());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetTempdataKeys()
     {
         $session = $this->getInstance();

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -7,131 +7,131 @@ use CodeIgniter\Session\Handlers\FileHandler;
 
 class SessionTest extends \CIUnitTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
+	public function setUp()
+	{
+		parent::setUp();
 
-        $_COOKIE = [];
-        $_SESSION = [];
-    }
+		$_COOKIE = [];
+		$_SESSION = [];
+	}
 
-    public function tearDown()
-    {
+	public function tearDown()
+	{
 
-    }
+	}
 
-    protected function getInstance($options=[])
-    {
-        $defaults = [
-            'sessionDriver' => 'CodeIgniter\Session\Handlers\FileHandler',
-            'sessionCookieName' => 'ci_session',
-            'sessionExpiration' => 7200,
-            'sessionSavePath' => null,
-            'sessionMatchIP' => false,
-            'sessionTimeToUpdate' => 300,
-            'sessionRegenerateDestroy' => false,
-            'cookieDomain' => '',
-            'cookiePrefix' => '',
-            'cookiePath' => '/',
-            'cookieSecure' => false,
-        ];
+	protected function getInstance($options = [])
+	{
+		$defaults = [
+			'sessionDriver' => 'CodeIgniter\Session\Handlers\FileHandler',
+			'sessionCookieName' => 'ci_session',
+			'sessionExpiration' => 7200,
+			'sessionSavePath' => null,
+			'sessionMatchIP' => false,
+			'sessionTimeToUpdate' => 300,
+			'sessionRegenerateDestroy' => false,
+			'cookieDomain' => '',
+			'cookiePrefix' => '',
+			'cookiePath' => '/',
+			'cookieSecure' => false,
+		];
 
-        $config = array_merge($defaults, $options);
-        $config = (object)$config;
+		$config = array_merge($defaults, $options);
+		$config = (object)$config;
 
-        $session = new MockSession(new FileHandler($config), $config);
-        $session->setLogger(new TestLogger(new Logger()));
+		$session = new MockSession(new FileHandler($config), $config);
+		$session->setLogger(new TestLogger(new Logger()));
 
-        return $session;
-    }
+		return $session;
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSessionSetsRegenerateTime()
-    {
-        $session = $this->getInstance();
-        $session->start();
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testSessionSetsRegenerateTime()
+	{
+		$session = $this->getInstance();
+		$session->start();
 
-        $this->assertTrue(isset($_SESSION['__ci_last_regenerate']) && ! empty($_SESSION['__ci_last_regenerate']));
-    }
+		$this->assertTrue(isset($_SESSION['__ci_last_regenerate']) && !empty($_SESSION['__ci_last_regenerate']));
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testWillRegenerateSessionAutomatically()
-    {
-        $session = $this->getInstance();
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testWillRegenerateSessionAutomatically()
+	{
+		$session = $this->getInstance();
 
-        $time = time()-400;
-        $_SESSION['__ci_last_regenerate'] = $time;
-        $session->start();
+		$time = time() - 400;
+		$_SESSION['__ci_last_regenerate'] = $time;
+		$session->start();
 
-        $this->assertTrue($session->didRegenerate);
-        $this->assertGreaterThan($time + 90 ,$_SESSION['__ci_last_regenerate']);
-    }
+		$this->assertTrue($session->didRegenerate);
+		$this->assertGreaterThan($time + 90, $_SESSION['__ci_last_regenerate']);
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testCanSetSingleValue()
-    {
-        $session = $this->getInstance();
-        $session->start();
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testCanSetSingleValue()
+	{
+		$session = $this->getInstance();
+		$session->start();
 
-        $session->set('foo', 'bar');
+		$session->set('foo', 'bar');
 
-        $this->assertEquals('bar', $_SESSION['foo']);
-    }
+		$this->assertEquals('bar', $_SESSION['foo']);
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testCanSetArray()
-    {
-        $session = $this->getInstance();
-        $session->start();
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testCanSetArray()
+	{
+		$session = $this->getInstance();
+		$session->start();
 
-        $session->set([
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ]);
+		$session->set([
+			'foo' => 'bar',
+			'bar' => 'baz'
+		]);
 
-        $this->assertEquals('bar', $_SESSION['foo']);
-        $this->assertEquals('baz', $_SESSION['bar']);
-        $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
-    }
+		$this->assertEquals('bar', $_SESSION['foo']);
+		$this->assertEquals('baz', $_SESSION['bar']);
+		$this->assertArrayNotHasKey('__ci_vars', $_SESSION);
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetSimpleKey()
-    {
-        $session = $this->getInstance();
-        $session->start();
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetSimpleKey()
+	{
+		$session = $this->getInstance();
+		$session->start();
 
-        $session->set('foo', 'bar');
+		$session->set('foo', 'bar');
 
-        $this->assertEquals('bar', $session->get('foo'));
-    }
+		$this->assertEquals('bar', $session->get('foo'));
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetReturnsNullWhenNotFound()
-    {
-    	$_SESSION = [];
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetReturnsNullWhenNotFound()
+	{
+		$_SESSION = [];
 
-        $session = $this->getInstance();
-        $session->start();
+		$session = $this->getInstance();
+		$session->start();
 
-        $this->assertNull($session->get('foo'));
-    }
+		$this->assertNull($session->get('foo'));
+	}
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetReturnsAllWithNoKeys()
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetReturnsAllWithNoKeys()
 	{
 		$_SESSION = [
 			'foo' => 'bar',
@@ -145,384 +145,384 @@ class SessionTest extends \CIUnitTestCase
 
 		$this->assertTrue(array_key_exists('foo', $result));
 		$this->assertTrue(array_key_exists('bar', $result));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetAsProperty()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->set('foo', 'bar');
-
-        $this->assertEquals('bar', $session->foo);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetAsNormal()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->set('foo', 'bar');
-
-        $this->assertEquals('bar', $_SESSION['foo']);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testHasReturnsTrueOnSuccess()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $_SESSION['foo'] = 'bar';
-
-        $this->assertTrue($session->has('foo'));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testHasReturnsFalseOnNotFound()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $_SESSION['foo'] = 'bar';
-
-        $this->assertFalse($session->has('bar'));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testRemoveActuallyRemoves()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $_SESSION['foo'] = 'bar';
-        $session->remove('foo');
-
-        $this->assertArrayNotHasKey('foo', $_SESSION);
-        $this->assertFalse($session->has('foo'));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testHasReturnsCanRemoveArray()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $_SESSION = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $this->assertTrue($session->has('foo'));
-
-        $session->remove(['foo', 'bar']);
-
-        $this->assertArrayNotHasKey('foo', $_SESSION);
-        $this->assertArrayNotHasKey('bar', $_SESSION);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSetMagicMethod()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->foo = 'bar';
-
-        $this->assertArrayHasKey('foo', $_SESSION);
-        $this->assertEquals('bar', $_SESSION['foo']);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testCanFlashData()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->setFlashdata('foo', 'bar');
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-
-        // Should reset the 'new' to 'old'
-        $session->start();
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
-
-        // Should no longer be available
-        $session->start();
-
-        $this->assertFalse($session->has('foo'));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testCanFlashArray()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->setFlashdata([
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ]);
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-        $this->assertTrue($session->has('bar'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testKeepFlashData()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->setFlashdata('foo', 'bar');
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-
-        // Should reset the 'new' to 'old'
-        $session->start();
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
-
-        $session->keepFlashdata('foo');
-
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-
-        // Should no longer be available
-        $session->start();
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testUnmarkFlashDataRemovesData()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->setFlashdata('foo', 'bar');
-        $session->set('bar', 'baz');
-
-        $this->assertTrue($session->has('foo'));
-        $this->assertArrayHasKey('foo', $_SESSION['__ci_vars']);
-
-        $session->unmarkFlashdata('foo');
-
-        // Should still be here
-        $this->assertTrue($session->has('foo'));
-        // but no longer marked as flash
-        $this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetFlashKeysOnlyReturnsFlashKeys()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->setFlashdata('foo', 'bar');
-        $session->set('bar', 'baz');
-
-        $keys = $session->getFlashKeys();
-
-        $this->assertContains('foo', $keys);
-        $this->assertNotContains('bar', $keys);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSetTempDataWorks()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $session->setTempdata('foo', 'bar', 300);
-        $this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSetTempDataArrayMultiTTL()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $time = time();
-
-        $session->setTempdata([
-            'foo' => 300,
-            'bar' => 400,
-            'baz' => 100
-        ]);
-
-        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 300);
-        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 400);
-        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSetTempDataArraySingleTTL()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $time = time();
-
-        $session->setTempdata(['foo', 'bar', 'baz'], null, 200);
-
-        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 200);
-        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 200);
-        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 200);
-    }
-
-    /**
-     * @group single
-     * @runInSeparateProcess
-     */
-    public function testGetTestDataReturnsAll()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $data = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $session->setTempdata($data);
-        $session->set('baz', 'ballywhoo');
-
-        $this->assertEquals($data, $session->getTempdata());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetTestDataReturnsSingle()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $data = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $session->setTempdata($data);
-
-        $this->assertEquals('bar', $session->getTempdata('foo'));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testRemoveTempDataActuallyDeletes()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $data = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $session->setTempdata($data);
-        $session->removeTempdata('foo');
-
-        $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testUnMarkTempDataSingle()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $data = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $session->setTempdata($data);
-        $session->unmarkTempdata('foo');
-
-        $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testUnMarkTempDataArray()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $data = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $session->setTempdata($data);
-        $session->unmarkTempdata(['foo', 'bar']);
-
-        $this->assertEquals([], $session->getTempdata());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetTempdataKeys()
-    {
-        $session = $this->getInstance();
-        $session->start();
-
-        $data = [
-            'foo' => 'bar',
-            'bar' => 'baz'
-        ];
-
-        $session->setTempdata($data);
-        $session->set('baz', 'ballywhoo');
-
-        $this->assertEquals(['foo', 'bar'], $session->getTempKeys());
-    }
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetAsProperty()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->set('foo', 'bar');
+
+		$this->assertEquals('bar', $session->foo);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetAsNormal()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->set('foo', 'bar');
+
+		$this->assertEquals('bar', $_SESSION['foo']);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testHasReturnsTrueOnSuccess()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$_SESSION['foo'] = 'bar';
+
+		$this->assertTrue($session->has('foo'));
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testHasReturnsFalseOnNotFound()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$_SESSION['foo'] = 'bar';
+
+		$this->assertFalse($session->has('bar'));
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testRemoveActuallyRemoves()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$_SESSION['foo'] = 'bar';
+		$session->remove('foo');
+
+		$this->assertArrayNotHasKey('foo', $_SESSION);
+		$this->assertFalse($session->has('foo'));
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testHasReturnsCanRemoveArray()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$_SESSION = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$this->assertTrue($session->has('foo'));
+
+		$session->remove(['foo', 'bar']);
+
+		$this->assertArrayNotHasKey('foo', $_SESSION);
+		$this->assertArrayNotHasKey('bar', $_SESSION);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testSetMagicMethod()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->foo = 'bar';
+
+		$this->assertArrayHasKey('foo', $_SESSION);
+		$this->assertEquals('bar', $_SESSION['foo']);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testCanFlashData()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->setFlashdata('foo', 'bar');
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+
+		// Should reset the 'new' to 'old'
+		$session->start();
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+
+		// Should no longer be available
+		$session->start();
+
+		$this->assertFalse($session->has('foo'));
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testCanFlashArray()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->setFlashdata([
+			'foo' => 'bar',
+			'bar' => 'baz'
+		]);
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+		$this->assertTrue($session->has('bar'));
+		$this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testKeepFlashData()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->setFlashdata('foo', 'bar');
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+
+		// Should reset the 'new' to 'old'
+		$session->start();
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+
+		$session->keepFlashdata('foo');
+
+		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+
+		// Should no longer be available
+		$session->start();
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testUnmarkFlashDataRemovesData()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->setFlashdata('foo', 'bar');
+		$session->set('bar', 'baz');
+
+		$this->assertTrue($session->has('foo'));
+		$this->assertArrayHasKey('foo', $_SESSION['__ci_vars']);
+
+		$session->unmarkFlashdata('foo');
+
+		// Should still be here
+		$this->assertTrue($session->has('foo'));
+		// but no longer marked as flash
+		$this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetFlashKeysOnlyReturnsFlashKeys()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->setFlashdata('foo', 'bar');
+		$session->set('bar', 'baz');
+
+		$keys = $session->getFlashKeys();
+
+		$this->assertContains('foo', $keys);
+		$this->assertNotContains('bar', $keys);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testSetTempDataWorks()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->setTempdata('foo', 'bar', 300);
+		$this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testSetTempDataArrayMultiTTL()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$time = time();
+
+		$session->setTempdata([
+			'foo' => 300,
+			'bar' => 400,
+			'baz' => 100
+		]);
+
+		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 300);
+		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 400);
+		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testSetTempDataArraySingleTTL()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$time = time();
+
+		$session->setTempdata(['foo', 'bar', 'baz'], null, 200);
+
+		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 200);
+		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 200);
+		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 200);
+	}
+
+	/**
+	 * @group single
+	 * @runInSeparateProcess
+	 */
+	public function testGetTestDataReturnsAll()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$data = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$session->setTempdata($data);
+		$session->set('baz', 'ballywhoo');
+
+		$this->assertEquals($data, $session->getTempdata());
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetTestDataReturnsSingle()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$data = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$session->setTempdata($data);
+
+		$this->assertEquals('bar', $session->getTempdata('foo'));
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testRemoveTempDataActuallyDeletes()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$data = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$session->setTempdata($data);
+		$session->removeTempdata('foo');
+
+		$this->assertEquals(['bar' => 'baz'], $session->getTempdata());
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testUnMarkTempDataSingle()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$data = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$session->setTempdata($data);
+		$session->unmarkTempdata('foo');
+
+		$this->assertEquals(['bar' => 'baz'], $session->getTempdata());
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testUnMarkTempDataArray()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$data = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$session->setTempdata($data);
+		$session->unmarkTempdata(['foo', 'bar']);
+
+		$this->assertEquals([], $session->getTempdata());
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetTempdataKeys()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$data = [
+			'foo' => 'bar',
+			'bar' => 'baz'
+		];
+
+		$session->setTempdata($data);
+		$session->set('baz', 'ballywhoo');
+
+		$this->assertEquals(['foo', 'bar'], $session->getTempKeys());
+	}
 }

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -7,131 +7,131 @@ use CodeIgniter\Session\Handlers\FileHandler;
 
 class SessionTest extends \CIUnitTestCase
 {
-	public function setUp()
-	{
-		parent::setUp();
+    public function setUp()
+    {
+        parent::setUp();
 
-		$_COOKIE = [];
-		$_SESSION = [];
-	}
+        $_COOKIE = [];
+        $_SESSION = [];
+    }
 
-	public function tearDown()
-	{
+    public function tearDown()
+    {
 
-	}
+    }
 
-	protected function getInstance($options = [])
-	{
-		$defaults = [
-			'sessionDriver' => 'CodeIgniter\Session\Handlers\FileHandler',
-			'sessionCookieName' => 'ci_session',
-			'sessionExpiration' => 7200,
-			'sessionSavePath' => null,
-			'sessionMatchIP' => false,
-			'sessionTimeToUpdate' => 300,
-			'sessionRegenerateDestroy' => false,
-			'cookieDomain' => '',
-			'cookiePrefix' => '',
-			'cookiePath' => '/',
-			'cookieSecure' => false,
-		];
+    protected function getInstance($options=[])
+    {
+        $defaults = [
+            'sessionDriver' => 'CodeIgniter\Session\Handlers\FileHandler',
+            'sessionCookieName' => 'ci_session',
+            'sessionExpiration' => 7200,
+            'sessionSavePath' => null,
+            'sessionMatchIP' => false,
+            'sessionTimeToUpdate' => 300,
+            'sessionRegenerateDestroy' => false,
+            'cookieDomain' => '',
+            'cookiePrefix' => '',
+            'cookiePath' => '/',
+            'cookieSecure' => false,
+        ];
 
-		$config = array_merge($defaults, $options);
-		$config = (object)$config;
+        $config = array_merge($defaults, $options);
+        $config = (object)$config;
 
-		$session = new MockSession(new FileHandler($config), $config);
-		$session->setLogger(new TestLogger(new Logger()));
+        $session = new MockSession(new FileHandler($config), $config);
+        $session->setLogger(new TestLogger(new Logger()));
 
-		return $session;
-	}
+        return $session;
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testSessionSetsRegenerateTime()
-	{
-		$session = $this->getInstance();
-		$session->start();
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionSetsRegenerateTime()
+    {
+        $session = $this->getInstance();
+        $session->start();
 
-		$this->assertTrue(isset($_SESSION['__ci_last_regenerate']) && !empty($_SESSION['__ci_last_regenerate']));
-	}
+        $this->assertTrue(isset($_SESSION['__ci_last_regenerate']) && ! empty($_SESSION['__ci_last_regenerate']));
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testWillRegenerateSessionAutomatically()
-	{
-		$session = $this->getInstance();
+    /**
+     * @runInSeparateProcess
+     */
+    public function testWillRegenerateSessionAutomatically()
+    {
+        $session = $this->getInstance();
 
-		$time = time() - 400;
-		$_SESSION['__ci_last_regenerate'] = $time;
-		$session->start();
+        $time = time()-400;
+        $_SESSION['__ci_last_regenerate'] = $time;
+        $session->start();
 
-		$this->assertTrue($session->didRegenerate);
-		$this->assertGreaterThan($time + 90, $_SESSION['__ci_last_regenerate']);
-	}
+        $this->assertTrue($session->didRegenerate);
+        $this->assertGreaterThan($time + 90 ,$_SESSION['__ci_last_regenerate']);
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testCanSetSingleValue()
-	{
-		$session = $this->getInstance();
-		$session->start();
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanSetSingleValue()
+    {
+        $session = $this->getInstance();
+        $session->start();
 
-		$session->set('foo', 'bar');
+        $session->set('foo', 'bar');
 
-		$this->assertEquals('bar', $_SESSION['foo']);
-	}
+        $this->assertEquals('bar', $_SESSION['foo']);
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testCanSetArray()
-	{
-		$session = $this->getInstance();
-		$session->start();
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanSetArray()
+    {
+        $session = $this->getInstance();
+        $session->start();
 
-		$session->set([
-			'foo' => 'bar',
-			'bar' => 'baz'
-		]);
+        $session->set([
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ]);
 
-		$this->assertEquals('bar', $_SESSION['foo']);
-		$this->assertEquals('baz', $_SESSION['bar']);
-		$this->assertArrayNotHasKey('__ci_vars', $_SESSION);
-	}
+        $this->assertEquals('bar', $_SESSION['foo']);
+        $this->assertEquals('baz', $_SESSION['bar']);
+        $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetSimpleKey()
-	{
-		$session = $this->getInstance();
-		$session->start();
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetSimpleKey()
+    {
+        $session = $this->getInstance();
+        $session->start();
 
-		$session->set('foo', 'bar');
+        $session->set('foo', 'bar');
 
-		$this->assertEquals('bar', $session->get('foo'));
-	}
+        $this->assertEquals('bar', $session->get('foo'));
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetReturnsNullWhenNotFound()
-	{
-		$_SESSION = [];
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetReturnsNullWhenNotFound()
+    {
+    	$_SESSION = [];
 
-		$session = $this->getInstance();
-		$session->start();
+        $session = $this->getInstance();
+        $session->start();
 
-		$this->assertNull($session->get('foo'));
-	}
+        $this->assertNull($session->get('foo'));
+    }
 
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetReturnsAllWithNoKeys()
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetReturnsAllWithNoKeys()
 	{
 		$_SESSION = [
 			'foo' => 'bar',
@@ -145,384 +145,384 @@ class SessionTest extends \CIUnitTestCase
 
 		$this->assertTrue(array_key_exists('foo', $result));
 		$this->assertTrue(array_key_exists('bar', $result));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetAsProperty()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->set('foo', 'bar');
-
-		$this->assertEquals('bar', $session->foo);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetAsNormal()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->set('foo', 'bar');
-
-		$this->assertEquals('bar', $_SESSION['foo']);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testHasReturnsTrueOnSuccess()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$_SESSION['foo'] = 'bar';
-
-		$this->assertTrue($session->has('foo'));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testHasReturnsFalseOnNotFound()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$_SESSION['foo'] = 'bar';
-
-		$this->assertFalse($session->has('bar'));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testRemoveActuallyRemoves()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$_SESSION['foo'] = 'bar';
-		$session->remove('foo');
-
-		$this->assertArrayNotHasKey('foo', $_SESSION);
-		$this->assertFalse($session->has('foo'));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testHasReturnsCanRemoveArray()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$_SESSION = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$this->assertTrue($session->has('foo'));
-
-		$session->remove(['foo', 'bar']);
-
-		$this->assertArrayNotHasKey('foo', $_SESSION);
-		$this->assertArrayNotHasKey('bar', $_SESSION);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testSetMagicMethod()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->foo = 'bar';
-
-		$this->assertArrayHasKey('foo', $_SESSION);
-		$this->assertEquals('bar', $_SESSION['foo']);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testCanFlashData()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->setFlashdata('foo', 'bar');
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-
-		// Should reset the 'new' to 'old'
-		$session->start();
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
-
-		// Should no longer be available
-		$session->start();
-
-		$this->assertFalse($session->has('foo'));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testCanFlashArray()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->setFlashdata([
-			'foo' => 'bar',
-			'bar' => 'baz'
-		]);
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-		$this->assertTrue($session->has('bar'));
-		$this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testKeepFlashData()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->setFlashdata('foo', 'bar');
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-
-		// Should reset the 'new' to 'old'
-		$session->start();
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
-
-		$session->keepFlashdata('foo');
-
-		$this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
-
-		// Should no longer be available
-		$session->start();
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testUnmarkFlashDataRemovesData()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->setFlashdata('foo', 'bar');
-		$session->set('bar', 'baz');
-
-		$this->assertTrue($session->has('foo'));
-		$this->assertArrayHasKey('foo', $_SESSION['__ci_vars']);
-
-		$session->unmarkFlashdata('foo');
-
-		// Should still be here
-		$this->assertTrue($session->has('foo'));
-		// but no longer marked as flash
-		$this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetFlashKeysOnlyReturnsFlashKeys()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->setFlashdata('foo', 'bar');
-		$session->set('bar', 'baz');
-
-		$keys = $session->getFlashKeys();
-
-		$this->assertContains('foo', $keys);
-		$this->assertNotContains('bar', $keys);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testSetTempDataWorks()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$session->setTempdata('foo', 'bar', 300);
-		$this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testSetTempDataArrayMultiTTL()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$time = time();
-
-		$session->setTempdata([
-			'foo' => 300,
-			'bar' => 400,
-			'baz' => 100
-		]);
-
-		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 300);
-		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 400);
-		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testSetTempDataArraySingleTTL()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$time = time();
-
-		$session->setTempdata(['foo', 'bar', 'baz'], null, 200);
-
-		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 200);
-		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 200);
-		$this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 200);
-	}
-
-	/**
-	 * @group single
-	 * @runInSeparateProcess
-	 */
-	public function testGetTestDataReturnsAll()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$data = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$session->setTempdata($data);
-		$session->set('baz', 'ballywhoo');
-
-		$this->assertEquals($data, $session->getTempdata());
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetTestDataReturnsSingle()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$data = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$session->setTempdata($data);
-
-		$this->assertEquals('bar', $session->getTempdata('foo'));
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testRemoveTempDataActuallyDeletes()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$data = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$session->setTempdata($data);
-		$session->removeTempdata('foo');
-
-		$this->assertEquals(['bar' => 'baz'], $session->getTempdata());
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testUnMarkTempDataSingle()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$data = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$session->setTempdata($data);
-		$session->unmarkTempdata('foo');
-
-		$this->assertEquals(['bar' => 'baz'], $session->getTempdata());
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testUnMarkTempDataArray()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$data = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$session->setTempdata($data);
-		$session->unmarkTempdata(['foo', 'bar']);
-
-		$this->assertEquals([], $session->getTempdata());
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetTempdataKeys()
-	{
-		$session = $this->getInstance();
-		$session->start();
-
-		$data = [
-			'foo' => 'bar',
-			'bar' => 'baz'
-		];
-
-		$session->setTempdata($data);
-		$session->set('baz', 'ballywhoo');
-
-		$this->assertEquals(['foo', 'bar'], $session->getTempKeys());
-	}
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetAsProperty()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->set('foo', 'bar');
+
+        $this->assertEquals('bar', $session->foo);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetAsNormal()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->set('foo', 'bar');
+
+        $this->assertEquals('bar', $_SESSION['foo']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testHasReturnsTrueOnSuccess()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $_SESSION['foo'] = 'bar';
+
+        $this->assertTrue($session->has('foo'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testHasReturnsFalseOnNotFound()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $_SESSION['foo'] = 'bar';
+
+        $this->assertFalse($session->has('bar'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRemoveActuallyRemoves()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $_SESSION['foo'] = 'bar';
+        $session->remove('foo');
+
+        $this->assertArrayNotHasKey('foo', $_SESSION);
+        $this->assertFalse($session->has('foo'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testHasReturnsCanRemoveArray()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $_SESSION = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $this->assertTrue($session->has('foo'));
+
+        $session->remove(['foo', 'bar']);
+
+        $this->assertArrayNotHasKey('foo', $_SESSION);
+        $this->assertArrayNotHasKey('bar', $_SESSION);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSetMagicMethod()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->foo = 'bar';
+
+        $this->assertArrayHasKey('foo', $_SESSION);
+        $this->assertEquals('bar', $_SESSION['foo']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanFlashData()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->setFlashdata('foo', 'bar');
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+
+        // Should reset the 'new' to 'old'
+        $session->start();
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+
+        // Should no longer be available
+        $session->start();
+
+        $this->assertFalse($session->has('foo'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanFlashArray()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->setFlashdata([
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ]);
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+        $this->assertTrue($session->has('bar'));
+        $this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testKeepFlashData()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->setFlashdata('foo', 'bar');
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+
+        // Should reset the 'new' to 'old'
+        $session->start();
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+
+        $session->keepFlashdata('foo');
+
+        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+
+        // Should no longer be available
+        $session->start();
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testUnmarkFlashDataRemovesData()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->setFlashdata('foo', 'bar');
+        $session->set('bar', 'baz');
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertArrayHasKey('foo', $_SESSION['__ci_vars']);
+
+        $session->unmarkFlashdata('foo');
+
+        // Should still be here
+        $this->assertTrue($session->has('foo'));
+        // but no longer marked as flash
+        $this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetFlashKeysOnlyReturnsFlashKeys()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->setFlashdata('foo', 'bar');
+        $session->set('bar', 'baz');
+
+        $keys = $session->getFlashKeys();
+
+        $this->assertContains('foo', $keys);
+        $this->assertNotContains('bar', $keys);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSetTempDataWorks()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->setTempdata('foo', 'bar', 300);
+        $this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSetTempDataArrayMultiTTL()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $time = time();
+
+        $session->setTempdata([
+            'foo' => 300,
+            'bar' => 400,
+            'baz' => 100
+        ]);
+
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 300);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 400);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSetTempDataArraySingleTTL()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $time = time();
+
+        $session->setTempdata(['foo', 'bar', 'baz'], null, 200);
+
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['foo'], $time + 200);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['bar'], $time + 200);
+        $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 200);
+    }
+
+    /**
+     * @group single
+     * @runInSeparateProcess
+     */
+    public function testGetTestDataReturnsAll()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $session->setTempdata($data);
+        $session->set('baz', 'ballywhoo');
+
+        $this->assertEquals($data, $session->getTempdata());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetTestDataReturnsSingle()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $session->setTempdata($data);
+
+        $this->assertEquals('bar', $session->getTempdata('foo'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRemoveTempDataActuallyDeletes()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $session->setTempdata($data);
+        $session->removeTempdata('foo');
+
+        $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testUnMarkTempDataSingle()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $session->setTempdata($data);
+        $session->unmarkTempdata('foo');
+
+        $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testUnMarkTempDataArray()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $session->setTempdata($data);
+        $session->unmarkTempdata(['foo', 'bar']);
+
+        $this->assertEquals([], $session->getTempdata());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetTempdataKeys()
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ];
+
+        $session->setTempdata($data);
+        $session->set('baz', 'ballywhoo');
+
+        $this->assertEquals(['foo', 'bar'], $session->getTempKeys());
+    }
 }

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -45,6 +45,9 @@ class SessionTest extends \CIUnitTestCase
         return $session;
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSessionSetsRegenerateTime()
     {
         $session = $this->getInstance();
@@ -53,6 +56,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertTrue(isset($_SESSION['__ci_last_regenerate']) && ! empty($_SESSION['__ci_last_regenerate']));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testWillRegenerateSessionAutomatically()
     {
         $session = $this->getInstance();
@@ -65,6 +71,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertGreaterThan($time + 90 ,$_SESSION['__ci_last_regenerate']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testCanSetSingleValue()
     {
         $session = $this->getInstance();
@@ -75,6 +84,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testCanSetArray()
     {
         $session = $this->getInstance();
@@ -90,6 +102,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetSimpleKey()
     {
         $session = $this->getInstance();
@@ -100,6 +115,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $session->get('foo'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetReturnsNullWhenNotFound()
     {
     	$_SESSION = [];
@@ -110,7 +128,10 @@ class SessionTest extends \CIUnitTestCase
         $this->assertNull($session->get('foo'));
     }
 
-	public function testGetReturnsAllWithNoKeys()
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetReturnsAllWithNoKeys()
 	{
 		$_SESSION = [
 			'foo' => 'bar',
@@ -126,8 +147,10 @@ class SessionTest extends \CIUnitTestCase
 		$this->assertTrue(array_key_exists('bar', $result));
     }
 
-
-	public function testGetAsProperty()
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetAsProperty()
     {
         $session = $this->getInstance();
         $session->start();
@@ -137,6 +160,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $session->foo);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetAsNormal()
     {
         $session = $this->getInstance();
@@ -147,6 +173,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testHasReturnsTrueOnSuccess()
     {
         $session = $this->getInstance();
@@ -157,6 +186,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertTrue($session->has('foo'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testHasReturnsFalseOnNotFound()
     {
         $session = $this->getInstance();
@@ -167,6 +199,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse($session->has('bar'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testRemoveActuallyRemoves()
     {
         $session = $this->getInstance();
@@ -179,6 +214,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse($session->has('foo'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testHasReturnsCanRemoveArray()
     {
         $session = $this->getInstance();
@@ -197,6 +235,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertArrayNotHasKey('bar', $_SESSION);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSetMagicMethod()
     {
         $session = $this->getInstance();
@@ -208,6 +249,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $_SESSION['foo']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testCanFlashData()
     {
         $session = $this->getInstance();
@@ -230,6 +274,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse($session->has('foo'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testCanFlashArray()
     {
         $session = $this->getInstance();
@@ -246,6 +293,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testKeepFlashData()
     {
         $session = $this->getInstance();
@@ -273,6 +323,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testUnmarkFlashDataRemovesData()
     {
         $session = $this->getInstance();
@@ -292,6 +345,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetFlashKeysOnlyReturnsFlashKeys()
     {
         $session = $this->getInstance();
@@ -306,6 +362,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertNotContains('bar', $keys);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSetTempDataWorks()
     {
         $session = $this->getInstance();
@@ -315,6 +374,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertGreaterThanOrEqual($_SESSION['__ci_vars']['foo'], time() + 300);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSetTempDataArrayMultiTTL()
     {
         $session = $this->getInstance();
@@ -333,6 +395,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertLessThanOrEqual($_SESSION['__ci_vars']['baz'], $time + 100);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSetTempDataArraySingleTTL()
     {
         $session = $this->getInstance();
@@ -349,6 +414,7 @@ class SessionTest extends \CIUnitTestCase
 
     /**
      * @group single
+     * @runInSeparateProcess
      */
     public function testGetTestDataReturnsAll()
     {
@@ -366,6 +432,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals($data, $session->getTempdata());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetTestDataReturnsSingle()
     {
         $session = $this->getInstance();
@@ -381,6 +450,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals('bar', $session->getTempdata('foo'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testRemoveTempDataActuallyDeletes()
     {
         $session = $this->getInstance();
@@ -397,6 +469,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testUnMarkTempDataSingle()
     {
         $session = $this->getInstance();
@@ -413,6 +488,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testUnMarkTempDataArray()
     {
         $session = $this->getInstance();
@@ -429,6 +507,9 @@ class SessionTest extends \CIUnitTestCase
         $this->assertEquals([], $session->getTempdata());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetTempdataKeys()
     {
         $session = $this->getInstance();


### PR DESCRIPTION
running phpunit tests in separate processes doesn't throw the error from #1106 anymore