### PR TITLE
BugFix  if there extension has only one mime type (string)

### DIFF
--- a/application/Config/Mimes.php
+++ b/application/Config/Mimes.php
@@ -313,7 +313,7 @@ class Mimes
 
 		$proposed_extension = trim(strtolower($proposed_extension));
 
-		if(!is_null($proposed_extension) && array_key_exists($proposed_extension, self::$mimes) && in_array($type, self::$mimes[$proposed_extension]))
+		if(!is_null($proposed_extension) && array_key_exists($proposed_extension, self::$mimes) && in_array($type, is_string(self::$mimes[$proposed_extension])?[self::$mimes[$proposed_extension]]:self::$mimes[$proposed_extension]))
 		{
 			return $proposed_extension;
 		}


### PR DESCRIPTION
 in_array() expects parameter 2 to be array, string given

APPPATH/Config/Mimes.php at line 316

Each pull request should address a single issue, and have a meaningful title.
