### PR TITLE
make name parameter in HTTP\Header mandatory

### DIFF
--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -64,12 +64,12 @@ class Header
 	//--------------------------------------------------------------------
 
 	/**
-	 * Header constructor. If a name or value is provided they will be set.
+	 * Header constructor. name is mandatory, if a value is provided, it will be set.
 	 *
-	 * @param string|null        $name
+	 * @param string             $name
 	 * @param string|array|null  $value
 	 */
-	public function __construct(string $name = null, $value = null)
+	public function __construct(string $name, $value = null)
 	{
 		$this->name = $name;
 		$this->value = $value;

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -33,12 +33,16 @@ class HeaderTest extends \CIUnitTestCase
 		$name  = 'foo';
 		$value = ['bar', 'baz'];
 
-		$header = new \CodeIgniter\HTTP\Header();
+                $header = new \CodeIgniter\HTTP\Header($name);
+                $this->assertEquals($name, $header->getName());
+                $this->assertEquals(null, $header->getValue());
+                $this->assertEquals($name . ': ', (string) $header);
 
+                $name = 'foo2';
 		$header->setName($name)->setValue($value);
-
 		$this->assertEquals($name, $header->getName());
 		$this->assertEquals($value, $header->getValue());
+                $this->assertEquals($name. ': bar, baz', (string) $header);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
if the name is not mandatory, when we create a `HTTP\Header` and call it as string from `__toString()`, we will get the ": " value, which seems incorrect as message header.