### PR TITLE
Toolbar needs logging. Fixes #1258

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -79,7 +79,8 @@ class Toolbar
 		{
 			if (! class_exists($collector))
 			{
-				// @todo Log this!
+				log_message('critical', 'Toolbar collector does not exists(' . $collector . ').'.
+                                        'please check $toolbarCollectors in the Config\App.php file.');
 				continue;
 			}
 


### PR DESCRIPTION
**Description**
Toolbar collector does not exists. log file is show they had a wrong classname.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide