### PR TITLE
Validation - is_unique_empty rule

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -174,6 +174,29 @@ class Rules
 	}
 
 	//--------------------------------------------------------------------
+	
+	/**
+	 * Checks the database to see if the given value is unique or empty.
+	 *
+	 * Example:
+	 *    is_unique_empty[table.field,ignore_field,ignore_value]
+	 *    is_unique_empty[users.email,id,5]
+	 *
+	 * @param string $str
+	 * @param string $field
+	 * @param array  $data
+	 *
+	 * @return bool
+	 */
+	public function is_unique_empty(string $str = null, string $field, array $data): bool
+	{
+		if(is_null($str) || $str == '')
+			return true;
+
+		return $this->is_unique($str, $field, $data);
+	}
+	
+	//--------------------------------------------------------------------
 
 	/**
 	 * Less than

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -668,6 +668,8 @@ required_with           Yes         The field is required if any of the fields i
 required_without        Yes         The field is required when any of the fields in the parameter are not set.                      required_without[field1,field2]
 is_unique               Yes         Checks if this field value exists in the database. Optionally set a                             is_unique[table.field,ignore_field,ignore_value]
                                     column and value to ignore, useful when updating records to ignore itself.
+is_unique_empty         Yes         Checks if this field value is empty (null or empty string) or exists in the database.           is_unique_empty[table.field,ignore_field,ignore_value]
+                                    Optionally set a column and value to ignore, useful when updating records to ignore itself.
 timezone                No          Fails if field does match a timezone per ``timezone_identifiers_list``
 valid_base64            No          Fails if field contains anything other than valid Base64 characters.
 valid_json              No          Fails if field does not contain a valid JSON string.


### PR DESCRIPTION
New Validation rule is_unique_empty - value should be unique in db (as is in is_unique) or empty (is_null($value) || $value == '')
