### PR TITLE
Fixes #1435 : unit test output not captured

### DIFF
--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -84,7 +84,9 @@ class BootstrapFCPATHTest extends \CIUnitTestCase
 	}
 
 	private function readOutput($file){
-		return  system('php -f ' . $file);
+		ob_start();
+		system('php -f ' . $file);
+		return ob_get_clean();
 	}
 
 


### PR DESCRIPTION
Fixes #1435 which the `FCPATH` constant is echoed in `system()` call.

**Checklist:**
- [x] Securely signed commits
