### PR TITLE
correcting method to get the FCPATH in tests/_support/_bootstrap.php

### DIFF
--- a/tests/_support/_bootstrap.php
+++ b/tests/_support/_bootstrap.php
@@ -7,8 +7,8 @@ ini_set('display_startup_errors', '1');
 $_SERVER['CI_ENVIRONMENT'] = 'testing';
 define('ENVIRONMENT', 'testing');
 
-// Path to the front controller (this file)
-define('FCPATH', getcwd().'/public'.DIRECTORY_SEPARATOR);
+// path to the directory that holds the front controller (index.php)
+define('FCPATH', realpath(__DIR__.'/../../') . '/public'.DIRECTORY_SEPARATOR);
 
 // The path to the "tests" directory
 define('TESTPATH', realpath(__DIR__.'/../').'/');
@@ -24,5 +24,5 @@ if (! isset($_SERVER['app.baseURL']))
 //--------------------------------------------------------------------
 // Load our TestCase
 //--------------------------------------------------------------------
-
+require_once (TESTPATH . '/../vendor/autoload.php');
 require  __DIR__.'/CIUnitTestCase.php';

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BootstrapFCPATHTest
+ *
+ * This test confirms that the tests/_support/_bootstrap.php
+ * will set the correct FCPATH regardless of the current directory
+ *
+ * It writes a file in the temp directory that loads the bootstrap file
+ * then compares its echo FCPATH; to the correct FCPATH returned
+ * from correctFCPATH();
+ *
+ */
+class BootstrapFCPATHTest extends TestCase
+{
+	private $currentDir = __dir__;
+	private $dir1 = '/tmp/dir1';
+	private $file1 = '/tmp/dir1/testFile.php';
+
+	protected function setUp() {
+		parent::setUp();
+		$this->deleteFiles();
+		$this->deleteDirectories();
+		$this->buildDirectories();
+		$this->writeFiles();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$this->deleteFiles();
+		$this->deleteDirectories();
+	}
+
+	public function testSetFCPATH(){
+		$result1 = $this->readOutput($this->file1);
+		self::assertEquals($this->correctFCPATH(), $result1);
+	}
+
+	private function correctFCPATH(){
+		return realpath(__dir__ . '/../../../public') . DIRECTORY_SEPARATOR;
+	}
+
+	private function buildDirectories() : void
+	{
+		mkdir( $this->dir1 , 0777, TRUE);
+	}
+
+
+	private function deleteDirectories() : void
+	{
+		// these need to be executed in reverse order: dir 2 in inside dir1
+		if(is_dir($this->dir1)){
+			rmdir( $this->dir1 );
+		}
+	}
+
+	private function writeFiles() : void
+	{
+		file_put_contents( $this->file1 , $this->fileContents());
+		chmod($this->file1, 0777);
+
+	}
+
+	private function deleteFiles() : void
+	{
+		if(file_exists($this->file1)){
+			unlink( $this->file1 );
+		}
+	}
+
+	private function fileContents(){
+
+		$fileContents = '';
+		$fileContents .= '<?php' . PHP_EOL;
+		$fileContents .= "include_once '" . $this->currentDir . "' . '/../../../tests/_support/_bootstrap.php';". PHP_EOL;
+		$fileContents .= '// return value of FCPATH'. PHP_EOL;
+		$fileContents .= 'echo FCPATH;'. PHP_EOL;
+
+		return $fileContents;
+
+	}
+
+	private function readOutput($file){
+		return  system('php -f ' . $file);
+	}
+
+
+}


### PR DESCRIPTION
**Description**

When running tests directly from a different directory (using PHPStorm or phpUnit.phar ) the FCPATH was being set incorrectly: it was using the working directory of the test file instead of the relative path to the _bootstrap.php file.

Changed the method to get the FCPATH from getcwd() to realpath():  
* Matches the format of the other path definitions in this file 
* sets the path relative to _bootstrap.php

The code change is pretty straightforward, the test file proves the change: fail on the old and pass on the new. You may not want to include the test file in the code base because it is fairly complex and would be unnecessary after the code change was made.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide