### PR TITLE
fix. extend namespace

### DIFF
--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -30,7 +30,7 @@ code.
 ::
 
 	<?php namespace App\Controllers;
-	class Pages extends CodeIgniter\Controller {
+	class Pages extends \CodeIgniter\Controller {
 
 		public function view($page = 'home')
 		{


### PR DESCRIPTION
**Description**
`Pages extends CodeIgniter\Controller` replace to `Pages extends \CodeIgniter\Controller`
`CodeIgniter\Controller` class in root namespace

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

