### PR TITLE
fix Parser::parsePairs always escapes

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -371,6 +371,7 @@ class Parser extends View
 				}
 
 				$temp = [];
+				$pairs = [];
 				$out = $match[1];
 				foreach ($row as $key => $val)
 				{
@@ -382,6 +383,7 @@ class Parser extends View
 
 						if ( ! empty($pair))
 						{
+							$pairs[array_keys( $pair )[0]] = true;
 							$temp = array_merge($temp, $pair);
 						}
 
@@ -402,7 +404,7 @@ class Parser extends View
 				// Now replace our placeholders with the new content.
 				foreach ($temp as $pattern => $content)
 				{
-					$out = $this->replaceSingle($pattern, $content, $out, true);
+					$out = $this->replaceSingle($pattern, $content, $out, !isset( $pairs[$pattern] ) );
 				}
 
 				$str .= $out;


### PR DESCRIPTION
Signed-off-by: Christoph Potas <christoph286@googlemail.com>

**Description**
The parser should only escape single values because parsePair is called recursive on each array.
Fix #1104 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
