### PR TITLE
can't call run() method with params from commands migrations.

### DIFF
--- a/system/Commands/Database/CreateMigration.php
+++ b/system/Commands/Database/CreateMigration.php
@@ -99,8 +99,6 @@ class CreateMigration extends BaseCommand
 	/**
 	 * Creates a new migration file with the current timestamp.
 	 *
-	 * @todo Have this check the settings and see what type of file it should create (timestamp or sequential)
-	 *
 	 * @param array $params
 	 */
 	public function run(array $params = [])
@@ -117,7 +115,7 @@ class CreateMigration extends BaseCommand
 			CLI::error(lang('Migrations.badCreateName'));
 			return;
 		}
-		$ns       = CLI::getOption('n');
+		$ns       = $params['-n'] ?? CLI::getOption('n');
 		$homepath = APPPATH;
 
 		if (! empty($ns))

--- a/system/Commands/Database/MigrateCurrent.php
+++ b/system/Commands/Database/MigrateCurrent.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package      CodeIgniter
- * @author       CodeIgniter Dev Team
- * @copyright    2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license      https://opensource.org/licenses/MIT	MIT License
- * @link         https://codeigniter.com
- * @since        Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
@@ -104,7 +105,7 @@ class MigrateCurrent extends BaseCommand
 
 		CLI::write(lang('Migrations.toVersion'), 'yellow');
 
-		$group = CLI::getOption('g');
+		$group = $params['-g'] ?? CLI::getOption('g');
 		try
 		{
 			$runner->current($group);
@@ -115,13 +116,11 @@ class MigrateCurrent extends BaseCommand
 			}
 
 			CLI::write('Done');
-
-		} catch (\Exception $e)
+		}
+		catch (\Exception $e)
 		{
 			$this->showError($e);
 		}
-
-
 	}
 
 }

--- a/system/Commands/Database/MigrateLatest.php
+++ b/system/Commands/Database/MigrateLatest.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package      CodeIgniter
- * @author       CodeIgniter Dev Team
- * @copyright    2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license      https://opensource.org/licenses/MIT	MIT License
- * @link         https://codeigniter.com
- * @since        Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
@@ -88,9 +89,9 @@ class MigrateLatest extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-n'	 => 'Set migration namespace',
-		'-g'	 => 'Set database group',
-		'-all'	 => 'Set latest for all namespace, will ignore (-n) option',
+		'-n'   => 'Set migration namespace',
+		'-g'   => 'Set database group',
+		'-all' => 'Set latest for all namespace, will ignore (-n) option',
 	];
 
 	/**
@@ -104,12 +105,12 @@ class MigrateLatest extends BaseCommand
 
 		CLI::write(lang('Migrations.toLatest'), 'yellow');
 
-		$namespace = CLI::getOption('n');
-		$group = CLI::getOption('g');
+		$namespace = $params['-n'] ?? CLI::getOption('n');
+		$group     = $params['-g'] ?? CLI::getOption('g');
 
 		try
 		{
-			if ( ! is_null(CLI::getOption('all')))
+			if ($this->isAllNamespace($params))
 			{
 				$runner->latestAll($group);
 			}
@@ -124,13 +125,31 @@ class MigrateLatest extends BaseCommand
 			}
 
 			CLI::write('Done');
-
-		} catch (\Exception $e)
+		}
+		catch (\Exception $e)
 		{
 			$this->showError($e);
 		}
+	}
 
+	/**
+	 * To migrate all namespaces to the latest migration
+	 *
+	 * Demo:
+	 *  1. command line: php spark migrate:latest -all
+	 *  2. command file: $this->call('migrate:latest', ['-g' => 'test','-all']);
+	 *
+	 * @param  array $params
+	 * @return boolean
+	 */
+	private function isAllNamespace(array $params)
+	{
+		if (array_search('-all', $params) !== false)
+		{
+			return true;
+		}
 
+		return ! is_null(CLI::getOption('all'));
 	}
 
 }

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package      CodeIgniter
- * @author       CodeIgniter Dev Team
- * @copyright    2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license      https://opensource.org/licenses/MIT	MIT License
- * @link         https://codeigniter.com
- * @since        Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
@@ -91,9 +92,9 @@ class MigrateRollback extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-n'	 => 'Set migration namespace',
-		'-g'	 => 'Set database group',
-		'-all'	 => 'Set latest for all namespace, will ignore (-n) option',
+		'-n'   => 'Set migration namespace',
+		'-g'   => 'Set database group',
+		'-all' => 'Set latest for all namespace, will ignore (-n) option',
 	];
 
 	/**
@@ -107,22 +108,24 @@ class MigrateRollback extends BaseCommand
 		$runner = Services::migrations();
 
 		CLI::write(lang('Migrations.rollingBack'), 'yellow');
-		$group = CLI::getOption('g');
-		if ( ! is_null($group))
+
+		$group = $params['-g'] ?? CLI::getOption('g');
+
+		if (! is_null($group))
 		{
 			$runner->setGroup($group);
 		}
 		try
 		{
-			if (is_null(CLI::getOption('all')))
+			if (! $this->isAllNamespace())
 			{
-				$namespace = CLI::getOption('n');
+				$namespace = $params['-n'] ?? CLI::getOption('n');
 				$runner->version(0, $namespace);
 			}
 			else
 			{
 				// Get all namespaces form  PSR4 paths.
-				$config = new Autoload();
+				$config     = new Autoload();
 				$namespaces = $config->psr4;
 				foreach ($namespaces as $namespace => $path)
 				{
@@ -142,13 +145,31 @@ class MigrateRollback extends BaseCommand
 			}
 
 			CLI::write('Done');
-
-		} catch (\Exception $e)
+		}
+		catch (\Exception $e)
 		{
 			$this->showError($e);
 		}
+	}
 
+	/**
+	 * To migrate all namespaces to the latest migration
+	 *
+	 * Demo:
+	 *  1. command line: php spark migrate:latest -all
+	 *  2. command file: $this->call('migrate:latest', ['-g' => 'test','-all']);
+	 *
+	 * @param  array $params
+	 * @return boolean
+	 */
+	private function isAllNamespace(array $params)
+	{
+		if (array_search('-all', $params) !== false)
+		{
+			return true;
+		}
 
+		return ! is_null(CLI::getOption('all'));
 	}
 
 }

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package      CodeIgniter
- * @author       CodeIgniter Dev Team
- * @copyright    2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license      https://opensource.org/licenses/MIT	MIT License
- * @link         https://codeigniter.com
- * @since        Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
@@ -96,7 +97,7 @@ class MigrateStatus extends BaseCommand
 	protected $ignoredNamespaces = [
 		'CodeIgniter',
 		'Config',
-		'Tests\Support'
+		'Tests\Support',
 	];
 
 	/**
@@ -108,13 +109,15 @@ class MigrateStatus extends BaseCommand
 	{
 		$runner = Services::migrations();
 
-		if ( ! is_null(CLI::getOption('g')))
+		$group = $params['-g'] ?? CLI::getOption('g');
+
+		if (! is_null($group))
 		{
-			$runner->setGroup(CLI::getOption('g'));
+			$runner->setGroup($group);
 		}
 
 		// Get all namespaces form  PSR4 paths.
-		$config = new Autoload();
+		$config     = new Autoload();
 		$namespaces = $config->psr4;
 
 		// Loop for all $namespaces
@@ -127,7 +130,7 @@ class MigrateStatus extends BaseCommand
 
 			$runner->setNamespace($namespace);
 			$migrations = $runner->findMigrations();
-			$history = $runner->getHistory();
+			$history    = $runner->getHistory();
 
 			CLI::write($namespace);
 
@@ -142,28 +145,27 @@ class MigrateStatus extends BaseCommand
 			$max = 0;
 			foreach ($migrations as $version => $migration)
 			{
-				$file = substr($migration->name, strpos($migration->name, $version . '_'));
+				$file                       = substr($migration->name, strpos($migration->name, $version . '_'));
 				$migrations[$version]->name = $file;
 
 				$max = max($max, strlen($file));
 			}
 
-			CLI::write('  '. str_pad(lang('Migrations.filename'), $max + 4) . lang('Migrations.on'), 'yellow');
-
+			CLI::write('  ' . str_pad(lang('Migrations.filename'), $max + 4) . lang('Migrations.on'), 'yellow');
 
 			foreach ($migrations as $version => $migration)
 			{
 				$date = '';
 				foreach ($history as $row)
 				{
-					if ($row['version'] != $version)
+					if ($row['version'] !== $version)
 					{
 						continue;
 					}
 
-					$date = date("Y-m-d H:i:s", $row['time']);
+					$date = date('Y-m-d H:i:s', $row['time']);
 				}
-				CLI::write(str_pad('  '.$migration->name, $max + 6) . ($date ? $date : '---'));
+				CLI::write(str_pad('  ' . $migration->name, $max + 6) . ($date ? $date : '---'));
 			}
 		}
 	}

--- a/system/Commands/Database/MigrateVersion.php
+++ b/system/Commands/Database/MigrateVersion.php
@@ -27,14 +27,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @package      CodeIgniter
- * @author       CodeIgniter Dev Team
- * @copyright    2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license      https://opensource.org/licenses/MIT	MIT License
- * @link         https://codeigniter.com
- * @since        Version 3.0.0
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 3.0.0
  * @filesource
  */
