### PR TITLE
Correcting FCPATH setting in tests/_support/_bootstrap.php

### DIFF
--- a/tests/_support/_bootstrap.php
+++ b/tests/_support/_bootstrap.php
@@ -7,8 +7,8 @@ ini_set('display_startup_errors', '1');
 $_SERVER['CI_ENVIRONMENT'] = 'testing';
 define('ENVIRONMENT', 'testing');
 
-// Path to the front controller (this file)
-define('FCPATH', getcwd().'/public'.DIRECTORY_SEPARATOR);
+// path to the directory that holds the front controller (index.php)
+define('FCPATH', realpath(__DIR__.'/../../') . '/public'.DIRECTORY_SEPARATOR);
 
 // The path to the "tests" directory
 define('TESTPATH', realpath(__DIR__.'/../').'/');

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -1,0 +1,91 @@
+<?php namespace CodeIgniter\Test;
+
+/**
+ * Class BootstrapFCPATHTest
+ *
+ * This test confirms that the tests/_support/_bootstrap.php
+ * will set the correct FCPATH regardless of the current directory
+ *
+ * It writes a file in the temp directory that loads the bootstrap file
+ * then compares its echo FCPATH; to the correct FCPATH returned
+ * from correctFCPATH();
+ *
+ */
+class BootstrapFCPATHTest extends \CIUnitTestCase
+{
+	private $currentDir = __dir__;
+	private $dir1 = '/tmp/dir1';
+	private $file1 = '/tmp/dir1/testFile.php';
+
+	public function setUp() {
+		parent::setUp();
+		$this->deleteFiles();
+		$this->deleteDirectories();
+		$this->buildDirectories();
+		$this->writeFiles();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->deleteFiles();
+		$this->deleteDirectories();
+	}
+
+	public function testSetFCPATH(){
+		$result1 = $this->readOutput($this->file1);
+		$correctPath = $this->correctFCPATH();
+		self::assertEquals($correctPath, $result1);
+	}
+
+	private function correctFCPATH(){
+		return realpath(__dir__ . '/../../../public') . DIRECTORY_SEPARATOR;
+	}
+
+	private function buildDirectories() : void
+	{
+		mkdir( $this->dir1 , 0777, TRUE);
+	}
+
+
+	private function deleteDirectories() : void
+	{
+		// these need to be executed in reverse order: dir 2 in inside dir1
+		if(is_dir($this->dir1)){
+			rmdir( $this->dir1 );
+		}
+	}
+
+	private function writeFiles() : void
+	{
+		file_put_contents( $this->file1 , $this->fileContents());
+		chmod($this->file1, 0777);
+
+	}
+
+	private function deleteFiles() : void
+	{
+		if(file_exists($this->file1)){
+			unlink( $this->file1 );
+		}
+	}
+
+
+	private function fileContents(){
+
+		$fileContents = '';
+		$fileContents .= '<?php' . PHP_EOL;
+		$fileContents .= "include_once '" . $this->currentDir . "' . '/../../../vendor/autoload.php';". PHP_EOL;
+		$fileContents .= "include_once '" . $this->currentDir . "' . '/../../../tests/_support/_bootstrap.php';". PHP_EOL;
+		$fileContents .= '// return value of FCPATH'. PHP_EOL;
+		$fileContents .= 'echo FCPATH;'. PHP_EOL;
+
+		return $fileContents;
+
+	}
+
+	private function readOutput($file){
+		return  system('php -f ' . $file);
+	}
+
+
+}


### PR DESCRIPTION
**Description**

Changed the method to get the FCPATH from getcwd() to realpath() to set paths relative to the bootstrap file. This allows tests to be run independently from their directories or using IDEs like PHPStorm.

This is a correction/update to pull request #1310.  It is essentially the same except there is no change to any autoloading behavior.

if you run the test without the change to _bootstrap.php, it will fail and all other tests will fail if you run them from their directory like this:

Before the fix this will fail (run from bash in linux, you may need to adjust your paths):

`/usr/bin/php /home/vagrant/Code/codeigniter4/vendor/phpunit/phpunit/phpunit --bootstrap /home/vagrant/Code/codeigniter4/tests/_support/_bootstrap.php --no-configuration FeatureTestCaseTest /home/vagrant/Code/codeigniter4/tests/system/Test/ReflectionHelperTest.php `

`PHP Warning:  Uncaught require_once(/Config/Constants.php): failed to open stream: No such file or directory`

(FCPATH is wrong)

After the _bootstrap.php fix it will work:

`OK (7 tests, 7 assertions)`

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide

