### PR TITLE
add missing break; in loop in View::render() when match the file search

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package	CodeIgniter
- * @author	CodeIgniter Dev Team
- * @copyright	2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license	https://opensource.org/licenses/MIT	MIT License
- * @link	https://codeigniter.com
- * @since	Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\View\Exceptions\ViewException;
 use Config\Services;
 use Psr\Log\LoggerInterface;
@@ -87,7 +88,7 @@ class View implements RendererInterface
 	/**
 	 * Should we store performance info?
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $debug = false;
 
@@ -107,14 +108,14 @@ class View implements RendererInterface
 	/**
 	 * Whether data should be saved between renders.
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $saveData;
 
 	/**
 	 * Number of loaded views
 	 *
-	 * @var int
+	 * @var integer
 	 */
 	protected $viewsCount = 0;
 
@@ -123,19 +124,19 @@ class View implements RendererInterface
 	/**
 	 * Constructor
 	 *
-	 * @param \Config\View           $config
-	 * @param string                 $viewPath
-	 * @param mixed                  $loader
-	 * @param bool                   $debug
-	 * @param LoggerInterface        $logger
+	 * @param \Config\View    $config
+	 * @param string          $viewPath
+	 * @param mixed           $loader
+	 * @param boolean         $debug
+	 * @param LoggerInterface $logger
 	 */
 	public function __construct($config, string $viewPath = null, $loader = null, bool $debug = null, LoggerInterface $logger = null)
 	{
-		$this->config = $config;
+		$this->config   = $config;
 		$this->viewPath = rtrim($viewPath, '/ ') . '/';
-		$this->loader = is_null($loader) ? Services::locator() : $loader;
-		$this->logger = is_null($logger) ? Services::logger() : $logger;
-		$this->debug = is_null($debug) ? CI_DEBUG : $debug;
+		$this->loader   = is_null($loader) ? Services::locator() : $loader;
+		$this->logger   = is_null($logger) ? Services::logger() : $logger;
+		$this->debug    = is_null($debug) ? CI_DEBUG : $debug;
 		$this->saveData = $config->saveData ?? null;
 	}
 
@@ -146,12 +147,12 @@ class View implements RendererInterface
 	 * data that has already been set.
 	 *
 	 * Valid $options:
-	 * 	- cache 		number of seconds to cache for
+	 *     - cache 		number of seconds to cache for
 	 *  - cache_name	Name to use for cache
 	 *
-	 * @param string $view
-	 * @param array  $options
-	 * @param bool $saveData
+	 * @param string  $view
+	 * @param array   $options
+	 * @param boolean $saveData
 	 *
 	 * @return string
 	 */
@@ -167,9 +168,9 @@ class View implements RendererInterface
 			$this->saveData = $saveData;
 		}
 
-		$fileExt = pathinfo($view, PATHINFO_EXTENSION);
-		$realPath = empty($fileExt) ? $view.'.php' : $view; // allow Views as .html, .tpl, etc (from CI3)
-		$this->renderVars['view'] = $realPath;
+		$fileExt                     = pathinfo($view, PATHINFO_EXTENSION);
+		$realPath                    = empty($fileExt) ? $view . '.php' : $view; // allow Views as .html, .tpl, etc (from CI3)
+		$this->renderVars['view']    = $realPath;
 		$this->renderVars['options'] = $options;
 
 		// Was it cached?
@@ -186,7 +187,7 @@ class View implements RendererInterface
 
 		$this->renderVars['file'] = $this->viewPath . $this->renderVars['view'];
 
-		if ( ! file_exists($this->renderVars['file']))
+		if (! file_exists($this->renderVars['file']))
 		{
 			$this->renderVars['file'] = $this->loader->locateFile($this->renderVars['view'], 'Views', empty($fileExt) ? 'php' : $fileExt);
 		}
@@ -200,7 +201,7 @@ class View implements RendererInterface
 		// Make our view data available to the view.
 		extract($this->data);
 
-		if ( ! $this->saveData)
+		if (! $this->saveData)
 		{
 			$this->data = [];
 		}
@@ -217,7 +218,7 @@ class View implements RendererInterface
 			$after = (new \Config\Filters())->globals['after'];
 			if (in_array('toolbar', $after) || array_key_exists('toolbar', $after))
 			{
-				$toolbarCollectors =  (config(\Config\App::class))->toolbarCollectors;
+				$toolbarCollectors = (config(\Config\App::class))->toolbarCollectors;
 				if (in_array('CodeIgniter\Debug\Toolbar\Collectors\Views', $toolbarCollectors) || array_key_exists('CodeIgniter\Debug\Toolbar\Collectors\Views', $toolbarCollectors))
 				{
 					// Clean up our path names to make them a little cleaner
@@ -225,11 +226,12 @@ class View implements RendererInterface
 					{
 						if (strpos($this->renderVars['file'], constant($path)) === 0)
 						{
-							$this->renderVars['file'] = str_replace(constant($path), $path.'/', $this->renderVars['file']);
+							$this->renderVars['file'] = str_replace(constant($path), $path . '/', $this->renderVars['file']);
+							break;
 						}
 					}
 					$this->renderVars['file'] = ++$this->viewsCount . ' ' . $this->renderVars['file'];
-					$output = '<!-- DEBUG-VIEW START ' . $this->renderVars['file'] . ' -->' . PHP_EOL
+					$output                   = '<!-- DEBUG-VIEW START ' . $this->renderVars['file'] . ' -->' . PHP_EOL
 						. $output . PHP_EOL
 						. '<!-- DEBUG-VIEW ENDED ' . $this->renderVars['file'] . ' -->' . PHP_EOL;
 				}
@@ -252,13 +254,13 @@ class View implements RendererInterface
 	 * data that has already been set.
 	 * Cache does not apply, because there is no "key".
 	 *
-	 * @param string $view	The view contents
-	 * @param array  $options  Reserved for 3rd-party uses since
-	 *                         it might be needed to pass additional info
-	 *                         to other template engines.
-	 * @param bool   $saveData If true, will save data for use with any other calls,
-	 *                         if false, will clean the data after displaying the view,
-	 * 						   if not specified, use the config setting.
+	 * @param string  $view     The view contents
+	 * @param array   $options  Reserved for 3rd-party uses since
+	 *                          it might be needed to pass additional info
+	 *                          to other template engines.
+	 * @param boolean $saveData If true, will save data for use with any other calls,
+	 *                          if false, will clean the data after displaying the view,
+	 *                             if not specified, use the config setting.
 	 *
 	 * @return string
 	 */
@@ -272,13 +274,13 @@ class View implements RendererInterface
 
 		extract($this->data);
 
-		if ( ! $saveData)
+		if (! $saveData)
 		{
 			$this->data = [];
 		}
 
 		ob_start();
-		$incoming = "?>" . $view;
+		$incoming = '?>' . $view;
 		eval($incoming);
 		$output = ob_get_contents();
 		@ob_end_clean();
@@ -293,8 +295,8 @@ class View implements RendererInterface
 	/**
 	 * Extract first bit of a long string and add ellipsis
 	 *
-	 * @param string	$string
-	 * @param	int		$length
+	 * @param  string  $string
+	 * @param  integer $length
 	 * @return string
 	 */
 	public function excerpt(string $string, int $length = 20): string
@@ -307,7 +309,7 @@ class View implements RendererInterface
 	/**
 	 * Sets several pieces of view data at once.
 	 *
-	 * @param array $data
+	 * @param array  $data
 	 * @param string $context The context to escape it for: html, css, js, url
 	 *                        If null, no escaping will happen
 	 *
@@ -315,7 +317,7 @@ class View implements RendererInterface
 	 */
 	public function setData(array $data = [], string $context = null): RendererInterface
 	{
-		if ( ! empty($context))
+		if (! empty($context))
 		{
 			$data = \esc($data, $context);
 		}
@@ -331,7 +333,7 @@ class View implements RendererInterface
 	 * Sets a single piece of view data.
 	 *
 	 * @param string $name
-	 * @param mixed   $value
+	 * @param mixed  $value
 	 * @param string $context The context to escape it for: html, css, js, url
 	 *                        If null, no escaping will happen
 	 *
@@ -339,7 +341,7 @@ class View implements RendererInterface
 	 */
 	public function setVar(string $name, $value = null, string $context = null): RendererInterface
 	{
-		if ( ! empty($context))
+		if (! empty($context))
 		{
 			$value = \esc($value, $context);
 		}
@@ -399,13 +401,15 @@ class View implements RendererInterface
 	 */
 	protected function logPerformance(float $start, float $end, string $view)
 	{
-		if ( ! $this->debug)
+		if (! $this->debug)
+		{
 			return;
+		}
 
 		$this->performanceData[] = [
-			'start'	 => $start,
-			'end'	 => $end,
-			'view'	 => $view
+			'start' => $start,
+			'end'   => $end,
+			'view'  => $view,
 		];
 	}
 


### PR DESCRIPTION
On line 229. 

Before (without break on found) : 

```php
foreach (['APPPATH', 'BASEPATH', 'ROOTPATH'] as $path)
{
    if (strpos($this->renderVars['file'], constant($path)) === 0)
    {
        $this->renderVars['file'] = str_replace(constant($path), $path . '/', $this->renderVars['file']);
    }
}
```

After (with break on found):

```php
foreach (['APPPATH', 'BASEPATH', 'ROOTPATH'] as $path)
{
    if (strpos($this->renderVars['file'], constant($path)) === 0)
    {
        $this->renderVars['file'] = str_replace(constant($path), $path . '/', $this->renderVars['file']);
        break;
    }
}
```

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
