### PR TITLE
Fix FileMovingTest leaving cruft

### DIFF
--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -11,10 +11,16 @@ class FileMovingTest extends \CIUnitTestCase
 	{
 		parent::setUp();
 
-		$this->root	 = vfsStream::setup();
-		$this->path	 = '_support/Files/';
+		$this->root = vfsStream::setup();
+		$this->path = '_support/Files/';
 		vfsStream::copyFromFileSystem(TESTPATH . $this->path, $this->root);
 		$this->start = $this->root->url() . '/';
+
+		$this->destination = $this->start . 'destination';
+		if (is_dir($this->destination))
+		{
+			rmdir($this->destination);
+		}
 
 		$_FILES = [];
 	}
@@ -22,10 +28,14 @@ class FileMovingTest extends \CIUnitTestCase
 	public function tearDown()
 	{
 		parent::tearDown();
-
 		$this->root = null;
-		if (is_dir('/tmp/destination'))
-			rmdir('/tmp/destination');
+
+		// cleanup folder being left behind (why?)
+		$leftover = WRITEPATH . 'uploads/vfs:';
+		if (is_dir($leftover))
+		{
+			rrmdir($leftover);
+		}
 	}
 
 	//--------------------------------------------------------------------
@@ -35,19 +45,19 @@ class FileMovingTest extends \CIUnitTestCase
 		$finalFilename = 'fileA';
 
 		$_FILES = [
-			'userfile1'	 => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/plain',
-				'size'		 => 124,
-				'tmp_name'	 => '/tmp/fileA.txt',
-				'error'		 => 0
+			'userfile1' => [
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/plain',
+				'size'     => 124,
+				'tmp_name' => '/tmp/fileA.txt',
+				'error'    => 0,
 			],
-			'userfile2'	 => [
-				'name'		 => 'fileA.txt',
-				'type'		 => 'text/csv',
-				'size'		 => 248,
-				'tmp_name'	 => '/tmp/fileB.txt',
-				'error'		 => 0
+			'userfile2' => [
+				'name'     => 'fileA.txt',
+				'type'     => 'text/csv',
+				'size'     => 248,
+				'tmp_name' => '/tmp/fileB.txt',
+				'error'    => 0,
 			],
 		];
 
@@ -56,7 +66,7 @@ class FileMovingTest extends \CIUnitTestCase
 		$this->assertTrue($collection->hasFile('userfile1'));
 		$this->assertTrue($collection->hasFile('userfile2'));
 
-		$destination = $this->root->url() . '/destination';
+		$destination = $this->destination;
 
 		// Create the destination if not exists
 		is_dir($destination) || mkdir($destination, 0777, true);
@@ -78,26 +88,26 @@ class FileMovingTest extends \CIUnitTestCase
 		$finalFilename = 'file_with_delimiters_underscore';
 
 		$_FILES = [
-			'userfile1'	 => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/plain',
-				'size'		 => 124,
-				'tmp_name'	 => '/tmp/fileA.txt',
-				'error'		 => 0
+			'userfile1' => [
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/plain',
+				'size'     => 124,
+				'tmp_name' => '/tmp/fileA.txt',
+				'error'    => 0,
 			],
-			'userfile2'	 => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/csv',
-				'size'		 => 248,
-				'tmp_name'	 => '/tmp/fileB.txt',
-				'error'		 => 0
+			'userfile2' => [
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/csv',
+				'size'     => 248,
+				'tmp_name' => '/tmp/fileB.txt',
+				'error'    => 0,
 			],
-			'userfile3'	 => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/csv',
-				'size'		 => 248,
-				'tmp_name'	 => '/tmp/fileC.txt',
-				'error'		 => 0
+			'userfile3' => [
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/csv',
+				'size'     => 248,
+				'tmp_name' => '/tmp/fileC.txt',
+				'error'    => 0,
 			],
 		];
 
@@ -107,7 +117,7 @@ class FileMovingTest extends \CIUnitTestCase
 		$this->assertTrue($collection->hasFile('userfile2'));
 		$this->assertTrue($collection->hasFile('userfile3'));
 
-		$destination = $this->root->url() . '/destination';
+		$destination = $this->destination;
 
 		// Create the destination if not exists
 		is_dir($destination) || mkdir($destination, 0777, true);
@@ -132,11 +142,11 @@ class FileMovingTest extends \CIUnitTestCase
 
 		$_FILES = [
 			'userfile1' => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/plain',
-				'size'		 => 124,
-				'tmp_name'	 => '/tmp/fileA.txt',
-				'error'		 => 0
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/plain',
+				'size'     => 124,
+				'tmp_name' => '/tmp/fileA.txt',
+				'error'    => 0,
 			],
 		];
 
@@ -144,7 +154,7 @@ class FileMovingTest extends \CIUnitTestCase
 
 		$this->assertTrue($collection->hasFile('userfile1'));
 
-		$destination = $this->root->url() . '/destination';
+		$destination = $this->destination;
 
 		// Create the destination if not exists
 		is_dir($destination) || mkdir($destination, 0777, true);
@@ -165,11 +175,11 @@ class FileMovingTest extends \CIUnitTestCase
 
 		$_FILES = [
 			'userfile1' => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/plain',
-				'size'		 => 124,
-				'tmp_name'	 => '/tmp/fileA.txt',
-				'error'		 => 0
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/plain',
+				'size'     => 124,
+				'tmp_name' => '/tmp/fileA.txt',
+				'error'    => 0,
 			],
 		];
 
@@ -177,7 +187,7 @@ class FileMovingTest extends \CIUnitTestCase
 
 		$this->assertTrue($collection->hasFile('userfile1'));
 
-		$destination = 'destination/';
+		$destination = $this->destination;
 
 		// Create the destination if not exists
 		is_dir($destination) || mkdir($destination, 0777, true);
@@ -185,7 +195,7 @@ class FileMovingTest extends \CIUnitTestCase
 		$file = $collection->getFile('userfile1');
 
 		$this->assertInstanceOf(UploadedFile::class, $file);
-		$path = $file->store($destination, $file->getName(), false);
+		$path = $file->store($destination, $file->getName());
 		$this->assertEquals($destination . '/fileA.txt', $path);
 	}
 
@@ -197,11 +207,11 @@ class FileMovingTest extends \CIUnitTestCase
 
 		$_FILES = [
 			'userfile1' => [
-				'name'		 => $finalFilename . '.txt',
-				'type'		 => 'text/plain',
-				'size'		 => 124,
-				'tmp_name'	 => '/tmp/fileA.txt',
-				'error'		 => 0
+				'name'     => $finalFilename . '.txt',
+				'type'     => 'text/plain',
+				'size'     => 124,
+				'tmp_name' => '/tmp/fileA.txt',
+				'error'    => 0,
 			],
 		];
 
@@ -209,7 +219,7 @@ class FileMovingTest extends \CIUnitTestCase
 
 		$this->assertTrue($collection->hasFile('userfile1'));
 
-		$destination = $this->root->url() . '/destination';
+		$destination = $this->destination;
 
 		// Create the destination if not exists
 		is_dir($destination) || mkdir($destination, 0777, true);
@@ -229,19 +239,18 @@ class FileMovingTest extends \CIUnitTestCase
 	{
 		$_FILES = [
 			'userfile' => [
-				'name'		 => 'someFile.txt',
-				'type'		 => 'text/plain',
-				'size'		 => '124',
-				'tmp_name'	 => '/tmp/myTempFile.txt',
-				'error'		 => UPLOAD_ERR_INI_SIZE
-			]
+				'name'     => 'someFile.txt',
+				'type'     => 'text/plain',
+				'size'     => '124',
+				'tmp_name' => '/tmp/myTempFile.txt',
+				'error'    => UPLOAD_ERR_INI_SIZE,
+			],
 		];
 
-		$destination = $this->root->url() . '/destination';
-		// don't create the folder, so setPath() is invoked.
+		$destination = $this->destination;
 
-		$collection	 = new FileCollection();
-		$file		 = $collection->getFile('userfile');
+		$collection = new FileCollection();
+		$file       = $collection->getFile('userfile');
 
 		$this->expectException(HTTPException::class);
 		$file->move($destination, $file->getName(), false);
@@ -253,20 +262,21 @@ class FileMovingTest extends \CIUnitTestCase
 	{
 		$_FILES = [
 			'userfile' => [
-				'name'		 => 'someFile.txt',
-				'type'		 => 'text/plain',
-				'size'		 => '124',
-				'tmp_name'	 => '/tmp/myTempFile.txt',
-				'error'		 => 0,
-			]
+				'name'     => 'someFile.txt',
+				'type'     => 'text/plain',
+				'size'     => '124',
+				'tmp_name' => '/tmp/myTempFile.txt',
+				'error'    => 0,
+			],
 		];
 
-		$destination = '/tmp/destination';
+		$destination = $this->destination;
+
 		// Create the destination and make it read only
 		is_dir($destination) || mkdir($destination, 0400, true);
 
-		$collection	 = new FileCollection();
-		$file		 = $collection->getFile('userfile');
+		$collection = new FileCollection();
+		$file       = $collection->getFile('userfile');
 
 		$this->expectException(HTTPException::class);
 		$file->move($destination, $file->getName(), false);
@@ -284,7 +294,7 @@ class FileMovingTest extends \CIUnitTestCase
 
 function is_uploaded_file($filename)
 {
-	if ( ! file_exists($filename))
+	if (! file_exists($filename))
 	{
 		file_put_contents($filename, 'data');
 	}
@@ -299,5 +309,28 @@ function is_uploaded_file($filename)
 
 function move_uploaded_file($filename, $destination)
 {
-		return copy($filename, $destination);
+	copy($filename, $destination);
+	unlink($filename);
+}
+
+function rrmdir($src)
+{
+	$dir = opendir($src);
+	while (false !== ( $file = readdir($dir)))
+	{
+		if (( $file !== '.' ) && ( $file !== '..' ))
+		{
+			$full = $src . '/' . $file;
+			if (is_dir($full))
+			{
+				rrmdir($full);
+			}
+			else
+			{
+				unlink($full);
+			}
+		}
+	}
+	closedir($dir);
+	rmdir($src);
 }


### PR DESCRIPTION
HTTP\Files]FilesMovingTest was leaving a "vfs:" folder inside WRITEPATH/uploads.
That is now explicitly deleted as part of tearDown().