### PR TITLE
remove start() call on session() function call at Validation

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -631,7 +631,7 @@ class Validation implements ValidationInterface
 			// Start up the session if it's not already
 			if ( ! isset($_SESSION))
 			{
-				session()->start();
+				session();
 			}
 
 			if ($errors = session('_ci_validation_errors'))


### PR DESCRIPTION
as the `session()` function is calling `\Config\Services::session()` which call `start()` when `session_status() == PHP_SESSION_NONE`