### PR TITLE
FIX   form_hidden and form_open - value escaping as is in form_input.

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -92,7 +92,7 @@ if ( ! function_exists('form_open'))
 		{
 			foreach ($hidden as $name => $value)
 			{
-				$form .= '<input type="hidden" name="' . $name . '" value="' . $value . '" style="display: none;" />' . "\n";
+				$form .= '<input type="hidden" name="' . $name . '" value="' . esc($value,'html') . '" style="display: none;" />' . "\n";
 			}
 		}
 
@@ -171,7 +171,7 @@ if ( ! function_exists('form_hidden'))
 
 		if ( ! is_array($value))
 		{
-			$form .= '<input type="hidden" name="' . $name . '" value="' . $value . "\" />\n";
+			$form .= '<input type="hidden" name="' . $name . '" value="' . esc($value,'html') . "\" />\n";
 		}
 		else
 		{


### PR DESCRIPTION
When string contains quotes i.e. json or serialized object was passed as  $hidden => form_open or as a $value => form_hidden it wasn't escaped properly.

i.e.:   form_hidden('aaa', '{"foo":"bar"}')  wasn't work
