### PR TITLE
Correct class namespacing in the user guide

### DIFF
--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -38,7 +38,8 @@ Let's create a simple controller so you can see it in action. Using your
 text editor, create a file called Tools.php, and put the following code
 in it::
 
-	<?php namespace CodeIgniter;
+	namespace App\Controller;
+        use CodeIgniter\Controller;
 
 	class Tools extends Controller {
 

--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -38,8 +38,9 @@ Let's create a simple controller so you can see it in action. Using your
 text editor, create a file called Tools.php, and put the following code
 in it::
 
-	<?php
-	class Tools extends \CodeIgniter\Controller {
+	<?php namespace CodeIgniter;
+
+	class Tools extends Controller {
 
 		public function message($to = 'World')
 		{

--- a/user_guide_src/source/extending/core_classes.rst
+++ b/user_guide_src/source/extending/core_classes.rst
@@ -49,7 +49,6 @@ For example, if you have a new ``App\Libraries\RouteCollection`` class that you 
 the core system class, you would create your class like this::
 
     namespace App\Libraries;
-
     use CodeIgniter\Router\RouteCollectionInterface;
 
     class RouteCollection implements RouteCollectionInterface
@@ -81,7 +80,6 @@ identical to replacing a class with a one exception:
 For example, to extend the native RouteCollection class, you would declare your class with::
 
     namespace App\Libraries;
-
     use CodeIgniter\Router\RouteCollection;
 
     class RouteCollection extends RouteCollection
@@ -92,16 +90,15 @@ For example, to extend the native RouteCollection class, you would declare your 
 If you need to use a constructor in your class make sure you extend the parent constructor::
 
     namespace App\Libraries;
-
     use CodeIgniter\Router\RouteCollection;
 
-       class RouteCollection implements RouteCollection
-        {
-            public function __construct()
-            {
-                parent::__construct();
-            }
-        }
+    class RouteCollection extends RouteCollection
+    {
+         public function __construct()
+         {
+             parent::__construct();
+         }
+     }
 
 **Tip:**  Any functions in your class that are named identically to the methods in the parent class will be used
 instead of the native ones (this is known as “method overriding”). This allows you to substantially alter the CodeIgniter core.
@@ -110,7 +107,6 @@ If you are extending the Controller core class, then be sure to extend your new 
 constructors::
 
     namespace App\Controllers;
-
     use App\BaseController;
 
     class Home extends BaseController {

--- a/user_guide_src/source/extending/core_classes.rst
+++ b/user_guide_src/source/extending/core_classes.rst
@@ -50,7 +50,9 @@ the core system class, you would create your class like this::
 
     namespace App\Libraries;
 
-    class RouteCollection implements \CodeIgniter\Router\RouteCollectionInterface
+    use CodeIgniter\Router\RouteCollectionInterface;
+
+    class RouteCollection implements RouteCollectionInterface
     {
 
     }
@@ -78,14 +80,22 @@ identical to replacing a class with a one exception:
 
 For example, to extend the native RouteCollection class, you would declare your class with::
 
-    class RouteCollection extends \CodeIgniter\Router\RouteCollection
+    namespace App\Libraries;
+
+    use CodeIgniter\Router\RouteCollection;
+
+    class RouteCollection extends RouteCollection
     {
 
     }
 
 If you need to use a constructor in your class make sure you extend the parent constructor::
 
-        class RouteCollection implements \CodeIgniter\Router\RouteCollection
+    namespace App\Libraries;
+
+    use CodeIgniter\Router\RouteCollection;
+
+       class RouteCollection implements RouteCollection
         {
             public function __construct()
             {
@@ -99,7 +109,11 @@ instead of the native ones (this is known as “method overriding”). This allo
 If you are extending the Controller core class, then be sure to extend your new class in your application controller’s
 constructors::
 
-	class Home extends App\BaseController {
+    namespace App\Controllers;
 
-	}
+    use App\BaseController;
+
+    class Home extends BaseController {
+
+    }
 

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -51,9 +51,8 @@ If you need to create a new configuration file you would create a new file at yo
 **/application/Config** by default. Then create the class and fill it with public properties that
 represent your settings::
 
-    namespace Config;
-    
-    use CodeIgniter\Config\BaseConfig ;
+    namespace Config;    
+    use CodeIgniter\Config\BaseConfig;
 
     class App extends BaseConfig
     {
@@ -201,8 +200,8 @@ the same way as described for namespaced variables.
 A sample configuration class setup for this::
 
     namespace App\Config;
+    use CodeIgniter\Config\BaseConfig;
 
-    use CodeIgniter\Config\BaseConfig
     class MySalesConfig extends BaseConfig
     {
         public $target        = 100;

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -51,9 +51,11 @@ If you need to create a new configuration file you would create a new file at yo
 **/application/Config** by default. Then create the class and fill it with public properties that
 represent your settings::
 
-    <?php namespace Config;
+    namespace Config;
+    
+    use CodeIgniter\Config\BaseConfig ;
 
-    class App extends \CodeIgniter\Config\BaseConfig
+    class App extends BaseConfig
     {
     	public $siteName  = 'My Great Site';
     	public $siteEmail = 'webmaster@example.com';
@@ -200,7 +202,8 @@ A sample configuration class setup for this::
 
     namespace App\Config;
 
-    class MySalesConfig extends \CodeIgniter\Config\BaseConfig
+    use CodeIgniter\Config\BaseConfig
+    class MySalesConfig extends BaseConfig
     {
         public $target        = 100;
         public $campaign      = "Winter Wonderland";

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -28,11 +28,11 @@ Let's try it: Hello World!
 Let's create a simple controller so you can see it in action. Using your text editor, create a file called Blog.php,
 and put the following code in it::
 
-	<?php namespace App\Controllers;
-        user CodeIgniter\Controller;
+	namespace App\Controllers;
+        use CodeIgniter\Controller;
 
-	class Blog extends Controller
-	{
+	class Blog extends Controller 
+        {
 		public function index()
 		{
 			echo 'Hello World!';
@@ -55,8 +55,8 @@ If you did it right, you should see::
 
 This is valid::
 
-	<?php namespace App\Controllers;
-        user CodeIgniter\Controller;
+	namespace App\Controllers;
+        use CodeIgniter\Controller;
 
 	class Blog extends Controller {
 
@@ -64,8 +64,8 @@ This is valid::
 
 This is **not** valid::
 
-	<?php namespace App\Controllers;
-        user CodeIgniter\Controller;
+	namespace App\Controllers;
+        use CodeIgniter\Controller;
 
 	class blog extends Controller {
 
@@ -88,11 +88,11 @@ controller gets called.**
 
 Let's try it. Add a new method to your controller::
 
-	<?php
-	<?php namespace App\Controllers;
-        user CodeIgniter\Controller;
+	namespace App\Controllers;
+        use CodeIgniter\Controller;
 
-	class Blog extends Controller {
+	class Blog extends Controller 
+        {
 
 		public function index()
 		{
@@ -123,8 +123,11 @@ For example, let's say you have a URI like this::
 
 Your method will be passed URI segments 3 and 4 ("sandals" and "123")::
 
-	<?php
-	class Products extends \CodeIgniter\Controller {
+	namespace App\Controllers;
+        use CodeIgniter\Controller;
+
+	class Products extends Controller 
+        {
 
 		public function shoes($sandals, $id)
 		{
@@ -295,10 +298,10 @@ You can define an array of helper files as a class property. Whenever the contro
 these helper files will be automatically loaded into memory so that you can use their methods anywhere
 inside the controller::
 
-	<?php namespace App\Controllers;
-        user CodeIgniter\Controller;
+	namespace App\Controllers;
+        use CodeIgniter\Controller;
 
-	class MyController extends Controller {
+	class MyController extends Controller 
 	{
 		protected $helpers = ['url', 'form'];
 	}

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -28,8 +28,10 @@ Let's try it: Hello World!
 Let's create a simple controller so you can see it in action. Using your text editor, create a file called Blog.php,
 and put the following code in it::
 
-	<?php
-	class Blog extends \CodeIgniter\Controller
+	<?php namespace App\Controllers;
+        user CodeIgniter\Controller;
+
+	class Blog extends Controller
 	{
 		public function index()
 		{
@@ -53,15 +55,19 @@ If you did it right, you should see::
 
 This is valid::
 
-	<?php
-	class Blog extends \CodeIgniter\Controller {
+	<?php namespace App\Controllers;
+        user CodeIgniter\Controller;
+
+	class Blog extends Controller {
 
 	}
 
 This is **not** valid::
 
-	<?php
-	class blog extends \CodeIgniter\Controller {
+	<?php namespace App\Controllers;
+        user CodeIgniter\Controller;
+
+	class blog extends Controller {
 
 	}
 
@@ -83,7 +89,10 @@ controller gets called.**
 Let's try it. Add a new method to your controller::
 
 	<?php
-	class Blog extends \CodeIgniter\Controller {
+	<?php namespace App\Controllers;
+        user CodeIgniter\Controller;
+
+	class Blog extends Controller {
 
 		public function index()
 		{
@@ -286,7 +295,10 @@ You can define an array of helper files as a class property. Whenever the contro
 these helper files will be automatically loaded into memory so that you can use their methods anywhere
 inside the controller::
 
-	class MyController extends \CodeIgniter\Controller
+	<?php namespace App\Controllers;
+        user CodeIgniter\Controller;
+
+	class MyController extends Controller {
 	{
 		protected $helpers = ['url', 'form'];
 	}

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -16,7 +16,10 @@ Accessing the Request
 An instance of the request class already populated for you if the current class is a descendant of
 ``CodeIgniter\Controller`` and can be accessed as a class property::
 
-	class UserController extends CodeIgniter\Controller
+        namespace App\Controllers;
+        user CodeIgniter\Controller;
+
+	class UserController extends Controller
 	{
 		public function index()
 		{

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -14,6 +14,7 @@ instance of the database connection and you're good to go.
 
 ::
 
+        namespace App\Models;
 	use \CodeIgniter\Database\ConnectionInterface;
 
 	class UserModel
@@ -46,7 +47,10 @@ Creating Your Model
 To take advantage of CodeIgniter's model, you would simply create a new model class
 that extends ``CodeIgniter\Model``::
 
-	class UserModel extends \CodeIgniter\Model
+        namespace App\Models;
+        user CodeIgniter\Model;
+
+	class UserModel extends Model
 	{
 
 	}
@@ -64,6 +68,9 @@ This ensures that within the model any references to ``$this->db`` are made thro
 connection.
 ::
 
+        namespace App\Models;
+        user CodeIgniter\Model;
+
 	class UserModel extends \CodeIgniter\Model
 	{
 		protected $DBGroup = 'group_name';
@@ -78,6 +85,9 @@ Configuring Your Model
 The model class has a few configuration options that can be set to allow the class' methods
 to work seamlessly for you. The first two are used by all of the CRUD methods to determine
 what table to use and how we can find the required records::
+
+        namespace App\Models;
+        user CodeIgniter\Model;
 
 	class UserModel extends \CodeIgniter\Model
 	{

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -14,7 +14,6 @@ instance of the database connection and you're good to go.
 
 ::
 
-        namespace App\Models;
 	use \CodeIgniter\Database\ConnectionInterface;
 
 	class UserModel
@@ -47,8 +46,7 @@ Creating Your Model
 To take advantage of CodeIgniter's model, you would simply create a new model class
 that extends ``CodeIgniter\Model``::
 
-        namespace App\Models;
-        user CodeIgniter\Model;
+        use CodeIgniter\Model;
 
 	class UserModel extends Model
 	{
@@ -68,10 +66,9 @@ This ensures that within the model any references to ``$this->db`` are made thro
 connection.
 ::
 
-        namespace App\Models;
-        user CodeIgniter\Model;
+        use CodeIgniter\Model;
 
-	class UserModel extends \CodeIgniter\Model
+	class UserModel extends Model
 	{
 		protected $DBGroup = 'group_name';
 	}
@@ -86,10 +83,9 @@ The model class has a few configuration options that can be set to allow the cla
 to work seamlessly for you. The first two are used by all of the CRUD methods to determine
 what table to use and how we can find the required records::
 
-        namespace App\Models;
-        user CodeIgniter\Model;
+        use CodeIgniter\Model;
 
-	class UserModel extends \CodeIgniter\Model
+	class UserModel extends Model
 	{
 		protected $table      = 'users';
 		protected $primaryKey = 'id';
@@ -358,7 +354,9 @@ simplest, they might look like this::
 
 A very simple model to work with this might look like::
 
-	class JobModel extends \CodeIgniter\Model
+        use CodeIgniter\Model;
+
+	class JobModel extends Model
 	{
 		protected $table = 'jobs';
 		protected $returnType = '\App\Entities\Job';

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -16,6 +16,8 @@ The Helper Trait
 You can use either of the base test classes, but you do need to use the ``ControllerTester`` trait
 within your tests::
 
+    namespace CodeIgniter;
+
     use Tests\Support\Helpers\ControllerTester;
 
     class TestControllerA extends \CIDatabaseTestCase
@@ -28,9 +30,11 @@ the request body, URI, and more. You specify the controller to use with the ``co
 fully qualified class name of your controller. Finally, call the ``execute()`` method with the name of the method
 to run as the parameter::
 
+    namespace CodeIgniter;
+
     use Tests\Support\Helpers\ControllerTester;
 
-    class TestControllerA extends CIDatabaseTestCase
+    class TestControllerA extends \CIDatabaseTestCase
     {
         use ControllerTester;
 

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -115,7 +115,7 @@ fields in the ``$allowedFields`` property.
 
 ::
 
-    <?php namespace App\Models;
+    namespace App\Models;
     use CodeIgniter\Model;
 
     class NewsModel extends Model

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -115,8 +115,10 @@ fields in the ``$allowedFields`` property.
 
 ::
 
-    <?php
-    class NewsModel extends \CodeIgniter\Model
+    <?php namespace App\Models;
+    use CodeIgniter\Model;
+
+    class NewsModel extends Model
     {
         protected $table = 'news';
 

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -24,8 +24,9 @@ your database properly as described :doc:`here <../database/configuration>`.
 	<?php
 
 	namespace App\Models;
+        use CodeIgniter\Model;
 
-	class NewsModel extends \CodeIgniter\Model
+	class NewsModel extends Model
 	{
 		protected $table = 'news';
 	}

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -21,9 +21,6 @@ your database properly as described :doc:`here <../database/configuration>`.
 
 ::
 
-	<?php
-
-	namespace App\Models;
         use CodeIgniter\Model;
 
 	class NewsModel extends Model
@@ -100,11 +97,11 @@ a new ``News`` controller is defined. Create the new controller at
 
 ::
 
-	<?php namespace App\Controllers;
-
+	namespace App\Controllers;
 	use App\Models\NewsModel;
+        use CodeIgniter\Controller;
 
-	class News extends \CodeIgniter\Controller
+	class News extends Controller
 	{
 		public function index()
 		{

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -29,7 +29,7 @@ code.
 
 ::
 
-	<?php namespace App\Controllers;
+	namespace App\Controllers;
         use CodeIgniter\Controller;
 
 	class Pages extends Controller {

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -30,7 +30,9 @@ code.
 ::
 
 	<?php namespace App\Controllers;
-	class Pages extends CodeIgniter\Controller {
+        use CodeIgniter\Controller;
+
+	class Pages extends Controller {
 
 		public function view($page = 'home')
 		{


### PR DESCRIPTION
A sweep through the user guide, to correct class namespacing declarations.
Fixes #1401