### PR TITLE
Phpcs Auto-fix on commit

### DIFF
--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+PROJECT=`php -r "echo dirname(dirname(dirname(realpath('$0'))));"`
+STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+
+# Determine if a file list is passed
+if [ "$#" -eq 1 ]
+then
+	oIFS=$IFS
+	IFS='
+	'
+	SFILES="$1"
+	IFS=$oIFS
+fi
+SFILES=${SFILES:-$STAGED_FILES_CMD}
+
+echo "Checking PHP Lint..."
+for FILE in $SFILES
+do
+	php -l -d display_errors=0 $PROJECT/$FILE
+	if [ $? != 0 ]
+	then
+		echo "Fix the error before commit."
+		exit 1
+	fi
+	FILES="$FILES $PROJECT/$FILE"
+done
+
+if [ "$FILES" != "" ]
+then
+	echo "Fixing formatting with Code Sniffer..."
+	./vendor/bin/phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 --encoding=utf-8 -n -p $FILES
+	if [ $? != 0 ]
+	then
+		echo "Fix the error before commit."
+		exit 1
+	fi
+fi
+
+exit $?

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -28,7 +28,7 @@ done
 
 if [ "$FILES" != "" ]
 then
-	echo "Fixing formatting with Code Sniffer..."
+	echo "Running Code Sniffer..."
 	./vendor/bin/phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 --encoding=utf-8 -n -p $FILES
 	if [ $? != 0 ]
 	then

--- a/admin/setup.sh
+++ b/admin/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Install a pre-commit hook that
+# automatically runs phpcs to fix styles
+cp admin/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,14 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "mikey179/vfsStream": "1.6.*",
-        "codeigniter4/codeigniter4-standard": "^1.0"
+        "codeigniter4/codeigniter4-standard": "^1.0",
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "scripts": {
         "post-update-cmd": [
             "composer dump-autoload",
-            "CodeIgniter\\ComposerScripts::postUpdate"
+            "CodeIgniter\\ComposerScripts::postUpdate",
+            "bash admin/setup.sh"
         ]
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -4,12 +4,12 @@
 $minPHPVersion = '7.1';
 if (phpversion() < $minPHPVersion)
 {
-	die("You PHP version must be {$minPHPVersion} or higher to run CodeIgniter. Current version: ". phpversion());
+	die("You PHP version must be {$minPHPVersion} or higher to run CodeIgniter. Current version: " . phpversion());
 }
 unset($minPHPVersion);
 
 // Path to the front controller (this file)
-define('FCPATH', __DIR__.DIRECTORY_SEPARATOR);
+define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
 // Location of the Paths config file.
 // This is the first of two lines that might need to be changed, depending on your folder structure.

--- a/user_guide_src/source/installation/index.rst
+++ b/user_guide_src/source/installation/index.rst
@@ -21,6 +21,9 @@ While not required, CodeIgniter can be installed via `composer <https://getcompo
 
     composer create-project codeigniter4/framework
 
+.. note:: When installing via composer, a pre-commit hook is installed for this repo that automatically runs
+     PHP Code Sniffer and fixes any fixable issues on commit.
+
 Running
 =======
 

--- a/writable/temp/ci_sessionguloetob9c0ets5iapm8dkfnen0c90kn
+++ b/writable/temp/ci_sessionguloetob9c0ets5iapm8dkfnen0c90kn
@@ -1,0 +1,1 @@
+__ci_last_regenerate|i:1540355773;_ci_previous_url|s:22:"http://localhost:8081/";

--- a/writable/temp/ci_sessionguloetob9c0ets5iapm8dkfnen0c90kn
+++ b/writable/temp/ci_sessionguloetob9c0ets5iapm8dkfnen0c90kn
@@ -1,1 +1,0 @@
-__ci_last_regenerate|i:1540355773;_ci_previous_url|s:22:"http://localhost:8081/";


### PR DESCRIPTION
This integrates auto code fixes with PHPCS using [CodeIgniter4-Standard](https://github.com/bcit-ci/CodeIgniter4-Standard) on commit to help ensure code consistency. 

- added CodeIgniter4-Standard to composer.json
- added phpcs to composer.json
- added new post-install script that copies a bash script into the project's .git hooks. 
- new bash script that lints and fixes any fixable errors automatically for each PHP file during commit.