### PR TITLE
use string type hint in $file parameter in DotEnv::__construct()

### DIFF
--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -57,13 +57,8 @@ class DotEnv
 	 * @param string $path
 	 * @param string $file
 	 */
-	public function __construct(string $path, $file = '.env')
+	public function __construct(string $path, string $file = '.env')
 	{
-		if ( ! is_string($file))
-		{
-			$file = '.env';
-		}
-
 		$this->path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file;
 	}
 


### PR DESCRIPTION
so no need to check not string of $file which set value to its default value `.env'