### PR TITLE
set more_entropy = true in all uniqid() usage

### DIFF
--- a/application/Views/errors/html/error_exception.php
+++ b/application/Views/errors/html/error_exception.php
@@ -1,4 +1,4 @@
-<?php $error_id = uniqid('error'); ?>
+<?php $error_id = uniqid('error', true); ?>
 <!doctype html>
 <html>
 <head>

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -773,7 +773,7 @@ class Email
 			if ($this->attachments[$i]['name'][0] === $filename)
 			{
 				$this->attachments[$i]['multipart'] = 'related';
-				$this->attachments[$i]['cid']       = uniqid(basename($this->attachments[$i]['name'][0]).'@');
+				$this->attachments[$i]['cid']       = uniqid(basename($this->attachments[$i]['name'][0]).'@', true);
 
 				return $this->attachments[$i]['cid'];
 			}
@@ -943,7 +943,7 @@ class Email
 	{
 		$from = str_replace(['>', '<'], '', $this->headers['Return-Path']);
 
-		return '<'.uniqid('').strstr($from, '@').'>';
+		return '<'.uniqid('', true).strstr($from, '@').'>';
 	}
 
 	//--------------------------------------------------------------------
@@ -1336,7 +1336,7 @@ class Email
 				}
 				else
 				{
-					$boundary = uniqid('B_ALT_');
+					$boundary = uniqid('B_ALT_', true);
 					$hdr      .= 'Content-Type: multipart/alternative; boundary="'.$boundary.'"';
 
 					$body .= $this->getMimeMessage().$this->newline.$this->newline
@@ -1371,7 +1371,7 @@ class Email
 
 			case 'plain-attach':
 
-				$boundary = uniqid('B_ATC_');
+				$boundary = uniqid('B_ATC_', true);
 				$hdr      .= 'Content-Type: multipart/mixed; boundary="'.$boundary.'"';
 
 				if ($this->getProtocol() === 'mail')
@@ -1392,19 +1392,19 @@ class Email
 				break;
 			case 'html-attach':
 
-				$alt_boundary  = uniqid('B_ALT_');
+				$alt_boundary  = uniqid('B_ALT_', true);
 				$last_boundary = null;
 
 				if ($this->attachmentsHaveMultipart('mixed'))
 				{
-					$atc_boundary  = uniqid('B_ATC_');
+					$atc_boundary  = uniqid('B_ATC_', true);
 					$hdr           .= 'Content-Type: multipart/mixed; boundary="'.$atc_boundary.'"';
 					$last_boundary = $atc_boundary;
 				}
 
 				if ($this->attachmentsHaveMultipart('related'))
 				{
-					$rel_boundary        = uniqid('B_REL_');
+					$rel_boundary        = uniqid('B_REL_', true);
 					$rel_boundary_header = 'Content-Type: multipart/related; boundary="'.$rel_boundary.'"';
 
 					if (isset($last_boundary))


### PR DESCRIPTION
as in php manual documented at http://php.net/manual/en/function.uniqid.php#refsect1-function.uniqid-parameters

```
If set to TRUE, uniqid() will add additional entropy (using the combined linear congruential generator) at the end of the return value, which increases the likelihood that the result will be unique. 
```

**Checklist:**
- [x] Securely signed commits
