### PR TITLE
Fix language file

### DIFF
--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -34,7 +34,7 @@ return [
 
 	// DownloadResponse
 	'cannotSetBinary'            => 'When setting filepath can not set binary.',
-	'cannotSetFilepath'          => 'When setting binary can not set filepath: {0}',
+	'cannotSetFilePath'          => 'When setting binary can not set filepath: {0}',
 	'notFoundDownloadSource'     => 'Not found download body source.',
 	'cannotSetCache'             => 'It does not supported caching for downloading.',
 	'cannotSetStatusCode'        => 'It does not supported chnage status code for downloading. code: {0}, reason: {1}',


### PR DESCRIPTION
Fix language file `HTTP`, change `cannotSetFilepath` to `cannotSetFilePath`

As is was referenced as `cannotSetFilePath` in `system\Exceptions\DownloadException.php:13`

**Checklist:**
- [ Y ] Securely signed commits
- [ N/A ] Component(s) with PHPdocs
- [ N/A ] Unit testing, with >80% coverage
- [ N/A ] User guide updated
- [ N/A ] Conforms to style guide
