### PR TITLE
fix: Bug that can not split correctly when validation rule does not `regex_match`.

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -716,12 +716,14 @@ class Validation implements ValidationInterface
 				$separator = $rules[$open_bracket_pos + 1];
 
 				$regex_end_pos = strpos($rules, $separator . ']');
-				$_rules[] = substr($rules, 0, $regex_end_pos + 2);
+				if ($regex_end_pos !== false) {
+					$_rules[] = substr($rules, 0, $regex_end_pos + 2);
 
-				$rules = substr($rules, $regex_end_pos + 3);
+					$rules = substr($rules, $regex_end_pos + 3);
 
-				$pipe_pos = strpos($rules, '|');
-				continue;
+					$pipe_pos = strpos($rules, '|');
+					continue;
+				}
 			}
 
 			$_rules[] = substr($rules, 0, $pipe_pos);

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -503,6 +503,29 @@ class ValidationTest extends \CIUnitTestCase
 
 //--------------------------------------------------------------------
 
+	public function testSplitRuleNotRegexMatchTrue(){
+		$this->validation->setRules([
+			'number' => 'greater_than[10]|less_than[12]',
+		]);
+		$data = [
+			'number' => '11',
+		];
+
+		$result = $this->validation->run($data);
+		$this->assertTrue($result);
+	}
+
+	public function testSplitRuleNotRegexMatchFalse(){
+		$this->validation->setRules([
+			'number' => 'greater_than[10]|less_than[12]',
+		]);
+		$data = [
+			'number' => '16',
+		];
+
+		$result = $this->validation->run($data);
+		$this->assertFalse($result);
+	}
 
 	public function testSplitRulesTrue()
 	{


### PR DESCRIPTION
Based on documentation, it shown :

```php
$this->validate([
    'avatar' => 'uploaded[avatar]|max_size[avatar,1024]'
]);
```

It will get the following error:

```
CodeIgniter\Validation\Exceptions\ValidationException: up is not a valid rule.
```

@see: #1201