### PR TITLE
only register PSR4 "Tests\Support" namespace in "testing" environment

### DIFF
--- a/application/Config/Autoload.php
+++ b/application/Config/Autoload.php
@@ -57,11 +57,7 @@ class Autoload extends \CodeIgniter\Config\AutoloadConfig
 
 		if (defined('ENVIRONMENT') && ENVIRONMENT === 'testing')
 		{
-			$psr4 = array_merge(
-				$psr4,
-				[
-					'Tests\Support' => TESTPATH . '_support',    // So custom migrations can run during testing
-				]);
+			$psr4['Tests\Support'] = TESTPATH . '_support'; // So custom migrations can run during testing
 		}
 
 		/**

--- a/application/Config/Autoload.php
+++ b/application/Config/Autoload.php
@@ -1,6 +1,6 @@
 <?php namespace Config;
 
-require_once BASEPATH.'Config/AutoloadConfig.php';
+require_once BASEPATH . 'Config/AutoloadConfig.php';
 
 /**
  * -------------------------------------------------------------------
@@ -50,11 +50,19 @@ class Autoload extends \CodeIgniter\Config\AutoloadConfig
 		 *   `];
 		 */
 		$psr4 = [
-			'Config'                     => APPPATH.'Config',
-			APP_NAMESPACE                => APPPATH,			    // For custom namespace
-			'App'                        => APPPATH,			    // To ensure filters, etc still found,
-			'Tests\Support'              => TESTPATH.'_support',    // So custom migrations can run during testing
+			'Config'      => APPPATH . 'Config',
+			APP_NAMESPACE => APPPATH,                // For custom namespace
+			'App'         => APPPATH,                // To ensure filters, etc still found,
 		];
+
+		if (defined('ENVIRONMENT') && ENVIRONMENT === 'testing')
+		{
+			$psr4 = array_merge(
+				$psr4,
+				[
+					'Tests\Support' => TESTPATH . '_support',    // So custom migrations can run during testing
+				]);
+		}
 
 		/**
 		 * -------------------------------------------------------------------
@@ -78,7 +86,7 @@ class Autoload extends \CodeIgniter\Config\AutoloadConfig
 		// Do Not Edit Below This Line
 		//--------------------------------------------------------------------
 
-		$this->psr4 = array_merge($this->psr4, $psr4);
+		$this->psr4     = array_merge($this->psr4, $psr4);
 		$this->classmap = array_merge($this->classmap, $classmap);
 
 		unset($psr4, $classmap);


### PR DESCRIPTION
By this, the "Tests\Support" namespace won't be registered in `development` and `production` env which is not used.

**Checklist:**
- [x] Securely signed commits
