### PR TITLE
Add timing assertion to CIUnitTestCase

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -139,7 +139,7 @@ class CIUnitTestCase extends TestCase
 				break;
 		}
 
-		$this->assertTrue($found,"Didn't find header for {$header}");
+		$this->assertTrue($found, "Didn't find header for {$header}");
 	}
 
 	/**
@@ -165,7 +165,27 @@ class CIUnitTestCase extends TestCase
 		}
 
 		$success = ! $found;
-		$this->assertTrue($success,"Found header for {$header}");
+		$this->assertTrue($success, "Found header for {$header}");
+	}
+
+	/**
+	 * Custom function to test that two values are "close enough".
+	 * This is intended for extended execution time testing,
+	 * where the result is close but not exactly equal to the
+	 * expected time, for reasons beyond our control.
+	 *
+	 * @param int $expected
+	 * @param mixed $actual
+	 * @param string   $message
+	 * @param int $tolerance
+	 *
+	 * @throws \Exception
+	 */
+	public function assertCloseEnough(int $expected, $actual, string $message = '', int $tolerance = 1)
+	{
+		$difference = abs($expected - (int) floor($actual));
+
+		$this->assertLessThanOrEqual($tolerance, $difference, $message);
 	}
 
 	/**

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -93,21 +93,17 @@ class TimerTest extends \CIUnitTestCase
 	public function testLongExecutionTime()
 	{
 		$timer = new Timer();
-
 		$timer->start('longjohn', strtotime('-11 minutes'));
-
-		// Use floor here to account for fractional differences in seconds.
-		$this->assertEquals(11 * 60, (int) floor($timer->getElapsedTime('longjohn')));
+		$this->assertCloseEnough(11 * 60, $timer->getElapsedTime('longjohn'));
 	}
 
 	//--------------------------------------------------------------------
 
 	public function testLongExecutionTimeThroughCommonFunc()
 	{
-		timer()->start('longjohn', strtotime('-11 minutes'));
-
-		// Use floor here to account for fractional differences in seconds.
-		$this->assertEquals(11 * 60, (int) floor(timer()->getElapsedTime('longjohn')));
+		$timer = new Timer();
+		$timer->start('longjohn', strtotime('-11 minutes'));
+		$this->assertCloseEnough(11 * 60, $timer->getElapsedTime('longjohn'));
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -71,7 +71,7 @@ system /
     - Router/
         - RouteCollection #1285, #1355
     - Test/
-        - CIUnitTestCase #1312
+        - CIUnitTestCase #1312, #1361
         - FeatureTestCase #1282
     - CodeIgniter #1239 #1337
     - Common #1291
@@ -154,6 +154,7 @@ user_guide_src /source/
 PRs merged:
 -----------
 
+- #1361 Add timing assertion to CIUnitTestCase
 - #1312 Add headerEmitted assertions to CIUnitTestCase
 - #1356 Testing/commands
 - #1355 Handle duplicate HTTP verb and generic rules properly

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -143,6 +143,17 @@ Ensure that a header or cookie was actually emitted::
 Note: the test case with this should be `run as a separate process
 in PHPunit <https://phpunit.readthedocs.io/en/7.4/annotations.html#runinseparateprocess>`_.
 
+**assertCloseEnough($expected, $actual, $message='', $tolerance=1)**
+
+For extended execution time testing, tests that the absolute difference
+between expected and actual time is within the prescribed tolerance.::
+
+    $timer = new Timer();
+    $timer->start('longjohn', strtotime('-11 minutes'));
+    $this->assertCloseEnough(11 * 60, $timer->getElapsedTime('longjohn'));
+
+The above test will allow the actual time to be either 600 or 601 seconds.
+
 Accessing Protected/Private Properties
 --------------------------------------
 


### PR DESCRIPTION
Tired of tweaking the long execution time tests, I have added a new assertCloseEnough assertion to CIUnitTestCase ;P