### PR TITLE
【Improvemented】 If you can not lock after getting ttl, you can not start the session using redis driver.

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -356,10 +356,13 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 				continue;
 			}
 
-			if ( ! $this->redis->setex($lock_key, 300, time()))
+			$result = ($ttl === -2)
+				? $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300))
+				: $this->_redis->setex($lock_key, 300, time());
+
+			if ( ! $result)
 			{
-				$this->logger->error('Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID);
-				return FALSE;
+				continue;
 			}
 
 			$this->lockKey = $lock_key;


### PR DESCRIPTION
This problem occurred frequently in applications where large amount of concurrent access at Ajax occurs.

session error occurs in setex when locked by another process after acquiring ttl.

setex is return false if the key exists.

Therefore, I thought that failure of lock should not be treated as an immediate error.

@see: https://github.com/bcit-ci/CodeIgniter/pull/5585