### PR TITLE
rm --cached php_errors.log file

### DIFF
--- a/php_errors.log
+++ b/php_errors.log
@@ -1,1 +1,0 @@
-[30-Jan-2018 23:57:36 America/Chicago] PHP Fatal error:  Class 'z' not found in /Users/kilishan/WebSites/CodeIgniter4/tests/system/Validation/RulesTest.php on line 5


### PR DESCRIPTION
The `php_errors.log` file is ignored in `.gitignore` but seems was not deleted which may caused by overlap register it to `.gitignore`. I applied `git rm --cached php_errors.log` to it to remove it completely from the repo.