### PR TITLE
Ensure FileHandlerTest uses MockFileHandler

### DIFF
--- a/tests/system/Log/FileHandlerTest.php
+++ b/tests/system/Log/FileHandlerTest.php
@@ -9,44 +9,44 @@ class FileHandlerTest extends \CIUnitTestCase
 
 	public function setUp()
 	{
-		$this->root = vfsStream::setup('root');
+		$this->root  = vfsStream::setup('root');
 		$this->start = $this->root->url() . '/';
 	}
 
 	public function testHandle()
 	{
-		$config = new LoggerConfig();
+		$config                                                                = new LoggerConfig();
 		$config->handlers['Tests\Support\Log\Handlers\TestHandler']['handles'] = ['critical'];
 
-		$logger = new FileHandler($config->handlers['Tests\Support\Log\Handlers\TestHandler']);
-		$logger->setDateFormat("Y-m-d H:i:s:u");
-		$this->assertTrue($logger->handle("warning", "This is a test log"));
+		$logger = new MockFileHandler($config->handlers['Tests\Support\Log\Handlers\TestHandler']);
+		$logger->setDateFormat('Y-m-d H:i:s:u');
+		$this->assertTrue($logger->handle('warning', 'This is a test log'));
 	}
 
 	//--------------------------------------------------------------------
 
 	public function testBasicHandle()
 	{
-		$config = new LoggerConfig();
-		$config->path = $this->start . 'charlie/';
+		$config                                                                = new LoggerConfig();
+		$config->path                                                          = $this->start . 'charlie/';
 		$config->handlers['Tests\Support\Log\Handlers\TestHandler']['handles'] = ['critical'];
-		$logger = new MockFileHandler($config->handlers['Tests\Support\Log\Handlers\TestHandler']);
-		$logger->setDateFormat("Y-m-d H:i:s:u");
-		$this->assertTrue($logger->handle("warning", "This is a test log"));
+		$logger                                                                = new MockFileHandler($config->handlers['Tests\Support\Log\Handlers\TestHandler']);
+		$logger->setDateFormat('Y-m-d H:i:s:u');
+		$this->assertTrue($logger->handle('warning', 'This is a test log'));
 	}
 
 	public function testHandleCreateFile()
 	{
-		$config = new LoggerConfig();
+		$config       = new LoggerConfig();
 		$config->path = $this->start;
-		$logger = new MockFileHandler((array) $config);
+		$logger       = new MockFileHandler((array) $config);
 
-		$logger->setDateFormat("Y-m-d H:i:s:u");
-		$logger->handle("warning", "This is a test log");
+		$logger->setDateFormat('Y-m-d H:i:s:u');
+		$logger->handle('warning', 'This is a test log');
 
 		$expected = 'log-' . date('Y-m-d') . '.php';
-		$fp = fopen($config->path . $expected, 'r');
-		$line = fgets($fp);
+		$fp       = fopen($config->path . $expected, 'r');
+		$line     = fgets($fp);
 		fclose($fp);
 
 		// did the log file get created?
@@ -56,16 +56,16 @@ class FileHandlerTest extends \CIUnitTestCase
 
 	public function testHandleDateTimeCorrectly()
 	{
-		$config = new LoggerConfig();
+		$config       = new LoggerConfig();
 		$config->path = $this->start;
-		$logger = new MockFileHandler((array) $config);
+		$logger       = new MockFileHandler((array) $config);
 
 		$logger->setDateFormat('Y-m-d');
 		$expected = 'log-' . date('Y-m-d') . '.php';
 
 		$logger->handle('debug', 'Test message');
 
-		$fp = fopen($config->path . $expected, 'r');
+		$fp   = fopen($config->path . $expected, 'r');
 		$line = fgets($fp); // skip opening PHP tag
 		$line = fgets($fp); // skip blank line
 		$line = fgets($fp); // and get the second line


### PR DESCRIPTION
"This is a test log" entries were piling up inside log files inside writable/logs, which would then have to be manually deleted. The log files are gt ignored, but cluttering up the writeable/logs folder.