+
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
@@ -120,18 +121,18 @@ class MigrateVersion extends BaseCommand
 
 		CLI::write(sprintf(lang('Migrations.toVersionPH'), $version), 'yellow');
 
-		$namespace = CLI::getOption('n');
-		$group = CLI::getOption('g');
+		$namespace = $params['-n'] ?? CLI::getOption('n');
+		$group     = $params['-g'] ?? CLI::getOption('g');
+
 		try
 		{
 			$runner->version($version, $namespace, $group);
 			CLI::write('Done');
-		} catch (\Exception $e)
+		}
+		catch (\Exception $e)
 		{
 			$this->showError($e);
 		}
-
-
 	}
 
 }

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -190,7 +190,7 @@ You can use (latest) with the following options:
 
 - (-g) to chose database group, otherwise default database group will be used.
 - (-n) to choose namespace, otherwise (App) namespace will be used.
-- (all) to migrate all namespaces to the latest migration
+- (-all) to migrate all namespaces to the latest migration
 
 This example will migrate Blog namespace to latest::
 
@@ -237,7 +237,7 @@ You can use (rollback) with the following options:
 
 - (-g) to chose database group, otherwise default database group will be used.
 - (-n) to choose namespace, otherwise (App) namespace will be used.
-- (all) to migrate all namespaces to the latest migration
+- (-all) to migrate all namespaces to the latest migration
 
 **refresh**
 
@@ -249,7 +249,7 @@ You can use (refresh) with the following options:
 
 - (-g) to chose database group, otherwise default database group will be used.
 - (-n) to choose namespace, otherwise (App) namespace will be used.
-- (all) to migrate all namespaces to the latest migration
+- (-all) to migrate all namespaces to the latest migration
 
 **status**
 


### PR DESCRIPTION
**Description**
- can't call run() method with params from commands migrations. Fixes #1308
- update user guide for migration

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
