### PR TITLE
remove unneded "defined('BASEPATH') OR exit('No direct script access allowed') in Views/Errors files

### DIFF
--- a/application/Views/errors/cli/error_404.php
+++ b/application/Views/errors/cli/error_404.php
@@ -1,6 +1,4 @@
 <?php
-defined('BASEPATH') OR exit('No direct script access allowed');
-
 use CodeIgniter\CLI\CLI;
 
 CLI::error('ERROR: ' . $code);

--- a/application/Views/errors/cli/error_exception.php
+++ b/application/Views/errors/cli/error_exception.php
@@ -1,5 +1,3 @@
-<?php defined('BASEPATH') OR exit('No direct script access allowed'); ?>
-
 An uncaught Exception was encountered
 
 Type:        <?= get_class($exception), "\n"; ?>

--- a/application/Views/errors/html/error_404.php
+++ b/application/Views/errors/html/error_404.php
@@ -1,6 +1,4 @@
-<?php
-defined('BASEPATH') OR exit('No direct script access allowed');
-?><!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="utf-8">


### PR DESCRIPTION
It only in files in `Views/errors` directory, while it not applied in `welcome_message.php` and `form.php`. I think it was a legacy code check while we still didn't point the root directory to `public` directory yet. I removed it.


**Checklist:**
- [x] Securely signed commits
