### PR TITLE
doc fix: replace validation_errors() function with \Config\Services::validation()->listErrors()

### DIFF
--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -7,10 +7,6 @@ you haven't written any information to the database yet. In this section
 you'll expand your news controller and model created earlier to include
 this functionality.
 
-.. note:: This section of the tutorial cannot be completed as certain
-    portions of the framework, like the form helper and the validation
-    library have not been completed yet.
-
 Create a form
 -------------
 

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -24,7 +24,7 @@ the slug from our title in the model. Create the new view at
 
     <h2><?= esc($title); ?></h2>
 
-    <?= validation_errors(); ?>
+    <?= \Config\Services::validation()->listErrors(); ?>
 
     <?= form_open('news/create'); ?>
 
@@ -39,7 +39,7 @@ the slug from our title in the model. Create the new view at
     </form>
 
 There are only two things here that probably look unfamiliar to you: the
-``form_open()`` function and the ``validation_errors()`` function.
+``form_open()`` function and the ``\Config\Services::validation()->listErrors()`` function.
 
 The first function is provided by the :doc:`form
 helper <../helpers/form_helper>` and renders the form element and


### PR DESCRIPTION
**Checklist:**
- [x] Securely signed commits
- [x] User guide updated

as there is no `validation_errors()` function, and there is a `\Config\Services::validation()->listErrors()` for that.