### PR TITLE
Improved division logic of validation rules.

### DIFF
--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -550,8 +550,8 @@ class ValidationTest extends \CIUnitTestCase
 	{
 		$method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
 
-		$result = $method('required|regex_match[/^[0-9]{4}[\-\.\/][0-9]{2}[\-\.\/][0-9]{2}/]|max_length[10]');
+		$result = $method('required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]');
 
-		$this->assertEquals('regex_match[/^[0-9]{4}[\-\.\/][0-9]{2}[\-\.\/][0-9]{2}/]', $result[1]);
+		$this->assertEquals('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
 	}
 }


### PR DESCRIPTION
**Description**

Approach for solution to the problem reported in the comment
https://github.com/bcit-ci/CodeIgniter4/pull/1203#issuecomment-420878322

In order to solve this problem, we changed the division logic of verification so that it splits it with a pipe not in square brackets.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] ~~User guide updated~~
- [x] Conforms to style guide