### PR TITLE
Change github organization name in docs (1of4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CodeIgniter 4 Development
 
-[![Build Status](https://travis-ci.org/bcit-ci/CodeIgniter4.svg?branch=develop)](https://travis-ci.org/bcit-ci/CodeIgniter4)
-[![Coverage Status](https://coveralls.io/repos/github/bcit-ci/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/github/bcit-ci/CodeIgniter4?branch=develop)
+[![Build Status](https://travis-ci.orgcodeigniter4/CodeIgniter4.svg?branch=develop)](https://travis-ci.orgcodeigniter4/CodeIgniter4)
+[![Coverage Status](https://coveralls.io/repos/githubcodeigniter4/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/githubcodeigniter4/CodeIgniter4?branch=develop)
 <br>
 
 ## What is CodeIgniter?
@@ -63,7 +63,7 @@ if you want to take the lead for one of them.
 
 We are not looking for out-of-scope contributions, only those that would be considered part of our controlled evolution!
 
-Please read the [*Contributing to CodeIgniter*](https://github.com/bcit-ci/CodeIgniter4/blob/develop/contributing.md) section in the user guide
+Please read the [*Contributing to CodeIgniter*](https://github.comcodeigniter4/CodeIgniter4/blob/develop/contributing.md) section in the user guide
 
 ## Server Requirements
 PHP version 7.1 or higher is required, with the following extensions installed: 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CodeIgniter 4 Development
 
-[![Build Status](https://travis-ci.orgcodeigniter4/CodeIgniter4.svg?branch=develop)](https://travis-ci.orgcodeigniter4/CodeIgniter4)
-[![Coverage Status](https://coveralls.io/repos/githubcodeigniter4/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/githubcodeigniter4/CodeIgniter4?branch=develop)
+[![Build Status](https://travis-ci.org/codeigniter4/CodeIgniter4.svg?branch=develop)](https://travis-ci.orgcodeigniter4/CodeIgniter4)
+[![Coverage Status](https://coveralls.io/repos/github/codeigniter4/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/githubcodeigniter4/CodeIgniter4?branch=develop)
 <br>
 
 ## What is CodeIgniter?
@@ -63,7 +63,7 @@ if you want to take the lead for one of them.
 
 We are not looking for out-of-scope contributions, only those that would be considered part of our controlled evolution!
 
-Please read the [*Contributing to CodeIgniter*](https://github.comcodeigniter4/CodeIgniter4/blob/develop/contributing.md) section in the user guide
+Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/CodeIgniter4/blob/develop/contributing.md) section in the user guide
 
 ## Server Requirements
 PHP version 7.1 or higher is required, with the following extensions installed: 

--- a/admin/docbot
+++ b/admin/docbot
@@ -2,7 +2,7 @@
 
 # Rebuild and deploy CodeIgniter4 user guide
 
-UPSTREAM=https://github.comcodeigniter4/CodeIgniter4.git
+UPSTREAM=https://github.com/codeigniter4/CodeIgniter4.git
 
 # Prepare the nested repo clone folder
 cd user_guide_src

--- a/admin/docbot
+++ b/admin/docbot
@@ -2,7 +2,7 @@
 
 # Rebuild and deploy CodeIgniter4 user guide
 
-UPSTREAM=https://github.com/bcit-ci/CodeIgniter4.git
+UPSTREAM=https://github.comcodeigniter4/CodeIgniter4.git
 
 # Prepare the nested repo clone folder
 cd user_guide_src

--- a/admin/post_release
+++ b/admin/post_release
@@ -2,7 +2,7 @@
 
 ## Cleanup after a framework release
 
-UPSTREAM=https://github.com/bcit-ci/CodeIgniter4.git
+UPSTREAM=https://github.comcodeigniter4/CodeIgniter4.git
 version=4
 qualifier=
 

--- a/admin/release
+++ b/admin/release
@@ -5,7 +5,7 @@
 #---------------------------------------------------
 # Setup variables
 
-UPSTREAM=https://github.com/bcit-ci/CodeIgniter4.git
+UPSTREAM=https://github.comcodeigniter4/CodeIgniter4.git
 action=test
 version=4
 qualifier=

--- a/admin/release-notes.md
+++ b/admin/release-notes.md
@@ -6,23 +6,23 @@ and the core implementation in place!
 This is an early pre-release of 4.0.0. It is not suitable for production!
 
 There are several possible downloads, that you can see on the 
-[release page](https://github.com/bcit-ci/CodeIgniter4/releases/tag/v4.0.0-alpha.1) 
+[release page](https://github.comcodeigniter4/CodeIgniter4/releases/tag/v4.0.0-alpha.1) 
 
 - the runnable versions as a 
-[zip](https://github.com/bcit-ci/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.zip) or a 
-[tarball](https://github.com/bcit-ci/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.tar.gz)/
+[zip](https://github.comcodeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.zip) or a 
+[tarball](https://github.comcodeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.tar.gz)/
 - the developer versions of the framework (with contributor components) as
-a [zip](https://github.com/bcit-ci/CodeIgniter4/archive/v4.0.0-alpha.1.zip) or a 
-[tarball](https://github.com/bcit-ci/CodeIgniter4/archive/v4.0.0-alpha.1.tar.gz)/
-- and finally the [epub](https://github.com/bcit-ci/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.epub) version of the user guide for this release.
+a [zip](https://github.comcodeigniter4/CodeIgniter4/archive/v4.0.0-alpha.1.zip) or a 
+[tarball](https://github.comcodeigniter4/CodeIgniter4/archive/v4.0.0-alpha.1.tar.gz)/
+- and finally the [epub](https://github.comcodeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.epub) version of the user guide for this release.
 
 The release has all the major features in place, but there are still gaps
 and issues. See ...
 
-- [Bugs in the 4.0.0-alpha.1](https://github.com/bcit-ci/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0-alpha)
-- [Things that we definitely want to see fixed before first proper release](https://github.com/bcit-ci/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0)
+- [Bugs in the 4.0.0-alpha.1](https://github.comcodeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0-alpha)
+- [Things that we definitely want to see fixed before first proper release](https://github.comcodeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0)
 - [Features we would like to see in the initial proper release](), if possible, else the next update to it
-- [Features that we are consciously deferring to later](https://github.com/bcit-ci/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.1.0)
+- [Features that we are consciously deferring to later](https://github.comcodeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.1.0)
 
 What we need now is feedback from the community ...
 

--- a/admin/release-notes.md
+++ b/admin/release-notes.md
@@ -6,23 +6,23 @@ and the core implementation in place!
 This is an early pre-release of 4.0.0. It is not suitable for production!
 
 There are several possible downloads, that you can see on the 
-[release page](https://github.comcodeigniter4/CodeIgniter4/releases/tag/v4.0.0-alpha.1) 
+[release page](https://github.com/codeigniter4/CodeIgniter4/releases/tag/v4.0.0-alpha.1) 
 
 - the runnable versions as a 
-[zip](https://github.comcodeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.zip) or a 
-[tarball](https://github.comcodeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.tar.gz)/
+[zip](https://github.com/codeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.zip) or a 
+[tarball](https://github.com/codeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.tar.gz)/
 - the developer versions of the framework (with contributor components) as
-a [zip](https://github.comcodeigniter4/CodeIgniter4/archive/v4.0.0-alpha.1.zip) or a 
-[tarball](https://github.comcodeigniter4/CodeIgniter4/archive/v4.0.0-alpha.1.tar.gz)/
-- and finally the [epub](https://github.comcodeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.epub) version of the user guide for this release.
+a [zip](https://github.com/codeigniter4/CodeIgniter4/archive/v4.0.0-alpha.1.zip) or a 
+[tarball](https://github.com/codeigniter4/CodeIgniter4/archive/v4.0.0-alpha.1.tar.gz)/
+- and finally the [epub](https://github.com/codeigniter4/CodeIgniter4/releases/download/v4.0.0-alpha.1/CodeIgniter-4.0.0-alpha.1.epub) version of the user guide for this release.
 
 The release has all the major features in place, but there are still gaps
 and issues. See ...
 
-- [Bugs in the 4.0.0-alpha.1](https://github.comcodeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0-alpha)
-- [Things that we definitely want to see fixed before first proper release](https://github.comcodeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0)
+- [Bugs in the 4.0.0-alpha.1](https://github.com/codeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0-alpha)
+- [Things that we definitely want to see fixed before first proper release](https://github.com/codeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0.0)
 - [Features we would like to see in the initial proper release](), if possible, else the next update to it
-- [Features that we are consciously deferring to later](https://github.comcodeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.1.0)
+- [Features that we are consciously deferring to later](https://github.com/codeigniter4/CodeIgniter4/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.1.0)
 
 What we need now is feedback from the community ...
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "support": {
         "forum": "http://forum.codeigniter.com/",
-        "source": "https://github.com/bcit-ci/CodeIgniter4",
+        "source": "https://github.comcodeigniter4/CodeIgniter4",
         "slack": "https://codeigniterchat.slack.com"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "support": {
         "forum": "http://forum.codeigniter.com/",
-        "source": "https://github.comcodeigniter4/CodeIgniter4",
+        "source": "https://github.com/codeigniter4/CodeIgniter4",
         "slack": "https://codeigniterchat.slack.com"
     }
 }

--- a/contributing.md
+++ b/contributing.md
@@ -68,11 +68,11 @@ Once the maintainer handling your pull request is happy with it they will merge 
 
 ### Keeping your fork up-to-date
 
-Unlike systems like Subversion, Git can have multiple remotes. A remote is the name for a URL of a Git repository. By default your fork will have a remote named "origin" which points to your fork, but you can add another remote named "codeigniter" which points to `git://github.com/bcit-ci/CodeIgniter4.git`. This is a read-only remote but you can pull from this develop branch to update your own.
+Unlike systems like Subversion, Git can have multiple remotes. A remote is the name for a URL of a Git repository. By default your fork will have a remote named "origin" which points to your fork, but you can add another remote named "codeigniter" which points to `git://github.comcodeigniter4/CodeIgniter4.git`. This is a read-only remote but you can pull from this develop branch to update your own.
 
 If you are using command-line you can do the following:
 
-1. `git remote add codeigniter git://github.com/bcit-ci/CodeIgniter4.git`
+1. `git remote add codeigniter git://github.comcodeigniter4/CodeIgniter4.git`
 2. `git pull codeigniter develop`
 3. `git push origin develop`
 

--- a/contributing.md
+++ b/contributing.md
@@ -68,11 +68,11 @@ Once the maintainer handling your pull request is happy with it they will merge 
 
 ### Keeping your fork up-to-date
 
-Unlike systems like Subversion, Git can have multiple remotes. A remote is the name for a URL of a Git repository. By default your fork will have a remote named "origin" which points to your fork, but you can add another remote named "codeigniter" which points to `git://github.comcodeigniter4/CodeIgniter4.git`. This is a read-only remote but you can pull from this develop branch to update your own.
+Unlike systems like Subversion, Git can have multiple remotes. A remote is the name for a URL of a Git repository. By default your fork will have a remote named "origin" which points to your fork, but you can add another remote named "codeigniter" which points to `git://github.com/codeigniter4/CodeIgniter4.git`. This is a read-only remote but you can pull from this develop branch to update your own.
 
 If you are using command-line you can do the following:
 
-1. `git remote add codeigniter git://github.comcodeigniter4/CodeIgniter4.git`
+1. `git remote add codeigniter git://github.com/codeigniter4/CodeIgniter4.git`
 2. `git pull codeigniter develop`
 3. `git push origin develop`
 

--- a/contributing/README.rst
+++ b/contributing/README.rst
@@ -13,7 +13,7 @@ Contributing to CodeIgniter
 CodeIgniter is a community driven project and accepts contributions of code
 and documentation from the community. These contributions are made in the form
 of Issues or `Pull Requests <https://help.github.com/articles/using-pull-requests/>`_
-on the `CodeIgniter4 repository <https://github.comcodeigniter4/CodeIgniter4>`_ on GitHub.
+on the `CodeIgniter4 repository <https://github.com/codeigniter4/CodeIgniter4>`_ on GitHub.
 
 Issues are a quick way to point out a bug. If you find a bug or documentation
 error in CodeIgniter then please check a few things first:

--- a/contributing/README.rst
+++ b/contributing/README.rst
@@ -13,7 +13,7 @@ Contributing to CodeIgniter
 CodeIgniter is a community driven project and accepts contributions of code
 and documentation from the community. These contributions are made in the form
 of Issues or `Pull Requests <https://help.github.com/articles/using-pull-requests/>`_
-on the `CodeIgniter4 repository <https://github.com/bcit-ci/CodeIgniter4>`_ on GitHub.
+on the `CodeIgniter4 repository <https://github.comcodeigniter4/CodeIgniter4>`_ on GitHub.
 
 Issues are a quick way to point out a bug. If you find a bug or documentation
 error in CodeIgniter then please check a few things first:

--- a/contributing/guidelines.rst
+++ b/contributing/guidelines.rst
@@ -67,7 +67,7 @@ Not all changes will need an entry in it, but new classes, major or BC changes
 to existing classes, and bug fixes should.
 
 See the `CodeIgniter 4 change log
-<https://github.comcodeigniter4/CodeIgniter/blob/develop/user_guide_src/source/changelog.rst>`_
+<https://github.com/codeigniter4/CodeIgniter/blob/develop/user_guide_src/source/changelog.rst>`_
 for an example.
 
 PHP Compatibility

--- a/contributing/guidelines.rst
+++ b/contributing/guidelines.rst
@@ -66,8 +66,8 @@ The change-log, in the user guide root, needs to be kept up-to-date.
 Not all changes will need an entry in it, but new classes, major or BC changes
 to existing classes, and bug fixes should.
 
-See the `CodeIgniter 3 change log
-<https://github.com/bcit-ci/CodeIgniter/blob/develop/user_guide_src/source/changelog.rst>`_
+See the `CodeIgniter 4 change log
+<https://github.comcodeigniter4/CodeIgniter/blob/develop/user_guide_src/source/changelog.rst>`_
 for an example.
 
 PHP Compatibility

--- a/contributing/workflow.rst
+++ b/contributing/workflow.rst
@@ -46,7 +46,7 @@ you cannot do the same with the shared one - you have to submit pull requests
 to it instead.
 
 `Creating a fork <https://help.github.com/articles/fork-a-repo/>`_ is done through the Github website. Navigate to `our
-repository <https://github.comcodeigniter4/CodeIgniter4>`_,
+repository <https://github.com/codeigniter4/CodeIgniter4>`_,
 click the **Fork** button in the top-right of the page, and choose which account or
 organization of yours should contain that fork.
 

--- a/contributing/workflow.rst
+++ b/contributing/workflow.rst
@@ -46,7 +46,7 @@ you cannot do the same with the shared one - you have to submit pull requests
 to it instead.
 
 `Creating a fork <https://help.github.com/articles/fork-a-repo/>`_ is done through the Github website. Navigate to `our
-repository <https://github.com/bcit-ci/CodeIgniter4>`_,
+repository <https://github.comcodeigniter4/CodeIgniter4>`_,
 click the **Fork** button in the top-right of the page, and choose which account or
 organization of yours should contain that fork.
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -294,7 +294,7 @@ Release Date: September 28, 2018
 
 Non-code changes:
     - User Guide adapted or rewritten
-    - [System message translations repository](https://github.com/bcit-ci/CodeIgniter4-translations)
+    - [System message translations repository](https://github.comcodeigniter4/CodeIgniter4-translations)
     - [Roadmap subforum](https://forum.codeigniter.com/forum-33.html) for more transparent planning
 
 New core classes:

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -294,7 +294,7 @@ Release Date: September 28, 2018
 
 Non-code changes:
     - User Guide adapted or rewritten
-    - [System message translations repository](https://github.comcodeigniter4/CodeIgniter4-translations)
+    - [System message translations repository](https://github.com/codeigniter4/CodeIgniter4-translations)
     - [Roadmap subforum](https://forum.codeigniter.com/forum-33.html) for more transparent planning
 
 New core classes:

--- a/user_guide_src/source/extending/contributing.rst
+++ b/user_guide_src/source/extending/contributing.rst
@@ -5,7 +5,7 @@ Contributing to CodeIgniter
 CodeIgniter is a community driven project and accepts contributions of code
 and documentation from the community. These contributions are made in the form
 of Issues or `Pull Requests <https://help.github.com/articles/using-pull-requests/>`_
-on the `CodeIgniter4 repository <https://github.com/bcit-ci/CodeIgniter4>`_ on GitHub.
+on the `CodeIgniter4 repository <https://github.comcodeigniter4/CodeIgniter4>`_ on GitHub.
 
 Issues are a quick way to point out a bug. If you find a bug or documentation
 error in CodeIgniter then please check a few things first:
@@ -19,7 +19,7 @@ Reporting issues is helpful but an even better approach is to send a Pull
 Request, which is done by "Forking" the main repository and committing to your
 own copy. This will require you to use the version control system called Git.
 
-Please see the `Contributing to CodeIgniter4 <https://github.com/bcit-ci/CodeIgniter4/tree/develop/contributing>`_ 
+Please see the `Contributing to CodeIgniter4 <https://github.comcodeigniter4/CodeIgniter4/tree/develop/contributing>`_ 
 section of our code repository.
 
 

--- a/user_guide_src/source/extending/contributing.rst
+++ b/user_guide_src/source/extending/contributing.rst
@@ -5,7 +5,7 @@ Contributing to CodeIgniter
 CodeIgniter is a community driven project and accepts contributions of code
 and documentation from the community. These contributions are made in the form
 of Issues or `Pull Requests <https://help.github.com/articles/using-pull-requests/>`_
-on the `CodeIgniter4 repository <https://github.comcodeigniter4/CodeIgniter4>`_ on GitHub.
+on the `CodeIgniter4 repository <https://github.com/codeigniter4/CodeIgniter4>`_ on GitHub.
 
 Issues are a quick way to point out a bug. If you find a bug or documentation
 error in CodeIgniter then please check a few things first:
@@ -19,7 +19,7 @@ Reporting issues is helpful but an even better approach is to send a Pull
 Request, which is done by "Forking" the main repository and committing to your
 own copy. This will require you to use the version control system called Git.
 
-Please see the `Contributing to CodeIgniter4 <https://github.comcodeigniter4/CodeIgniter4/tree/develop/contributing>`_ 
+Please see the `Contributing to CodeIgniter4 <https://github.com/codeigniter4/CodeIgniter4/tree/develop/contributing>`_ 
 section of our code repository.
 
 

--- a/user_guide_src/source/installation/downloads.rst
+++ b/user_guide_src/source/installation/downloads.rst
@@ -4,12 +4,12 @@ Downloading CodeIgniter
 
 `Git <http://git-scm.com/about>`_ is a distributed version control system.
 
-Public Git access is available at `GitHub <https://github.com/bcit-ci/CodeIgniter4>`_.
+Public Git access is available at `GitHub <https://github.comcodeigniter4/CodeIgniter4>`_.
 Please note that while every effort is made to keep this code base
 functional, we cannot guarantee the functionality of code taken from
 the develop branch.
 
-Stable versions are available via `GitHub Releases <https://github.com/bcit-ci/CodeIgniter4/releases>`_.
+Stable versions are available via `GitHub Releases <https://github.comcodeigniter4/CodeIgniter4/releases>`_.
 
-You can also download a zip of the `development branch <https://codeload.github.com/bcit-ci/CodeIgniter4/zip/develop>`_,
+You can also download a zip of the `development branch <https://codeload.github.comcodeigniter4/CodeIgniter4/zip/develop>`_,
 i.e. the upcoming version.

--- a/user_guide_src/source/installation/downloads.rst
+++ b/user_guide_src/source/installation/downloads.rst
@@ -4,12 +4,12 @@ Downloading CodeIgniter
 
 `Git <http://git-scm.com/about>`_ is a distributed version control system.
 
-Public Git access is available at `GitHub <https://github.comcodeigniter4/CodeIgniter4>`_.
+Public Git access is available at `GitHub <https://github.com/codeigniter4/CodeIgniter4>`_.
 Please note that while every effort is made to keep this code base
 functional, we cannot guarantee the functionality of code taken from
 the develop branch.
 
-Stable versions are available via `GitHub Releases <https://github.comcodeigniter4/CodeIgniter4/releases>`_.
+Stable versions are available via `GitHub Releases <https://github.com/codeigniter4/CodeIgniter4/releases>`_.
 
-You can also download a zip of the `development branch <https://codeload.github.comcodeigniter4/CodeIgniter4/zip/develop>`_,
+You can also download a zip of the `development branch <https://codeload.github.com/codeigniter4/CodeIgniter4/zip/develop>`_,
 i.e. the upcoming version.

--- a/user_guide_src/source/intro/psr.rst
+++ b/user_guide_src/source/intro/psr.rst
@@ -10,7 +10,7 @@ status of our compliance with the various accepted, and some draft, proposals.
 **PSR-1: Basic Coding Standard**
 
 This recommendation covers basic class, method, and file-naming standards. Our 
-`style guide <https://github.com/bcit-ci/CodeIgniter4/blob/develop/contributing/styleguide.rst>_`
+`style guide <https://github.comcodeigniter4/CodeIgniter4/blob/develop/contributing/styleguide.rst>_`
 meets PSR-1 and adds its own requirements on top of it.
 
 **PSR-2: Coding Style Guide**

--- a/user_guide_src/source/intro/psr.rst
+++ b/user_guide_src/source/intro/psr.rst
@@ -10,7 +10,7 @@ status of our compliance with the various accepted, and some draft, proposals.
 **PSR-1: Basic Coding Standard**
 
 This recommendation covers basic class, method, and file-naming standards. Our 
-`style guide <https://github.comcodeigniter4/CodeIgniter4/blob/develop/contributing/styleguide.rst>_`
+`style guide <https://github.com/codeigniter4/CodeIgniter4/blob/develop/contributing/styleguide.rst>_`
 meets PSR-1 and adds its own requirements on top of it.
 
 **PSR-2: Coding Style Guide**

--- a/user_guide_src/source/tutorial/conclusion.rst
+++ b/user_guide_src/source/tutorial/conclusion.rst
@@ -21,6 +21,6 @@ If you still have questions about the framework or your own CodeIgniter
 code, you can:
 
 -  Check out our `forums <http://forum.codeigniter.com/>`_
--  Visit our `IRC chatroom <https://github.com/bcit-ci/CodeIgniter/wiki/IRC>`_
--  Explore the `Wiki <https://github.com/bcit-ci/CodeIgniter/wiki/>`_
+-  Visit our `IRC chatroom <https://github.comcodeigniter4/CodeIgniter/wiki/IRC>`_
+-  Explore the `Wiki <https://github.comcodeigniter4/CodeIgniter/wiki/>`_
 

--- a/user_guide_src/source/tutorial/conclusion.rst
+++ b/user_guide_src/source/tutorial/conclusion.rst
@@ -21,6 +21,6 @@ If you still have questions about the framework or your own CodeIgniter
 code, you can:
 
 -  Check out our `forums <http://forum.codeigniter.com/>`_
--  Visit our `IRC chatroom <https://github.comcodeigniter4/CodeIgniter/wiki/IRC>`_
--  Explore the `Wiki <https://github.comcodeigniter4/CodeIgniter/wiki/>`_
+-  Visit our `IRC chatroom <https://github.com/codeigniter4/CodeIgniter/wiki/IRC>`_
+-  Explore the `Wiki <https://github.com/codeigniter4/CodeIgniter/wiki/>`_
 


### PR DESCRIPTION
Update the github organization, in the docs only, from bcit-ci to codeigniter4.
Note: these are done as separate PRs to make sure they go all the way through,