### PR TITLE
Fixes #1393: add missing sendCookies() after sendHeaders() call on Response::redirect()

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -27,21 +27,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package      CodeIgniter
- * @author       CodeIgniter Dev Team
- * @copyright    2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license      https://opensource.org/licenses/MIT	MIT License
- * @link         https://codeigniter.com
- * @since        Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use Config\App;
 use Config\Format;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 
 /**
  * Redirect exception
- *
  */
 class RedirectException extends \Exception
 {
@@ -120,8 +120,8 @@ class Response extends Message implements ResponseInterface
 		421 => 'Misdirected Request', // http://www.iana.org/go/rfc7540 Section 9.1.2
 		422 => 'Unprocessable Entity', // http://www.iana.org/go/rfc4918
 		423 => 'Locked', // http://www.iana.org/go/rfc4918
-              424 => 'Failed Dependency', // http://www.iana.org/go/rfc4918
-              425 => 'Too Early', // https://datatracker.ietf.org/doc/draft-ietf-httpbis-replay/
+		424 => 'Failed Dependency', // http://www.iana.org/go/rfc4918
+		425 => 'Too Early', // https://datatracker.ietf.org/doc/draft-ietf-httpbis-replay/
 		426 => 'Upgrade Required',
 		428 => 'Precondition Required', // 1.1; http://www.ietf.org/rfc/rfc6585.txt
 		429 => 'Too Many Requests', // 1.1; http://www.ietf.org/rfc/rfc6585.txt
@@ -154,14 +154,14 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * The current status code for this response.
 	 *
-	 * @var int
+	 * @var integer
 	 */
 	protected $statusCode = 200;
 
 	/**
 	 * Whether Content Security Policy is being enforced.
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $CSPEnabled = false;
 
@@ -196,14 +196,14 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * Cookie will only be set if a secure HTTPS connection exists.
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $cookieSecure = false;
 
 	/**
 	 * Cookie will only be accessible via HTTP(S) (no javascript)
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $cookieHTTPOnly = false;
 
@@ -217,7 +217,7 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * If true, will not write output. Useful during testing.
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $pretend = false;
 
@@ -264,7 +264,7 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * Turns "pretend" mode on or off to aid in testing.
 	 *
-	 * @param bool $pretend
+	 * @param boolean $pretend
 	 *
 	 * @return $this
 	 */
@@ -281,7 +281,7 @@ class Response extends Message implements ResponseInterface
 	 * The status code is a 3-digit integer result code of the getServer's attempt
 	 * to understand and satisfy the request.
 	 *
-	 * @return int Status code.
+	 * @return integer Status code.
 	 */
 	public function getStatusCode(): int
 	{
@@ -304,10 +304,10 @@ class Response extends Message implements ResponseInterface
 	 * @see http://tools.ietf.org/html/rfc7231#section-6
 	 * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 	 *
-	 * @param int    $code         The 3-digit integer result code to set.
-	 * @param string $reason       The reason phrase to use with the
-	 *                             provided status code; if none is provided, will
-	 *                             default to the IANA name.
+	 * @param integer $code   The 3-digit integer result code to set.
+	 * @param string  $reason The reason phrase to use with the
+	 *                        provided status code; if none is provided, will
+	 *                        default to the IANA name.
 	 *
 	 * @return self
 	 * @throws \InvalidArgumentException For invalid status code arguments.
@@ -376,7 +376,7 @@ class Response extends Message implements ResponseInterface
 	{
 		$date->setTimezone(new \DateTimeZone('UTC'));
 
-		$this->setHeader('Date', $date->format('D, d M Y H:i:s').' GMT');
+		$this->setHeader('Date', $date->format('D, d M Y H:i:s') . ' GMT');
 
 		return $this;
 	}
@@ -397,7 +397,7 @@ class Response extends Message implements ResponseInterface
 		// add charset attribute if not already there and provided as parm
 		if ((strpos($mime, 'charset=') < 1) && ! empty($charset))
 		{
-			$mime .= '; charset='.$charset;
+			$mime .= '; charset=' . $charset;
 		}
 
 		$this->removeHeader('Content-Type'); // replace existing content type
@@ -433,9 +433,9 @@ class Response extends Message implements ResponseInterface
 	{
 		$body = $this->body;
 
-		if ($this->bodyFormat != 'json')
+		if ($this->bodyFormat !== 'json')
 		{
-			$config = config(Format::class);
+			$config    = config(Format::class);
 			$formatter = $config->getFormatter('application/json');
 
 			$body = $formatter->format($body);
@@ -471,9 +471,9 @@ class Response extends Message implements ResponseInterface
 	{
 		$body = $this->body;
 
-		if ($this->bodyFormat != 'xml')
+		if ($this->bodyFormat !== 'xml')
 		{
-			$config = config(Format::class);
+			$config    = config(Format::class);
 			$formatter = $config->getFormatter('application/xml');
 
 			$body = $formatter->format($body);
@@ -488,7 +488,7 @@ class Response extends Message implements ResponseInterface
 	 * Handles conversion of the of the data into the appropriate format,
 	 * and sets the correct Content-Type header for our response.
 	 *
-	 * @param        $body
+	 * @param $body
 	 * @param string $format Valid: json, xml
 	 *
 	 * @return mixed
@@ -611,7 +611,7 @@ class Response extends Message implements ResponseInterface
 		if ($date instanceof \DateTime)
 		{
 			$date->setTimezone(new \DateTimeZone('UTC'));
-			$this->setHeader('Last-Modified', $date->format('D, d M Y H:i:s').' GMT');
+			$this->setHeader('Last-Modified', $date->format('D, d M Y H:i:s') . ' GMT');
 		}
 		elseif (is_string($date))
 		{
@@ -638,9 +638,10 @@ class Response extends Message implements ResponseInterface
 		if ($this->CSPEnabled === true)
 		{
 			$this->CSP->finalize($this);
-		}else{
-
-			$this->body = str_replace(['{csp-style-nonce}','{csp-script-nonce}'], '', $this->body);
+		}
+		else
+		{
+			$this->body = str_replace(['{csp-style-nonce}', '{csp-script-nonce}'], '', $this->body);
 		}
 
 		$this->sendHeaders();
@@ -679,7 +680,7 @@ class Response extends Message implements ResponseInterface
 		// Send all of our headers
 		foreach ($this->getHeaders() as $name => $values)
 		{
-			header($name.': '.$this->getHeaderLine($name), false, $this->statusCode);
+			header($name . ': ' . $this->getHeaderLine($name), false, $this->statusCode);
 		}
 
 		return $this;
@@ -714,9 +715,9 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * Perform a redirect to a new URL, in two flavors: header or location.
 	 *
-	 * @param string $uri  The URI to redirect to
-	 * @param string $method
-	 * @param int    $code The type of redirection, defaults to 302
+	 * @param string  $uri    The URI to redirect to
+	 * @param string  $method
+	 * @param integer $code   The type of redirection, defaults to 302
 	 *
 	 * @return $this
 	 * @throws \CodeIgniter\HTTP\RedirectException
@@ -725,7 +726,7 @@ class Response extends Message implements ResponseInterface
 	{
 		// IIS environment likely? Use 'refresh' for better compatibility
 		if ($method === 'auto' && isset($_SERVER['SERVER_SOFTWARE'])
-		    && strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== false)
+			&& strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== false)
 		{
 			$method = 'refresh';
 		}
@@ -746,7 +747,7 @@ class Response extends Message implements ResponseInterface
 		switch ($method)
 		{
 			case 'refresh':
-				$this->setHeader('Refresh', '0;url='.$uri);
+				$this->setHeader('Refresh', '0;url=' . $uri);
 				break;
 			default:
 				$this->setHeader('Location', $uri);
@@ -756,6 +757,7 @@ class Response extends Message implements ResponseInterface
 		$this->setStatusCode($code);
 
 		$this->sendHeaders();
+		$this->sendCookies();
 
 		return $this;
 	}
@@ -768,14 +770,14 @@ class Response extends Message implements ResponseInterface
 	 * Accepts an arbitrary number of binds (up to 7) or an associateive
 	 * array in the first parameter containing all the values.
 	 *
-	 * @param string|array $name     Cookie name or array containing binds
-	 * @param string       $value    Cookie value
-	 * @param string       $expire   Cookie expiration time in seconds
-	 * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
-	 * @param string       $path     Cookie path (default: '/')
-	 * @param string       $prefix   Cookie name prefix
-	 * @param bool|false   $secure   Whether to only transfer cookies via SSL
-	 * @param bool|false   $httponly Whether only make the cookie accessible via HTTP (no javascript)
+	 * @param string|array  $name     Cookie name or array containing binds
+	 * @param string        $value    Cookie value
+	 * @param string        $expire   Cookie expiration time in seconds
+	 * @param string        $domain   Cookie domain (e.g.: '.yourdomain.com')
+	 * @param string        $path     Cookie path (default: '/')
+	 * @param string        $prefix   Cookie name prefix
+	 * @param boolean|false $secure   Whether to only transfer cookies via SSL
+	 * @param boolean|false $httponly Whether only make the cookie accessible via HTTP (no javascript)
 	 */
 	public function setCookie(
 		$name,
@@ -786,7 +788,8 @@ class Response extends Message implements ResponseInterface
 		$prefix = '',
 		$secure = false,
 		$httponly = false
-	) {
+	)
+	{
 		if (is_array($name))
 		{
 			// always leave 'name' in last place, as the loop will break otherwise, due to $$item
@@ -804,7 +807,7 @@ class Response extends Message implements ResponseInterface
 			$prefix = $this->cookiePrefix;
 		}
 
-		if ($domain == '' && $this->cookieDomain != '')
+		if ($domain === '' && $this->cookieDomain !== '')
 		{
 			$domain = $this->cookieDomain;
 		}
@@ -826,15 +829,15 @@ class Response extends Message implements ResponseInterface
 
 		if (! is_numeric($expire))
 		{
-			$expire = time()-86500;
+			$expire = time() - 86500;
 		}
 		else
 		{
-			$expire = ($expire > 0) ? time()+$expire : 0;
+			$expire = ($expire > 0) ? time() + $expire : 0;
 		}
 
 		$this->cookies[] = [
-			'name'     => $prefix.$name,
+			'name'     => $prefix . $name,
 			'value'    => $value,
 			'expires'  => $expire,
 			'path'     => $path,
@@ -855,7 +858,7 @@ class Response extends Message implements ResponseInterface
 	 * @param null   $value
 	 * @param string $prefix
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
 	public function hasCookie(string $name, $value = null, string $prefix = '')
 	{
@@ -864,11 +867,11 @@ class Response extends Message implements ResponseInterface
 			$prefix = $this->cookiePrefix;
 		}
 
-		$name = $prefix.$name;
+		$name = $prefix . $name;
 
 		foreach ($this->cookies as $cookie)
 		{
-			if ($cookie['name'] != $prefix.$name)
+			if ($cookie['name'] !== $prefix . $name)
 			{
 				continue;
 			}
@@ -878,7 +881,7 @@ class Response extends Message implements ResponseInterface
 				return true;
 			}
 
-			return $cookie['value'] == $value;
+			return $cookie['value'] === $value;
 		}
 
 		return false;
@@ -899,11 +902,11 @@ class Response extends Message implements ResponseInterface
 			$prefix = $this->cookiePrefix;
 		}
 
-		$name = $prefix.$name;
+		$name = $prefix . $name;
 
 		foreach ($this->cookies as $cookie)
 		{
-			if ($cookie['name'] == $name)
+			if ($cookie['name'] === $name)
 			{
 				return $cookie;
 			}
@@ -913,7 +916,7 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * Sets a cookie to be deleted when the response is sent.
 	 *
-	 * @param        $name
+	 * @param $name
 	 * @param string $domain
 	 * @param string $path
 	 * @param string $prefix
@@ -925,13 +928,13 @@ class Response extends Message implements ResponseInterface
 			$prefix = $this->cookiePrefix;
 		}
 
-		$name = $prefix.$name;
+		$name = $prefix . $name;
 
 		foreach ($this->cookies as &$cookie)
 		{
-			if ($cookie['name'] == $name)
+			if ($cookie['name'] === $name)
 			{
-				$cookie['value'] = '';
+				$cookie['value']   = '';
 				$cookie['expires'] = '';
 
 				break;
@@ -966,9 +969,9 @@ class Response extends Message implements ResponseInterface
 	 * Generates the headers that force a download to happen. And
 	 * sends the file to the browser.
 	 *
-	 * @param string $filename The path to the file to send
-	 * @param string $data     The data to be downloaded
-	 * @param bool   $setMime  Whether to try and send the actual MIME type
+	 * @param string  $filename The path to the file to send
+	 * @param string  $data     The data to be downloaded
+	 * @param boolean $setMime  Whether to try and send the actual MIME type
 	 */
 	public function download(string $filename = '', $data = '', bool $setMime = false)
 	{


### PR DESCRIPTION
Fixes #1393 . The code of : 

```php
$this->response->redirect() ...
```

is calling `Response::redirect()` which doesn't call `sendCookies()` after `sendHeaders()`, so I added to be as follow:

```php
	public function redirect(string $uri, string $method = 'auto', int $code = null)
	{
                // ...
		$this->sendHeaders();
		$this->sendCookies();
                // ...
         }
```

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide