### PR TITLE
【Unsolicited PR】Give download a header conforming to RFC 6266

### DIFF
--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -288,7 +288,9 @@ class DownloadResponse extends Message implements ResponseInterface
 
 		$this->removeHeader('Content-Type'); // replace existing content type
 		$this->setHeader('Content-Type', $mime);
-		$this->charset = $charset;
+		if (!empty($charset)) {
+			$this->charset = $charset;
+		}
 
 		return $this;
 	}

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -210,7 +210,21 @@ class DownloadResponse extends Message implements ResponseInterface
 	 */
 	private function getContentDisponsition() : string
 	{
-		return sprintf('attachment; filename="%s"', $this->getDownloadFileName());
+		$download_filename = $this->getDownloadFileName();
+
+		$utf8_filename = $download_filename;
+
+		if (strtoupper($this->charset) !== 'UTF-8') {
+			$utf8_filename = mb_convert_encoding($download_filename, 'UTF-8', $this->charset);
+		}
+
+		$result = sprintf('attachment; filename="%s"', $download_filename);
+
+		if (isset($utf8_filename)) {
+			$result .= '; filename*=UTF-8\'\''.rawurlencode($utf8_filename);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -288,7 +288,7 @@ class DownloadResponse extends Message implements ResponseInterface
 
 		$this->removeHeader('Content-Type'); // replace existing content type
 		$this->setHeader('Content-Type', $mime);
-		if (!empty($charset)) {
+		if ( ! empty($charset)) {
 			$this->charset = $charset;
 		}
 

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -184,6 +184,17 @@ class DownloadResponseTest extends \CIUnitTestCase
 		$this->assertEquals(filesize(__FILE__), $response->getHeaderLine('Content-Length'));
 	}
 
+	public function testIfTheCharacterCodeIsOtherThanUtf8ReplaceItWithUtf8AndRawurlencode()
+	{
+		$response = new DownloadResponse(mb_convert_encoding('テスト.php', 'Shift-JIS', 'UTF-8'), false);
+
+		$response->setFilePath(__FILE__);
+		$response->setContentType('application/octet-stream', 'Shift-JIS');
+		$response->buildHeaders();
+
+		$this->assertEquals('attachment; filename="'.mb_convert_encoding('テスト.php', 'Shift-JIS', 'UTF-8').'"; filename*=UTF-8\'\'%E3%83%86%E3%82%B9%E3%83%88.php', $response->getHeaderLine('Content-Disposition'));
+	}
+
 	public function testFileExtensionIsUpperCaseWhenAndroidOSIs2()
 	{
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Linux; U; Android 2.0.3; ja-jp; SC-02C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30';

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -158,13 +158,13 @@ class DownloadResponseTest extends \CIUnitTestCase
 
 	public function testIsSetDownloadableHeadlersFromBinary()
 	{
-		$response = new DownloadResponse('unit-test.txt', false);
+		$response = new DownloadResponse('unit test.txt', false);
 
 		$response->setBinary('test');
 		$response->buildHeaders();
 
 		$this->assertEquals('application/octet-stream', $response->getHeaderLine('Content-Type'));
-		$this->assertEquals('attachment; filename="unit-test.txt"', $response->getHeaderLine('Content-Disposition'));
+		$this->assertEquals('attachment; filename="unit test.txt"; filename*=UTF-8\'\'unit%20test.txt', $response->getHeaderLine('Content-Disposition'));
 		$this->assertEquals('0', $response->getHeaderLine('Expires-Disposition'));
 		$this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
 		$this->assertEquals('4', $response->getHeaderLine('Content-Length'));
@@ -178,7 +178,7 @@ class DownloadResponseTest extends \CIUnitTestCase
 		$response->buildHeaders();
 
 		$this->assertEquals('application/octet-stream', $response->getHeaderLine('Content-Type'));
-		$this->assertEquals('attachment; filename="unit-test.php"', $response->getHeaderLine('Content-Disposition'));
+		$this->assertEquals('attachment; filename="unit-test.php"; filename*=UTF-8\'\'unit-test.php', $response->getHeaderLine('Content-Disposition'));
 		$this->assertEquals('0', $response->getHeaderLine('Expires-Disposition'));
 		$this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
 		$this->assertEquals(filesize(__FILE__), $response->getHeaderLine('Content-Length'));
@@ -192,7 +192,7 @@ class DownloadResponseTest extends \CIUnitTestCase
 		$response->setFilePath(__FILE__);
 		$response->buildHeaders();
 
-		$this->assertEquals('attachment; filename="unit-test.PHP"', $response->getHeaderLine('Content-Disposition'));
+		$this->assertEquals('attachment; filename="unit-test.PHP"; filename*=UTF-8\'\'unit-test.PHP', $response->getHeaderLine('Content-Disposition'));
 	}
 
 	public function testIsSetContentTypeFromFilename()

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -328,7 +328,7 @@ class ResponseTest extends \CIUnitTestCase
 
 		$this->assertInstanceOf(DownloadResponse::class, $actual);
 		$actual->buildHeaders();
-		$this->assertSame('attachment; filename="unit-test.txt"', $actual->getHeaderLine('Content-Disposition'));
+		$this->assertSame('attachment; filename="unit-test.txt"; filename*=UTF-8\'\'unit-test.txt', $actual->getHeaderLine('Content-Disposition'));
 
 		ob_start();
 		$actual->sendBody();
@@ -346,7 +346,7 @@ class ResponseTest extends \CIUnitTestCase
 
 		$this->assertInstanceOf(DownloadResponse::class, $actual);
 		$actual->buildHeaders();
-		$this->assertSame('attachment; filename="'.basename(__FILE__).'"', $actual->getHeaderLine('Content-Disposition'));
+		$this->assertSame('attachment; filename="'.basename(__FILE__).'"; filename*=UTF-8\'\''.basename(__FILE__), $actual->getHeaderLine('Content-Disposition'));
 
 		ob_start();
 		$actual->sendBody();


### PR DESCRIPTION
**Description**

When I created an application to download multibyte file name, the file name got corrupted.

Changed give download proccess a header conforming to "RFC6266"

The phenomenon that the file name is garbled can be confirmed with Internet Explorer 11 older.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
