### PR TITLE
Fix undefined variable "heading" in cli 404

### DIFF
--- a/application/Views/errors/cli/error_404.php
+++ b/application/Views/errors/cli/error_404.php
@@ -3,6 +3,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 use CodeIgniter\CLI\CLI;
 
-CLI::error('ERROR: '.$heading);
+CLI::error('ERROR: ' . $code);
 CLI::write($message);
 CLI::newLine();


### PR DESCRIPTION
Before:
-------

```bash
➜  CodeIgniter4 git:(develop) php public/index.php NotFound
PHP Fatal error:  Uncaught ErrorException: Undefined variable: heading in /Users/samsonasik/www/CodeIgniter4/application/Views/errors/cli/error_404.php:6
```

After:
------

```
➜  CodeIgniter4 git:(fix-undefined-var-heading-in-cli-404) php public/index.php NotFound
ERROR: 404
Controller or its method is not found: App\Controllers\NotFound::index
```