### PR TITLE
Avoid add two single quote to constratin.

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -951,7 +951,7 @@ class Forge
 				{
 					case 'ENUM':
 					case 'SET':
-						$attributes['CONSTRAINT'] = $this->db->escape($attributes['CONSTRAINT']);
+						$attributes['CONSTRAINT'] = $this->db->escapeString($attributes['CONSTRAINT']);
 						$field['length']          = is_array($attributes['CONSTRAINT']) ? "('".implode("','",
 								$attributes['CONSTRAINT'])."')" : '('.$attributes['CONSTRAINT'].')';
 						break;

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -87,6 +87,21 @@ class Forge extends \CodeIgniter\Database\Forge
 	];
 
 	/**
+	 * Table Options list which required to be quoted
+	 * 
+	 * @var    array
+	 */
+	protected $_quoted_table_options = [
+		'COMMENT',
+		'COMPRESSION',
+		'CONNECTION',
+		'DATA DIRECTORY',
+		'INDEX DIRECTORY',
+		'ENCRYPTION',
+		'PASSWORD',
+	];
+
+	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
 	 *
 	 * @var    string
@@ -109,18 +124,27 @@ class Forge extends \CodeIgniter\Database\Forge
 		{
 			if (is_string($key))
 			{
-				$sql .= ' ' . strtoupper($key) . ' = ' . $this->db->escape($attributes[$key]);
+				$sql .= ' ' . strtoupper($key) . ' = ';
+				
+				if (in_array(strtoupper($key), $this->_quoted_table_options))
+				{
+					$sql .= $this->db->escape($attributes[$key]);
+				}
+				else
+				{
+					$sql .= $this->db->escapeString($attributes[$key]);
+				}
 			}
 		}
 
 		if ( ! empty($this->db->charset) && ! strpos($sql, 'CHARACTER SET') && ! strpos($sql, 'CHARSET'))
 		{
-			$sql .= ' DEFAULT CHARACTER SET = ' . $this->db->escape($this->db->charset);
+			$sql .= ' DEFAULT CHARACTER SET = ' . $this->db->escapeString($this->db->charset);
 		}
 
 		if ( ! empty($this->db->DBCollat) && ! strpos($sql, 'COLLATE'))
 		{
-			$sql .= ' COLLATE = ' . $this->db->escape($this->db->DBCollat);
+			$sql .= ' COLLATE = ' . $this->db->escapeString($this->db->DBCollat);
 		}
 
 		return $sql;


### PR DESCRIPTION
**Description**
When using Forge to create database table and create a ENUM type field, it should only use one single quote to quote the constraint.

In previous code, the `$this->db->escape($attributes['CONSTRAINT'])` had add a single quote, and the following implode add another single quote, cause an invalid SQL code.

**Checklist:**
- [ No ] Securely signed commits
- [ N/A ] Component(s) with PHPdocs
- [ Maybe ] Unit testing, with >80% coverage
- [ N/A ] User guide updated
- [ Y ] Conforms to style guide
