### PR TITLE
Make it so the trigger arguments are pass by reference

### DIFF
--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -162,12 +162,14 @@ class Events
 	 *  a) All subscribers have finished or
 	 *  b) a method returns false, at which point execution of subscribers stops.
 	 *
+	 * Note: All arguments are passed by reference. This is so the listeners can modify them if necessary.
+	 *
 	 * @param $eventName
 	 * @param $arguments
 	 *
 	 * @return bool
 	 */
-	public static function trigger($eventName, ...$arguments): bool
+	public static function trigger($eventName,&...$arguments): bool
 	{
 		// Read in our Config/events file so that we have them all!
 		if ( ! self::$initialized)


### PR DESCRIPTION
**Description**
Add & so that arguments are passed by references on a trigger call. This allow triggers down the priority "chain" to modify the arguments as needed.


**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide