### PR TITLE
propose form helper function usage in sample view form and documentation

### DIFF
--- a/application/Views/form.php
+++ b/application/Views/form.php
@@ -1,9 +1,12 @@
 <br><br><br>
 
+<?php
+\Config\Services::validation()->listErrors();
 
-<form method="post" action="" enctype="multipart/form-data">
+helper('form');
+echo form_open('form/process',['enctype' => 'multipart/form-data']);
 
-	<input type="file" name="avatar" id="">
-	
-	<input type="submit" value="Send" name="Send">
-</form>
+echo form_input('avatar', '', '', 'file');
+
+echo form_submit('Send', 'Send');
+echo form_close();

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -24,15 +24,19 @@ the slug from our title in the model. Create the new view at
 
     <?= form_open('news/create'); ?>
 
-        <label for="title">Title</label>
-        <input type="input" name="title" /><br />
+        <?= form_label('Title', '', ['for' => 'title']); ?>
+        <?= form_input('title', '', '', 'text'); ?>
 
-        <label for="text">Text</label>
-        <textarea name="text"></textarea><br />
+        <br />
 
-        <input type="submit" name="submit" value="Create news item" />
+        <?= form_label('Text', '', ['for' => 'text']); ?>
+        <?= form_textarea('text'); ?>
 
-    </form>
+        <br />
+
+        <?= form_submit('submit', 'Create news item'); ?>
+
+    <?= form_close(); ?>
 
 There are only two things here that probably look unfamiliar to you: the
 ``form_open()`` function and the ``\Config\Services::validation()->listErrors()`` function.


### PR DESCRIPTION
There is sample form view at `application/Views/form.php`, I think it is better to show of the usage of 'form' helper. Also, in documentation, we already open the form with `form_open()`, and rest of code sample was using normal html, the form helper usage is for consistency for its usage to the rest.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
