### PR TITLE
Update Response.php

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -639,6 +639,8 @@ class Response extends Message implements ResponseInterface
 		if ($this->CSPEnabled === true)
 		{
 			$this->CSP->finalize($this);
+		}else{
+		    $this->body = preg_replace('/{csp-style-nonce}|{csp-script-nonce}/','', $this->body);
 		}
 
 		$this->sendHeaders();

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -640,7 +640,8 @@ class Response extends Message implements ResponseInterface
 		{
 			$this->CSP->finalize($this);
 		}else{
-		    $this->body = preg_replace('/{csp-style-nonce}|{csp-script-nonce}/','', $this->body);
+		    
+			$this->body = str_replace(['{csp-style-nonce}','{csp-script-nonce}'], '', $this->body);
 		}
 
 		$this->sendHeaders();


### PR DESCRIPTION
Remove {csp-style-nonce} from end page when CSP is not enabled. If page send to user contains {csp-style-nonce} or {csp-style-nonce} then it would not pass html check and says 'no value'.

Needs to check about performance because regex will runs to a whole views regardless of CSP setting.