### PR TITLE
Validation Class - corresponding about the escaped separator.

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -720,10 +720,10 @@ class Validation implements ValidationInterface
 			{
 				$separator = $rules[$open_bracket_pos+1];
 
-				$regex_end_pos = strpos($rules, $separator.']');
-
-				if ($regex_end_pos !== false)
+				if (preg_match('/(?<!\\\\)(?:\\\\\\\\)*\\'.$separator.'\]/', $rules, $matches, PREG_OFFSET_CAPTURE))
 				{
+					$regex_end_pos = $matches[0][1];
+
 					$_rules[] = substr($rules, 0, $regex_end_pos+2);
 
 					$rules = substr($rules, $regex_end_pos+3);

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -545,4 +545,13 @@ class ValidationTest extends \CIUnitTestCase
 
 		$this->assertEquals('uploaded[avatar]', $result[0]);
 	}
+
+	public function testSplitRegex()
+	{
+		$method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+
+		$result = $method('required|regex_match[/^[0-9]{4}[\-\.\/][0-9]{2}[\-\.\/][0-9]{2}/]|max_length[10]');
+
+		$this->assertEquals('regex_match[/^[0-9]{4}[\-\.\/][0-9]{2}[\-\.\/][0-9]{2}/]', $result[1]);
+	}
 }


### PR DESCRIPTION
When writing the following rules, this program works as follows.

```php
$ this-> validate ([
    'date' => 'required|regex_match[/^[0-9]{4}[\-\.\/][0-9]{2}[\-\.\/][0-9]{2}/]|max_length[10]'
]);
```

validation rule is `regex_match[/^[0-9]{4}[\-\.\/]`.

but, expected validation rule is `regex_match[/^[0-9]{4}[\-\.\/][0-9]{2}[\-\.\/][0-9]{2}/]`.

Signed-off-by: ytetsuro <phper.0o0@gmail.com>

detail: https://github.com/bcit-ci/CodeIgniter4/pull/1202#issuecomment-418964824