### PR TITLE
Refactor TimeTest

### DIFF
--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -25,7 +25,7 @@ class TimeTest extends \CIUnitTestCase
 
 		$time = new Time(null, 'America/Chicago');
 
-		$this->assertEquals($formatter->format(strtotime('now')), (string)$time);
+		$this->assertEquals($formatter->format($time), (string)$time);
 	}
 
 	public function testTimeWithTimezone()
@@ -41,7 +41,7 @@ class TimeTest extends \CIUnitTestCase
 
 		$time = new Time('now', 'Europe/London');
 
-		$this->assertEquals($formatter->format(strtotime('now')), (string)$time);
+		$this->assertEquals($formatter->format($time), (string)$time);
 	}
 
 	public function testTimeWithTimezoneAndLocale()
@@ -57,7 +57,7 @@ class TimeTest extends \CIUnitTestCase
 
 		$time = new Time('now', 'Europe/London', 'fr_FR');
 
-		$this->assertEquals($formatter->format(strtotime('now')), (string)$time);
+		$this->assertEquals($formatter->format($time), (string)$time);
 	}
 
 	public function testTimeWithDateTimeZone()
@@ -73,7 +73,7 @@ class TimeTest extends \CIUnitTestCase
 
 		$time = new Time('now', new \DateTimeZone('Europe/London'), 'fr_FR');
 
-		$this->assertEquals($formatter->format(strtotime('now')), (string)$time);
+		$this->assertEquals($formatter->format($time), (string)$time);
 	}
 
 	public function testToDateTime()


### PR DESCRIPTION
Updated the first four test cases to use the same $time object, since they are comparing formatted results, not specific time instances.
This should eliminate most of the travis-ci failures because of a 1 second tie difference.

TimeTest::testTestNow() may still have an occasional issue, because its two time objects could still be off.