### PR TITLE
comparison fix at CIDatabaseTestCase

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -172,7 +172,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 
 				foreach ($tables as $table)
 				{
-					if ($table = $this->db->DBPrefix.'migrations') continue;
+					if ($table == $this->db->DBPrefix.'migrations') continue;
 
 					$forge->dropTable($table, true);
 				}


### PR DESCRIPTION
previously, it uses assignment which the DBPrefix concated with string "migrations", which if using truthy check, it will always evaluated as `true`, so continue always called at this case. changed `=` to `==`