### PR TITLE
Fixes FileRules::max_size() to use file->getSize() instead of number_formatted size

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -115,7 +115,7 @@ class FileRules
 		{
 			return false;
 		}
-		return $params[0] >= $file->getSize('kb');
+		return $params[0] >= $file->getSize() / 1024;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -44,7 +44,16 @@ class FileRulesTest extends \CIUnitTestCase
 				'error'		 => 0,
 				'width'		 => 640,
 				'height'	 => 400,
-			]
+            ],
+            'bigfile' => [
+				'tmp_name'	 => TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+				'name'		 => 'my-big-file.png',
+				'size'		 => 1024000,
+				'type'		 => 'image/png',
+				'error'		 => 0,
+				'width'		 => 640,
+				'height'	 => 400,
+            ],
 		];
 	}
 
@@ -77,13 +86,31 @@ class FileRulesTest extends \CIUnitTestCase
 		]);
 
 		$this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMaxSizeBigFile()
+	{
+		$this->validation->setRules([
+			'bigfile' => "max_size[bigfile,9999]",
+		]);
+
+		$this->assertTrue($this->validation->run([]));
 	}
 
-	public function testMaxSizeFail()
-	{
+	   public function testMaxSizeFail()
+	   {
 		$this->validation->setRules([
 			'avatar' => "max_size[avatar,4]",
 		]);
+		$this->assertFalse($this->validation->run([]));
+       }
+
+       public function testMaxSizeBigFileFail()
+	{
+		$this->validation->setRules([
+			'bigfile' => "max_size[bigfile,10]",
+		]);
+
 		$this->assertFalse($this->validation->run([]));
 	}
 
@@ -205,5 +232,5 @@ class FileRulesTest extends \CIUnitTestCase
 		]);
 		$this->assertFalse($this->validation->run([]));
 	}
-	
+
 }


### PR DESCRIPTION
previously, it uses `$file->getSize('kb')` which got numbered format of size, which make it invalid for big file. Updated to `$file->getSize()/1024`, ref https://3v4l.org/7MuUB . Unit test included.