### PR TITLE
Update template file is not .php compatibility

### DIFF
--- a/system/Commands/Sessions/CreateMigration.php
+++ b/system/Commands/Sessions/CreateMigration.php
@@ -115,7 +115,7 @@ class CreateMigration extends BaseCommand
 			'matchIP'	 => $config->sessionMatchIP ?? false,
 		];
 
-		$template = view('\CodeIgniter\Commands\Sessions\Views\migration.tpl', $data, ['debug' => false]);
+		$template = view('\CodeIgniter\Commands\Sessions\Views\migration.tpl.php', $data, ['debug' => false]);
 		$template = str_replace('@php', '<?php', $template);
 
 		// Write the file out.

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -188,7 +188,7 @@ class View implements RendererInterface
 
 		if ( ! file_exists($this->renderVars['file']))
 		{
-			$this->renderVars['file'] = $this->loader->locateFile($this->renderVars['view'], 'Views');
+			$this->renderVars['file'] = $this->loader->locateFile($this->renderVars['view'], 'Views', empty($fileExt) ? 'php' : $fileExt);
 		}
 
 		// locateFile will return an empty string if the file cannot be found.


### PR DESCRIPTION
Update template file is not .php compatibility

**Description**
If the template I am using is not a .php file and I use the default path configuration, the system will not work. 
In the `locateFile()` method, the template file path will be forced to add `.php`
So it will cause the system to not find the template file.
An exception that cannot be found in a file will be reported.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

