### PR TITLE
Adjust log level to match RFC 5424

### DIFF
--- a/application/Config/Logger.php
+++ b/application/Config/Logger.php
@@ -18,15 +18,15 @@ class Logger extends BaseConfig
 	|	2 = Alert Messages      - Action Must Be Taken Immediately
 	|   3 = Critical Messages   - Application component unavailable, unexpected exception.
 	|   4 = Runtime Errors      - Don't need immediate action, but should be monitored.
-	|   5 = Debug               - Detailed debug information.
-	|   6 = Warnings            - Exceptional occurrences that are not errors.
-	|   7 = Notices             - Normal but significant events.
-	|   8 = Info                - Interesting events, like user logging in, etc.
+	|   5 = Warnings               - Exceptional occurrences that are not errors.
+	|   6 = Notices            - Normal but significant events.
+	|   7 = Info             - Interesting events, like user logging in, etc.
+	|   8 = Debug                - Detailed debug information.
 	|   9 = All Messages
 	|
 	| You can also pass an array with threshold levels to show individual error types
 	|
-	| 	array(1, 2, 3, 5) = Emergency, Alert, Critical, and Debug messages
+	| 	array(1, 2, 3, 8) = Emergency, Alert, Critical, and Debug messages
 	|
 	| For a live site you'll usually enable Critical or higher (3) to be logged otherwise
 	| your log files will fill up very fast.

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -73,10 +73,10 @@ class Logger implements LoggerInterface
 		'alert'		 => 2,
 		'critical'	 => 3,
 		'error'		 => 4,
-		'debug'		 => 5,
-		'warning'	 => 6,
-		'notice'	 => 7,
-		'info'		 => 8,
+		'warning'	 => 5,
+		'notice'	 => 6,
+		'info'	 	 => 7,
+		'debug'		 => 8,
 	];
 
 	/**

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -382,7 +382,7 @@ class LoggerTest extends \CIUnitTestCase
 		$config = new LoggerConfig();
 		$logger = new Logger($config);
 
-		$expected = 'DEBUG - ' . date('Y-m-d') . ' --> Test message';
+		$expected = 'WARNING - ' . date('Y-m-d') . ' --> Test message';
 
 		$logger->log(5, 'Test message');
 


### PR DESCRIPTION
Log level threshold is adjusted to match RFC 5424.
Set threshold to 'debug' level practically show 'all' debug messages. This usually the developer wants on debugging sessions