### PR TITLE
Fixed insufficient validation of parameters related to pager.

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -999,7 +999,7 @@ class Model
 	public function paginate(int $perPage = 20, string $group = 'default')
 	{
 		// Get the necessary parts.
-		$page = isset($_GET['page']) && $_GET['page'] > 1 ? $_GET['page'] : 1;
+		$page = ctype_digit($_GET['page'] ?? '') && $_GET['page'] > 1 ? $_GET['page'] : 1;
 
 		$total = $this->countAllResults(false);
 


### PR DESCRIPTION
The following error occurred when I gave '2example' to GET parameter `page`.

```
ErrorException
A non well formed numeric value encountered.
```

Therefore, i changed code like do validation for number.