### PR TITLE
Catch Email Exceptions

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -188,7 +188,10 @@ class Services extends BaseService
 			$config = new \Config\Email();
 		}
 
-		return new \CodeIgniter\Email\Email($config);
+		$email = new \CodeIgniter\Email\Email($config);
+		$email->setLogger(self::logger(true));
+
+		return $email;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1924,13 +1924,13 @@ class Email
 		$method   = 'sendWith'.ucfirst($protocol);
 		try
 		{
-			$failed = $this->$method();
+			$success = $this->$method();
 		} catch(\ErrorException $e)
 		{
-			$failed = true;
+			$success = false;
 		}
 
-		if ($failed)
+		if (! $success)
 		{
 			$this->setErrorMessage(lang('email.sendFailure'.($protocol === 'mail' ? 'PHPMail' : ucfirst($protocol))));
 			return false;

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -38,8 +38,7 @@
  */
 
 use Config\Mimes;
-use Config\Services;
-
+use Psr\Log\LoggerAwareTrait;
 
 /**
  * CodeIgniter Email Class
@@ -54,6 +53,7 @@ use Config\Services;
  */
 class Email
 {
+	use LoggerAwareTrait;
 	/**
 	 * @var string
 	 */
@@ -387,6 +387,12 @@ class Email
 	 * @var bool
 	 */
 	protected static $func_overload;
+
+	/**
+	 * Logger instance to record error messages and awarnings.
+	 * @var \PSR\Log\LoggerInterface
+	 */
+	protected $logger;
 
 	//--------------------------------------------------------------------
 
@@ -1929,7 +1935,7 @@ class Email
 		} catch(\ErrorException $e)
 		{
 			$success = false;
-			Services::logger()->error('Email: '.$method.' throwed '.$e->getMessage());
+			$this->logger->error('Email: '.$method.' throwed '.$e->getMessage());
 		}
 
 		if (! $success)

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1922,10 +1922,17 @@ class Email
 
 		$protocol = $this->getProtocol();
 		$method   = 'sendWith'.ucfirst($protocol);
-		if (! $this->$method())
+		try
+		{
+			$failed = $this->$method();
+		} catch(\ErrorException $e)
+		{
+			$failed = true;
+		}
+
+		if ($failed)
 		{
 			$this->setErrorMessage(lang('email.sendFailure'.($protocol === 'mail' ? 'PHPMail' : ucfirst($protocol))));
-
 			return false;
 		}
 

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -38,6 +38,7 @@
  */
 
 use Config\Mimes;
+use Config\Services;
 
 
 /**
@@ -1928,6 +1929,7 @@ class Email
 		} catch(\ErrorException $e)
 		{
 			$success = false;
+			Services::logger()->error('Email: '.$method.' throwed '.$e->getMessage());
 		}
 
 		if (! $success)


### PR DESCRIPTION
catch exceptions that are thrown in the send mail function
-> caused by wrong/invalid mail config

Signed-off-by: Christoph Potas <christoph286@googlemail.com>