### PR TITLE
add missing break; on loop cards to get card info at CreditCardRules::valid_cc_number()

### DIFF
--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -112,6 +112,7 @@ class CreditCardRules
 			if ($card['name'] == $type)
 			{
 				$info = $card;
+				break;
 			}
 		}
 


### PR DESCRIPTION
Add break in loop of `foreach` cards property to get card info, when `$card['name'] == $type`, it assign `$info` variable. 

**Checklist:**
- [x] Securely signed commits
