### PR TITLE
Toolbar Styles

### DIFF
--- a/application/Views/welcome_message.php
+++ b/application/Views/welcome_message.php
@@ -124,7 +124,7 @@
 				</pre>
 
 				<p>If you are exploring CodeIgniter for the very first time, you
-					should start by reading the (in progress)
+					should start by reading the
 					<a href="https://bcit-ci.github.io/CodeIgniter4">User Guide</a>.</p>
 
 			</div>

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -26,6 +26,7 @@
 #debug-bar {
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 16px;
+	font-weight: 400;
 	line-height: 36px;
 	background: #fff;
 	position: fixed;
@@ -93,7 +94,7 @@
 #debug-bar h1 {
 	font-size: 16px;
 	line-height: 36px;
-	font-weight: 300;
+	font-weight: 500;
 	margin: 0 16px 0 0;
 	padding: 0;
 	text-align: left;
@@ -118,7 +119,7 @@
 
 #debug-bar h2 {
 	font-size: 16px;
-	font-weight: 300;
+	font-weight: 500;
 	margin: 0;
 	padding: 0;
 }
@@ -214,6 +215,7 @@
 	padding: 0 10px;
 	color: inherit;
 	text-decoration: none;
+	letter-spacing: normal;
 }
 
 #debug-bar .ci-label.active {
@@ -246,7 +248,7 @@
 
 #debug-bar table {
 	margin: 0 0 10px 20px;
-	font-size: 13px;
+	font-size: 0.9rem;
 	border-collapse: collapse;
 	width: 100%;
 }
@@ -263,7 +265,7 @@
 
 #debug-bar td {
 	border: none;
-	padding: 2px 10px 2px 5px;
+	padding: 0 10px 0 5px;
 	margin: 0;
 }
 
@@ -272,7 +274,7 @@
 }
 
 #debug-bar tr td:first-child {
-	width: 20%;
+	max-width: 20%;
 }
 
 #debug-bar tr td:first-child.narrow {
@@ -315,9 +317,9 @@
 #debug-bar table.timeline .timer {
 	position: absolute;
 	display: inline-block;
-	padding: 3px;
-	bottom: 9px;
-	border-radius: 3px;
+	padding: 5px;
+	top: 40%;
+	border-radius: 4px;
 	background-color: #999;
 }
 


### PR DESCRIPTION
- Improved readability of fonts in general by ensuring they were slightly larger and a bit heavier for better contrast.
- Fixed spacing of version number on right of toolbar
- reduced padding around table rows to fit a bit more per "page"
- removed the `(in progress)` text from the Welcome page. 