### PR TITLE
Fixes "options" request call parameter in FeatureTestCase class

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -199,7 +199,7 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 */
 	public function options(string $path, array $params = null)
 	{
-		return $this->call('delete', $path, $params);
+		return $this->call('options', $path, $params);
 	}
 
 	/**


### PR DESCRIPTION
The function is `options()`, the parameter should be `options` instead of `delete`.

**Checklist:**
- [x] Securely signed commits
