### PR TITLE
Fix doc error : show_404() doesn't exist any more

### DIFF
--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -189,7 +189,7 @@ Example::
 		{
 			return $this->$method(...$params);
 		}
-		show_404();
+		throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
 	}
 
 Private methods


### PR DESCRIPTION
Fix doc error
show_404() doesn't exist any more