### PR TITLE
remove $psr4['Tests\Support'] definition in application\Config\Autoload::__construct()

### DIFF
--- a/application/Config/Autoload.php
+++ b/application/Config/Autoload.php
@@ -55,11 +55,6 @@ class Autoload extends \CodeIgniter\Config\AutoloadConfig
 			'App'         => APPPATH,                // To ensure filters, etc still found,
 		];
 
-		if (defined('ENVIRONMENT') && ENVIRONMENT === 'testing')
-		{
-			$psr4['Tests\Support'] = TESTPATH . '_support'; // So custom migrations can run during testing
-		}
-
 		/**
 		 * -------------------------------------------------------------------
 		 * Class Map

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -181,9 +181,13 @@ class AutoloadConfig
 			'CodeIgniter\View\Parser'                       => BASEPATH . 'View/Parser.php',
 			'CodeIgniter\View\Cell'                         => BASEPATH . 'View/Cell.php',
 			'Zend\Escaper\Escaper'                          => BASEPATH . 'ThirdParty/ZendEscaper/Escaper.php',
-			'CodeIgniter\Log\TestLogger'                    => SUPPORTPATH . 'Log/TestLogger.php',
-			'CIDatabaseTestCase'                            => SUPPORTPATH . 'CIDatabaseTestCase.php',
 		];
+
+		if (isset($_SERVER['CI_ENVIRONMENT']) && $_SERVER['CI_ENVIRONMENT'] === 'testing')
+		{
+			$this->classmap['CodeIgniter\Log\TestLogger'] = SUPPORTPATH . 'Log/TestLogger.php';
+			$this->classmap['CIDatabaseTestCase']         = SUPPORTPATH . 'CIDatabaseTestCase.php';
+		}
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -91,7 +91,7 @@ class AutoloadConfig
 
 		if (isset($_SERVER['CI_ENVIRONMENT']) && $_SERVER['CI_ENVIRONMENT'] === 'testing')
 		{
-			$this->psr4['Tests\Support'] = BASEPATH . '../tests/_support';
+			$this->psr4['Tests\Support'] = SUPPORTPATH;
 		}
 
 		/**

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -27,12 +27,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package	CodeIgniter
- * @author	CodeIgniter Dev Team
- * @copyright	2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license	https://opensource.org/licenses/MIT	MIT License
- * @link	https://codeigniter.com
- * @since	Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
 
@@ -47,12 +47,14 @@ class AutoloadConfig
 
 	/**
 	 * Array of namespaces for autoloading.
+	 *
 	 * @var array
 	 */
 	public $psr4 = [];
 
 	/**
 	 * Map of class names and locations
+	 *
 	 * @var array
 	 */
 	public $classmap = [];
@@ -86,7 +88,7 @@ class AutoloadConfig
 		 *   `];
 		 */
 		$this->psr4 = [
-			'CodeIgniter' => realpath(BASEPATH)
+			'CodeIgniter' => realpath(BASEPATH),
 		];
 
 		if (isset($_SERVER['CI_ENVIRONMENT']) && $_SERVER['CI_ENVIRONMENT'] === 'testing')
@@ -111,76 +113,76 @@ class AutoloadConfig
 		 *   ];
 		 */
 		$this->classmap = [
-			'CodeIgniter\CodeIgniter'						 => BASEPATH . 'CodeIgniter.php',
-			'CodeIgniter\CLI\CLI'							 => BASEPATH . 'CLI/CLI.php',
-			'CodeIgniter\Cache\CacheFactory'				 => BASEPATH . 'Cache/CacheFactory.php',
-			'CodeIgniter\Cache\CacheInterface'				 => BASEPATH . 'Cache/CacheInterface.php',
-			'CodeIgniter\Cache\Handlers\DummyHandler'		 => BASEPATH . 'Cache/Handlers/DummyHandler.php',
-			'CodeIgniter\Cache\Handlers\FileHandler'		 => BASEPATH . 'Cache/Handlers/FileHandler.php',
-			'CodeIgniter\Cache\Handlers\MemcachedHandler'	 => BASEPATH . 'Cache/Handlers/MemcachedHandler.php',
-			'CodeIgniter\Cache\Handlers\PredisHandler'		 => BASEPATH . 'Cache/Handlers/PredisHandler.php',
-			'CodeIgniter\Cache\Handlers\RedisHandler'		 => BASEPATH . 'Cache/Handlers/RedisHandler.php',
-			'CodeIgniter\Cache\Handlers\WincacheHandler'	 => BASEPATH . 'Cache/Handlers/WincacheHandler.php',
-			'CodeIgniter\Controller'						 => BASEPATH . 'Controller.php',
-			'CodeIgniter\Config\AutoloadConfig'				 => BASEPATH . 'Config/Autoload.php',
-			'CodeIgniter\Config\BaseConfig'					 => BASEPATH . 'Config/BaseConfig.php',
-			'CodeIgniter\Config\Database'					 => BASEPATH . 'Config/Database.php',
-			'CodeIgniter\Config\Database\Connection'		 => BASEPATH . 'Config/Database/Connection.php',
-			'CodeIgniter\Config\Database\Connection\MySQLi'	 => BASEPATH . 'Config/Database/Connection/MySQLi.php',
-			'CodeIgniter\Config\DotEnv'						 => BASEPATH . 'Config/DotEnv.php',
-			'CodeIgniter\Database\BaseBuilder'				 => BASEPATH . 'Database/BaseBuilder.php',
-			'CodeIgniter\Database\BaseConnection'			 => BASEPATH . 'Database/BaseConnection.php',
-			'CodeIgniter\Database\BaseResult'				 => BASEPATH . 'Database/BaseResult.php',
-			'CodeIgniter\Database\Config'					 => BASEPATH . 'Database/Config.php',
-			'CodeIgniter\Database\ConnectionInterface'		 => BASEPATH . 'Database/ConnectionInterface.php',
-			'CodeIgniter\Database\Database'					 => BASEPATH . 'Database/Database.php',
-			'CodeIgniter\Database\Query'					 => BASEPATH . 'Database/Query.php',
-			'CodeIgniter\Database\QueryInterface'			 => BASEPATH . 'Database/QueryInterface.php',
-			'CodeIgniter\Database\ResultInterface'			 => BASEPATH . 'Database/ResultInterface.php',
-			'CodeIgniter\Database\Migration'				 => BASEPATH . 'Database/Migration.php',
-			'CodeIgniter\Database\MigrationRunner'			 => BASEPATH . 'Database/MigrationRunner.php',
-			'CodeIgniter\Debug\Exceptions'					 => BASEPATH . 'Debug/Exceptions.php',
-			'CodeIgniter\Debug\Timer'						 => BASEPATH . 'Debug/Timer.php',
-			'CodeIgniter\Debug\Iterator'					 => BASEPATH . 'Debug/Iterator.php',
-			'CodeIgniter\Events\Events'						 => BASEPATH . 'Events/Events.php',
-			'CodeIgniter\HTTP\CLIRequest'					 => BASEPATH . 'HTTP/CLIRequest.php',
-			'CodeIgniter\HTTP\ContentSecurityPolicy'		 => BASEPATH . 'HTTP/ContentSecurityPolicy.php',
-			'CodeIgniter\HTTP\CURLRequest'					 => BASEPATH . 'HTTP/CURLRequest.php',
-			'CodeIgniter\HTTP\IncomingRequest'				 => BASEPATH . 'HTTP/IncomingRequest.php',
-			'CodeIgniter\HTTP\Message'						 => BASEPATH . 'HTTP/Message.php',
-			'CodeIgniter\HTTP\Negotiate'					 => BASEPATH . 'HTTP/Negotiate.php',
-			'CodeIgniter\HTTP\Request'						 => BASEPATH . 'HTTP/Request.php',
-			'CodeIgniter\HTTP\RequestInterface'				 => BASEPATH . 'HTTP/RequestInterface.php',
-			'CodeIgniter\HTTP\Response'						 => BASEPATH . 'HTTP/Response.php',
-			'CodeIgniter\HTTP\ResponseInterface'			 => BASEPATH . 'HTTP/ResponseInterface.php',
-			'CodeIgniter\HTTP\URI'							 => BASEPATH . 'HTTP/URI.php',
-			'CodeIgniter\Log\Logger'						 => BASEPATH . 'Log/Logger.php',
-			'Psr\Log\LoggerAwareInterface'					 => BASEPATH . 'ThirdParty/PSR/Log/LoggerAwareInterface.php',
-			'Psr\Log\LoggerAwareTrait'						 => BASEPATH . 'ThirdParty/PSR/Log/LoggerAwareTrait.php',
-			'Psr\Log\LoggerInterface'						 => BASEPATH . 'ThirdParty/PSR/Log/LoggerInterface.php',
-			'Psr\Log\LogLevel'								 => BASEPATH . 'ThirdParty/PSR/Log/LogLevel.php',
-			'CodeIgniter\Log\Handlers\BaseHandler'			 => BASEPATH . 'Log/Handlers/BaseHandler.php',
-			'CodeIgniter\Log\Handlers\ChromeLoggerHandler'	 => BASEPATH . 'Log/Handlers/ChromeLoggerHandler.php',
-			'CodeIgniter\Log\Handlers\FileHandler'			 => BASEPATH . 'Log/Handlers/FileHandler.php',
-			'CodeIgniter\Log\Handlers\HandlerInterface'		 => BASEPATH . 'Log/Handlers/HandlerInterface.php',
-			'CodeIgniter\Router\RouteCollection'			 => BASEPATH . 'Router/RouteCollection.php',
-			'CodeIgniter\Router\RouteCollectionInterface'	 => BASEPATH . 'Router/RouteCollectionInterface.php',
-			'CodeIgniter\Router\Router'						 => BASEPATH . 'Router/Router.php',
-			'CodeIgniter\Router\RouterInterface'			 => BASEPATH . 'Router/RouterInterface.php',
-			'CodeIgniter\Security\Security'					 => BASEPATH . 'Security/Security.php',
-			'CodeIgniter\Session\Session'					 => BASEPATH . 'Session/Session.php',
-			'CodeIgniter\Session\SessionInterface'			 => BASEPATH . 'Session/SessionInterface.php',
-			'CodeIgniter\Session\Handlers\BaseHandler'		 => BASEPATH . 'Session/Handlers/BaseHandler.php',
-			'CodeIgniter\Session\Handlers\FileHandler'		 => BASEPATH . 'Session/Handlers/FileHandler.php',
-			'CodeIgniter\Session\Handlers\MemcachedHandler'	 => BASEPATH . 'Session/Handlers/MemcachedHandler.php',
-			'CodeIgniter\Session\Handlers\RedisHandler'		 => BASEPATH . 'Session/Handlers/RedisHandler.php',
-			'CodeIgniter\View\RendererInterface'			 => BASEPATH . 'View/RendererInterface.php',
-			'CodeIgniter\View\View'							 => BASEPATH . 'View/View.php',
-			'CodeIgniter\View\Parser'						 => BASEPATH . 'View/Parser.php',
-			'CodeIgniter\View\Cell'							 => BASEPATH . 'View/Cell.php',
-			'Zend\Escaper\Escaper'							 => BASEPATH . 'ThirdParty/ZendEscaper/Escaper.php',
-			'CodeIgniter\Log\TestLogger'					 => BASEPATH . '../tests/_support/Log/TestLogger.php',
-			'CIDatabaseTestCase'							 => BASEPATH . '../tests/_support/CIDatabaseTestCase.php'
+			'CodeIgniter\CodeIgniter'                       => BASEPATH . 'CodeIgniter.php',
+			'CodeIgniter\CLI\CLI'                           => BASEPATH . 'CLI/CLI.php',
+			'CodeIgniter\Cache\CacheFactory'                => BASEPATH . 'Cache/CacheFactory.php',
+			'CodeIgniter\Cache\CacheInterface'              => BASEPATH . 'Cache/CacheInterface.php',
+			'CodeIgniter\Cache\Handlers\DummyHandler'       => BASEPATH . 'Cache/Handlers/DummyHandler.php',
+			'CodeIgniter\Cache\Handlers\FileHandler'        => BASEPATH . 'Cache/Handlers/FileHandler.php',
+			'CodeIgniter\Cache\Handlers\MemcachedHandler'   => BASEPATH . 'Cache/Handlers/MemcachedHandler.php',
+			'CodeIgniter\Cache\Handlers\PredisHandler'      => BASEPATH . 'Cache/Handlers/PredisHandler.php',
+			'CodeIgniter\Cache\Handlers\RedisHandler'       => BASEPATH . 'Cache/Handlers/RedisHandler.php',
+			'CodeIgniter\Cache\Handlers\WincacheHandler'    => BASEPATH . 'Cache/Handlers/WincacheHandler.php',
+			'CodeIgniter\Controller'                        => BASEPATH . 'Controller.php',
+			'CodeIgniter\Config\AutoloadConfig'             => BASEPATH . 'Config/Autoload.php',
+			'CodeIgniter\Config\BaseConfig'                 => BASEPATH . 'Config/BaseConfig.php',
+			'CodeIgniter\Config\Database'                   => BASEPATH . 'Config/Database.php',
+			'CodeIgniter\Config\Database\Connection'        => BASEPATH . 'Config/Database/Connection.php',
+			'CodeIgniter\Config\Database\Connection\MySQLi' => BASEPATH . 'Config/Database/Connection/MySQLi.php',
+			'CodeIgniter\Config\DotEnv'                     => BASEPATH . 'Config/DotEnv.php',
+			'CodeIgniter\Database\BaseBuilder'              => BASEPATH . 'Database/BaseBuilder.php',
+			'CodeIgniter\Database\BaseConnection'           => BASEPATH . 'Database/BaseConnection.php',
+			'CodeIgniter\Database\BaseResult'               => BASEPATH . 'Database/BaseResult.php',
+			'CodeIgniter\Database\Config'                   => BASEPATH . 'Database/Config.php',
+			'CodeIgniter\Database\ConnectionInterface'      => BASEPATH . 'Database/ConnectionInterface.php',
+			'CodeIgniter\Database\Database'                 => BASEPATH . 'Database/Database.php',
+			'CodeIgniter\Database\Query'                    => BASEPATH . 'Database/Query.php',
+			'CodeIgniter\Database\QueryInterface'           => BASEPATH . 'Database/QueryInterface.php',
+			'CodeIgniter\Database\ResultInterface'          => BASEPATH . 'Database/ResultInterface.php',
+			'CodeIgniter\Database\Migration'                => BASEPATH . 'Database/Migration.php',
+			'CodeIgniter\Database\MigrationRunner'          => BASEPATH . 'Database/MigrationRunner.php',
+			'CodeIgniter\Debug\Exceptions'                  => BASEPATH . 'Debug/Exceptions.php',
+			'CodeIgniter\Debug\Timer'                       => BASEPATH . 'Debug/Timer.php',
+			'CodeIgniter\Debug\Iterator'                    => BASEPATH . 'Debug/Iterator.php',
+			'CodeIgniter\Events\Events'                     => BASEPATH . 'Events/Events.php',
+			'CodeIgniter\HTTP\CLIRequest'                   => BASEPATH . 'HTTP/CLIRequest.php',
+			'CodeIgniter\HTTP\ContentSecurityPolicy'        => BASEPATH . 'HTTP/ContentSecurityPolicy.php',
+			'CodeIgniter\HTTP\CURLRequest'                  => BASEPATH . 'HTTP/CURLRequest.php',
+			'CodeIgniter\HTTP\IncomingRequest'              => BASEPATH . 'HTTP/IncomingRequest.php',
+			'CodeIgniter\HTTP\Message'                      => BASEPATH . 'HTTP/Message.php',
+			'CodeIgniter\HTTP\Negotiate'                    => BASEPATH . 'HTTP/Negotiate.php',
+			'CodeIgniter\HTTP\Request'                      => BASEPATH . 'HTTP/Request.php',
+			'CodeIgniter\HTTP\RequestInterface'             => BASEPATH . 'HTTP/RequestInterface.php',
+			'CodeIgniter\HTTP\Response'                     => BASEPATH . 'HTTP/Response.php',
+			'CodeIgniter\HTTP\ResponseInterface'            => BASEPATH . 'HTTP/ResponseInterface.php',
+			'CodeIgniter\HTTP\URI'                          => BASEPATH . 'HTTP/URI.php',
+			'CodeIgniter\Log\Logger'                        => BASEPATH . 'Log/Logger.php',
+			'Psr\Log\LoggerAwareInterface'                  => BASEPATH . 'ThirdParty/PSR/Log/LoggerAwareInterface.php',
+			'Psr\Log\LoggerAwareTrait'                      => BASEPATH . 'ThirdParty/PSR/Log/LoggerAwareTrait.php',
+			'Psr\Log\LoggerInterface'                       => BASEPATH . 'ThirdParty/PSR/Log/LoggerInterface.php',
+			'Psr\Log\LogLevel'                              => BASEPATH . 'ThirdParty/PSR/Log/LogLevel.php',
+			'CodeIgniter\Log\Handlers\BaseHandler'          => BASEPATH . 'Log/Handlers/BaseHandler.php',
+			'CodeIgniter\Log\Handlers\ChromeLoggerHandler'  => BASEPATH . 'Log/Handlers/ChromeLoggerHandler.php',
+			'CodeIgniter\Log\Handlers\FileHandler'          => BASEPATH . 'Log/Handlers/FileHandler.php',
+			'CodeIgniter\Log\Handlers\HandlerInterface'     => BASEPATH . 'Log/Handlers/HandlerInterface.php',
+			'CodeIgniter\Router\RouteCollection'            => BASEPATH . 'Router/RouteCollection.php',
+			'CodeIgniter\Router\RouteCollectionInterface'   => BASEPATH . 'Router/RouteCollectionInterface.php',
+			'CodeIgniter\Router\Router'                     => BASEPATH . 'Router/Router.php',
+			'CodeIgniter\Router\RouterInterface'            => BASEPATH . 'Router/RouterInterface.php',
+			'CodeIgniter\Security\Security'                 => BASEPATH . 'Security/Security.php',
+			'CodeIgniter\Session\Session'                   => BASEPATH . 'Session/Session.php',
+			'CodeIgniter\Session\SessionInterface'          => BASEPATH . 'Session/SessionInterface.php',
+			'CodeIgniter\Session\Handlers\BaseHandler'      => BASEPATH . 'Session/Handlers/BaseHandler.php',
+			'CodeIgniter\Session\Handlers\FileHandler'      => BASEPATH . 'Session/Handlers/FileHandler.php',
+			'CodeIgniter\Session\Handlers\MemcachedHandler' => BASEPATH . 'Session/Handlers/MemcachedHandler.php',
+			'CodeIgniter\Session\Handlers\RedisHandler'     => BASEPATH . 'Session/Handlers/RedisHandler.php',
+			'CodeIgniter\View\RendererInterface'            => BASEPATH . 'View/RendererInterface.php',
+			'CodeIgniter\View\View'                         => BASEPATH . 'View/View.php',
+			'CodeIgniter\View\Parser'                       => BASEPATH . 'View/Parser.php',
+			'CodeIgniter\View\Cell'                         => BASEPATH . 'View/Cell.php',
+			'Zend\Escaper\Escaper'                          => BASEPATH . 'ThirdParty/ZendEscaper/Escaper.php',
+			'CodeIgniter\Log\TestLogger'                    => SUPPORTPATH . 'Log/TestLogger.php',
+			'CIDatabaseTestCase'                            => SUPPORTPATH . 'CIDatabaseTestCase.php',
 		];
 	}
 


### PR DESCRIPTION
Actually, the `Config\Autoload` class in `application\Config` directory is extends the `CodeIgniter\Config\AutoloadConfig` which in the `__construct()` already set `$this->psr4['Tests\Support']`  and it called the:

```php
parent::__construct();
```

early, so it is no longer needed to be redefined as it will be merged with:

```php
$this->psr4     = array_merge($this->psr4, $psr4);
```

which merge parent `psr4` property to its `$psr4` variable. So, I removed its definition in `Config\Autoload::__construct()`.

**Checklist:**
- [x] Securely signed commits