### PR TITLE
using existing is_cli() function in HTTP\IncomingRequest::isCLI()

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -269,7 +269,7 @@ class IncomingRequest extends Request
 	 */
 	public function isCLI(): bool
 	{
-		return (PHP_SAPI === 'cli' || defined('STDIN'));
+		return is_cli();
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
There is already `is_cli()` function at `Common.php` for it, so I think it is better to use it as it already defined.

**Checklist:**
- [x] Securely signed commits
