### PR TITLE
Redirect to named route

### DIFF
--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -87,7 +87,7 @@ class RedirectResponse extends Response
 			throw HTTPException::forInvalidRedirectRoute($route);
 		}
 
-		return $this->redirect( config( App::class )->baseURL.rtrim( $route, '\\' ), $method, $code);
+		return $this->redirect(base_url($route), $method, $code);
 	}
 
 	/**

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -54,6 +54,13 @@ class RedirectResponseTest extends \CIUnitTestCase
 
 		$this->assertTrue($response->hasHeader('Location'));
 		$this->assertEquals('http://example.com/exampleRoute', $response->getHeaderLine('Location'));
+
+		$this->routes->add('exampleRoute', 'Home::index', ['as' => 'home']);
+
+		$response->route('home');
+
+		$this->assertTrue($response->hasHeader('Location'));
+		$this->assertEquals('http://example.com/exampleRoute', $response->getHeaderLine('Location'));
 	}
 
 	public function testRedirectRouteBad()


### PR DESCRIPTION
**Description**

The following code:

```php
return redirect()->route('access');
```

was redirecting to `http://localhost:8080//access` (note the two slashes).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
