### PR TITLE
Fixed not to output "Hello" at test execution.

### DIFF
--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -69,7 +69,9 @@ class TestCaseTest extends \CIUnitTestCase
 		$body = 'Hello';
 		$response->setBody($body);
 
+		ob_start();
 		$response->send();
+		ob_end_clean();
 
 		// Did PHPunit do its thing?
 		$this->assertHeaderEmitted("Content-type: text/html;");


### PR DESCRIPTION
**Description**

Fixed not to output `Hello` at test execution.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide