### PR TITLE
optional type hinting in guessExtension

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -108,9 +108,9 @@ class File extends SplFileInfo
 	 * Attempts to determine the file extension based on the trusted
 	 * getType() method. If the mime type is unknown, will return null.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	public function guessExtension(): string
+	public function guessExtension(): ?string
 	{
 		return \Config\Mimes::guessExtensionFromType($this->getMimeType());
 	}

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -350,7 +350,7 @@ class UploadedFile extends File implements UploadedFileInterface
 		return $this->guessExtension();
 	}
 
-	public function guessExtension(): string
+	public function guessExtension() : ?string
 	{
 		return \Config\Mimes::guessExtensionFromType($this->getMimeType(), $this->getClientExtension());
 	}


### PR DESCRIPTION
Null is allowed as the return value of \Config\Mimes::guessExtensionFromType that's why should be allowed in guessExtension either.

/ fix: no extension for given mimetype,  PR#1368 (@daljit3 - thx, for pointing this out)/