### PR TITLE
 Fixes #1393: add missing send() on response instance of RedirectResp…

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package	CodeIgniter
- * @author	CodeIgniter Dev Team
- * @copyright	2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license	https://opensource.org/licenses/MIT	MIT License
- * @link	https://codeigniter.com
- * @since	Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Request;
@@ -64,72 +65,84 @@ class CodeIgniter
 
 	/**
 	 * App startup time.
+	 *
 	 * @var mixed
 	 */
 	protected $startTime;
 
 	/**
 	 * Total app execution time
+	 *
 	 * @var float
 	 */
 	protected $totalTime;
 
 	/**
 	 * Main application configuration
+	 *
 	 * @var \Config\App
 	 */
 	protected $config;
 
 	/**
 	 * Timer instance.
+	 *
 	 * @var Timer
 	 */
 	protected $benchmark;
 
 	/**
 	 * Current request.
+	 *
 	 * @var HTTP\Request|HTTP\IncomingRequest|CLIRequest
 	 */
 	protected $request;
 
 	/**
 	 * Current response.
+	 *
 	 * @var HTTP\ResponseInterface
 	 */
 	protected $response;
 
 	/**
 	 * Router to use.
+	 *
 	 * @var Router\Router
 	 */
 	protected $router;
 
 	/**
 	 * Controller to use.
+	 *
 	 * @var string|\Closure
 	 */
 	protected $controller;
 
 	/**
 	 * Controller method to invoke.
+	 *
 	 * @var string
 	 */
 	protected $method;
 
 	/**
 	 * Output handler to use.
+	 *
 	 * @var string
 	 */
 	protected $output;
 
 	/**
 	 * Cache expiration time
-	 * @var int
+	 *
+	 * @var integer
 	 */
 	protected static $cacheTTL = 0;
 
 	/**
 	 * Request path to use.
+	 *
 	 * @var string
 	 */
 	protected $path;
@@ -137,7 +150,8 @@ class CodeIgniter
 	/**
 	 * Should the Response instance "pretend"
 	 * to keep from setting headers/cookies/etc
-	 * @var bool
+	 *
+	 * @var boolean
 	 */
 	protected $useSafeOutput = false;
 
@@ -146,7 +160,7 @@ class CodeIgniter
 	public function __construct($config)
 	{
 		$this->startTime = microtime(true);
-		$this->config = $config;
+		$this->config    = $config;
 	}
 
 	//--------------------------------------------------------------------
@@ -183,7 +197,7 @@ class CodeIgniter
 	 * makes all of the pieces work together.
 	 *
 	 * @param \CodeIgniter\Router\RouteCollectionInterface $routes
-	 * @param bool                                         $returnResponse
+	 * @param boolean                                      $returnResponse
 	 *
 	 * @throws \CodeIgniter\HTTP\RedirectException
 	 * @throws \Exception
@@ -204,7 +218,7 @@ class CodeIgniter
 		// Check for a cached page. Execution will stop
 		// if the page has been cached.
 		$cacheConfig = new Cache();
-		$response = $this->displayCache($cacheConfig);
+		$response    = $this->displayCache($cacheConfig);
 		if ($response instanceof ResponseInterface)
 		{
 			if ($returnResponse)
@@ -243,7 +257,7 @@ class CodeIgniter
 	 * cookies and headers are not actually sent, allowing PHP 7.2+ to
 	 * not complain when ini_set() function is used.
 	 *
-	 * @param bool $safe
+	 * @param boolean $safe
 	 *
 	 * @return $this
 	 */
@@ -260,8 +274,8 @@ class CodeIgniter
 	 * Handles the main request logic and fires the controller.
 	 *
 	 * @param \CodeIgniter\Router\RouteCollectionInterface $routes
-	 * @param                                              $cacheConfig
-	 * @param bool                                         $returnResponse
+	 * @param $cacheConfig
+	 * @param boolean                                      $returnResponse
 	 *
 	 * @return \CodeIgniter\HTTP\RequestInterface|\CodeIgniter\HTTP\Response|\CodeIgniter\HTTP\ResponseInterface|mixed
 	 * @throws \CodeIgniter\Filters\Exceptions\FilterException
@@ -278,18 +292,18 @@ class CodeIgniter
 		if (! is_null($routeFilter))
 		{
 			$filters->enableFilter($routeFilter, 'before');
-            $filters->enableFilter($routeFilter, 'after');
+			$filters->enableFilter($routeFilter, 'after');
 		}
 
 		$uri = $this->request instanceof CLIRequest ? $this->request->getPath() : $this->request->uri->getPath();
 
 		$possibleRedirect = $filters->run($uri, 'before');
-		if($possibleRedirect instanceof RedirectResponse)
+		if ($possibleRedirect instanceof RedirectResponse)
 		{
-			return $possibleRedirect;
+			return $possibleRedirect->send();
 		}
 		// If a Response instance is returned, the Response will be sent back to the client and script execution will stop
-		if($possibleRedirect instanceof ResponseInterface)
+		if ($possibleRedirect instanceof ResponseInterface)
 		{
 			return $possibleRedirect->send();
 		}
@@ -297,7 +311,7 @@ class CodeIgniter
 		$returned = $this->startController();
 
 		// Closure controller has run in startController().
-		if ( ! is_callable($this->controller))
+		if (! is_callable($this->controller))
 		{
 			$controller = $this->createController();
 
@@ -456,7 +470,7 @@ class CodeIgniter
 			return;
 		}
 
-		if (is_cli() && ! (ENVIRONMENT == 'testing'))
+		if (is_cli() && ! (ENVIRONMENT === 'testing'))
 		{
 			$this->request = Services::clirequest($this->config);
 		}
@@ -478,7 +492,7 @@ class CodeIgniter
 	{
 		$this->response = Services::response($this->config);
 
-		if ( ! is_cli() || ENVIRONMENT == 'testing')
+		if (! is_cli() || ENVIRONMENT === 'testing')
 		{
 			$this->response->setProtocolVersion($this->request->getProtocolVersion());
 		}
@@ -496,8 +510,8 @@ class CodeIgniter
 	 * as set the HTTP Strict Transport Security header for those browsers
 	 * that support it.
 	 *
-	 * @param int $duration  How long the Strict Transport Security
-	 *                       should be enforced for this URL.
+	 * @param integer $duration How long the Strict Transport Security
+	 *                          should be enforced for this URL.
 	 */
 	protected function forceSecureAccess($duration = 31536000)
 	{
@@ -518,20 +532,20 @@ class CodeIgniter
 	 *
 	 * @throws \Exception
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
 	public function displayCache($config)
 	{
 		if ($cachedResponse = cache()->get($this->generateCacheName($config)))
 		{
 			$cachedResponse = unserialize($cachedResponse);
-			if ( ! is_array($cachedResponse) || ! isset($cachedResponse['output']) || ! isset($cachedResponse['headers']))
+			if (! is_array($cachedResponse) || ! isset($cachedResponse['output']) || ! isset($cachedResponse['headers']))
 			{
-				throw new \Exception("Error unserializing page cache");
+				throw new \Exception('Error unserializing page cache');
 			}
 
 			$headers = $cachedResponse['headers'];
-			$output = $cachedResponse['output'];
+			$output  = $cachedResponse['output'];
 
 			// Clear all default headers
 			foreach ($this->response->getHeaders() as $key => $val)
@@ -557,7 +571,7 @@ class CodeIgniter
 	/**
 	 * Tells the app that the final output should be cached.
 	 *
-	 * @param int $time
+	 * @param integer $time
 	 *
 	 * @return $this
 	 */
@@ -599,8 +613,8 @@ class CodeIgniter
 	public function getPerformanceStats()
 	{
 		return [
-			'startTime'		 => $this->startTime,
-			'totalTime'		 => $this->totalTime,
+			'startTime' => $this->startTime,
+			'totalTime' => $this->totalTime,
 		];
 	}
 
@@ -615,7 +629,7 @@ class CodeIgniter
 	 */
 	protected function generateCacheName($config): string
 	{
-		if (is_cli() && ! (ENVIRONMENT == 'testing'))
+		if (is_cli() && ! (ENVIRONMENT === 'testing'))
 		{
 			return md5($this->request->getPath());
 		}
@@ -663,8 +677,8 @@ class CodeIgniter
 	 * match a route against the current URI. If the route is a
 	 * "redirect route", will also handle the redirect.
 	 *
-	 * @param RouteCollectionInterface $routes  An collection interface to use in place
-	 *                                          of the config file.
+	 * @param RouteCollectionInterface $routes An collection interface to use in place
+	 *                                         of the config file.
 	 *
 	 * @return array
 	 */
@@ -686,7 +700,7 @@ class CodeIgniter
 		ob_start();
 
 		$this->controller = $this->router->handle($path);
-		$this->method = $this->router->methodName();
+		$this->method     = $this->router->methodName();
 
 		// If a {locale} segment was matched in the final route,
 		// then we need to set the correct locale on our Request.
@@ -708,12 +722,12 @@ class CodeIgniter
 	 */
 	protected function determinePath()
 	{
-		if ( ! empty($this->path))
+		if (! empty($this->path))
 		{
 			return $this->path;
 		}
 
-		return (is_cli() && ! (ENVIRONMENT == 'testing')) ? $this->request->getPath() : $this->request->uri->getPath();
+		return (is_cli() && ! (ENVIRONMENT === 'testing')) ? $this->request->getPath() : $this->request->uri->getPath();
 	}
 
 	//--------------------------------------------------------------------
@@ -748,7 +762,7 @@ class CodeIgniter
 		$this->benchmark->start('controller_constructor');
 
 		// Is it routed to a Closure?
-		if (is_object($this->controller) && (get_class($this->controller) == 'Closure'))
+		if (is_object($this->controller) && (get_class($this->controller) === 'Closure'))
 		{
 			$controller = $this->controller;
 			return $controller(...$this->router->params());
@@ -761,11 +775,11 @@ class CodeIgniter
 		}
 
 		// Try to autoload the class
-		if ( ! class_exists($this->controller, true) || $this->method[0] === '_')
+		if (! class_exists($this->controller, true) || $this->method[0] === '_')
 		{
 			throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
 		}
-		else if ( ! method_exists($this->controller, '_remap') &&
+		else if (! method_exists($this->controller, '_remap') &&
 				! is_callable([$this->controller, $this->method], false)
 		)
 		{
@@ -838,7 +852,7 @@ class CodeIgniter
 				$this->benchmark->start('controller_constructor');
 
 				$this->controller = $override[0];
-				$this->method = $override[1];
+				$this->method     = $override[1];
 
 				unset($override);
 
@@ -893,7 +907,8 @@ class CodeIgniter
 			ob_end_clean();
 		}
 
-		if ($returned instanceof DownloadResponse) {
+		if ($returned instanceof DownloadResponse)
+		{
 			$this->response = $returned;
 			return;
 		}
@@ -906,7 +921,7 @@ class CodeIgniter
 		if ($returned instanceof Response)
 		{
 			$this->response = $returned;
-			$returned = $returned->getBody();
+			$returned       = $returned->getBody();
 		}
 
 		if (is_string($returned))
@@ -962,16 +977,22 @@ class CodeIgniter
 	public function spoofRequestMethod()
 	{
 		if (is_cli())
+		{
 			return;
+		}
 
 		// Only works with POSTED forms
 		if ($this->request->getMethod() !== 'post')
+		{
 			return;
+		}
 
 		$method = $this->request->getPost('_method');
 
 		if (empty($method))
+		{
 			return;
+		}
 
 		$this->request = $this->request->setMethod($method);
 	}


### PR DESCRIPTION
 Fixes #1393 : the `CodeIgniter::handleRequest()` missing call `send()` on `$possibleRedirect` instance of `RedirectResponse`.

Before:

```php
if ($possibleRedirect instanceof RedirectResponse)
{
        return $possibleRedirect;
}
```

After:

```php
if ($possibleRedirect instanceof RedirectResponse)
{
       return $possibleRedirect->send();
}
```

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
  
