### PR TITLE
add missing break; in loop at Email::getEncoding()

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -977,6 +977,7 @@ class Email
 			if (strpos($this->charset, $charset) === 0)
 			{
 				$this->encoding = '7bit';
+				break;
 			}
 		}
 


### PR DESCRIPTION
On encoding set on match strpos with loop, and set `$this->encoding`, it needs `break;`.

**Checklist:**
- [x] Securely signed commits
