### PR TITLE
Fixed problem that redirect does not work when placed in subdirectory.

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -568,8 +568,6 @@ class IncomingRequest extends Request
 	 */
 	protected function detectURI($protocol, $baseURL)
 	{
-		$this->uri->setPath($this->detectPath($protocol));
-
 		// It's possible the user forgot a trailing slash on their
 		// baseURL, so let's help them out.
 		$baseURL = ! empty($baseURL) ? rtrim($baseURL, '/ ') . '/' : $baseURL;
@@ -585,7 +583,7 @@ class IncomingRequest extends Request
 			$this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
 			$this->uri->setHost(parse_url($baseURL, PHP_URL_HOST));
 			$this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
-			$this->uri->resolveRelativeURI(parse_url($baseURL, PHP_URL_PATH));
+			$this->uri->setBasePath(parse_url($baseURL, PHP_URL_PATH));
 		} else
 		{
 			// @codeCoverageIgnoreStart
@@ -595,6 +593,9 @@ class IncomingRequest extends Request
 			}
 			// @codeCoverageIgnoreEnd
 		}
+
+		$path = $this->detectPath($protocol);
+		$this->uri->setPath($this->uri->trimBasePath($path));
 	}
 
 	//--------------------------------------------------------------------

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -114,6 +114,13 @@ class URI
 	protected $path;
 
 	/**
+	 * URI base path.
+	 *
+	 * @var string
+	 */
+	protected $basePath;
+
+	/**
 	 * The name of any fragment.
 	 *
 	 * @var
@@ -967,6 +974,34 @@ class URI
 		{
 			$this->segments = explode('/', trim($parts['path'], '/'));
 		}
+	}
+
+	/**
+	 * Set path that will not be changed.
+	 *
+	 * @param string $path
+	 */
+	public function setBasePath(string $path) : void
+	{
+		$this->basePath = rtrim($path, '/');
+	}
+
+	/**
+	 * trim basePath
+	 *
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	public function trimBasePath(string $path) : string
+	{
+		$path = '/'.ltrim($path, '/');
+		$base_path = $this->basePath ?? '';
+		if (strlen($base_path) && strpos($path, $base_path) === 0) {
+			return substr($path, strlen($base_path));
+		}
+
+		return $path;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -390,7 +390,7 @@ class URI
 	 */
 	public function getPath(): string
 	{
-		return (is_null($this->path)) ? '' : $this->path;
+		return (is_null($this->path)) ? '' : $this->basePath.$this->path;
 	}
 
 	//--------------------------------------------------------------------
@@ -1058,7 +1058,7 @@ class URI
 			{
 				if (strpos($relative->getPath(), '/') === 0)
 				{
-					$transformed->setPath($relative->getPath());
+					$transformed->setPath($this->basePath . $relative->getPath());
 				}
 				else
 				{


### PR DESCRIPTION
When I set CodeIgniter in the following URL, redirect expects the following behavior.

@link: #1126

### baseURL 

`http://example.com/path/to/codeigniter/`

### requestURL

`http://example.com/path/to/codeigniter/auth/index`

### Redirect expects

`redirect('/auth/login')` -> `http://example.com/path/to/codeigniter/auth/login`
`redirect('login')` -> `http://example.com/path/to/codeigniter/auth/login`

but, it became as follows.

### Redirect actual

`redirect('/auth/login')` -> `http://example.com/auth/login`🙅‍♂️
`redirect('login')` -> `http://example.com/path/to/codeigniter/auth/login`🙆‍♂️