### PR TITLE
Fix spark serve not working from commit  2d0b325

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -229,7 +229,7 @@ class RouteCollection implements RouteCollectionInterface
 	public function __construct(FileLocator $locator, $moduleConfig)
 	{
 		// Get HTTP verb
-		$this->HTTPVerb = Services::request()->getMethod() ?? 'cli';
+		$this->HTTPVerb = strtolower($_SERVER['REQUEST_METHOD'] ?? 'cli');
 
 		$this->fileLocator = $locator;
 


### PR DESCRIPTION
In previous latest commit https://github.com/bcit-ci/CodeIgniter4/commit/2d0b32556198aefec7057d99fa3af8daed9a504b , the `HTTPVerb` property of `RouteCollection` changed by call `Services::request()->getMethod()` by @lonnieezell that make command:

```bash
php spark serve
```

Got output:

```bash
ERROR: 404
Controller or its method is not found: App\Controllers\Ciserve::index
```

**Checklist:**
- [x] Securely signed commits

ping @lonnieezell
