### PR TITLE
Fixes build and coverage status links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # CodeIgniter 4 Development
 
-[![Build Status](https://travis-ci.org/codeigniter4/CodeIgniter4.svg?branch=develop)](https://travis-ci.orgcodeigniter4/CodeIgniter4)
-[![Coverage Status](https://coveralls.io/repos/github/codeigniter4/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/githubcodeigniter4/CodeIgniter4?branch=develop)
+[![Build Status](https://travis-ci.org/bcit-ci/CodeIgniter4.svg?branch=develop)](https://travis-ci.org/bcit-ci/CodeIgniter4)
+[![Coverage Status](https://coveralls.io/repos/github/bcit-ci/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/github/bcit-ci/CodeIgniter4?branch=develop)
 <br>
 
 ## What is CodeIgniter?
-CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure. 
+CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure.
 More information can be found at the [official site](http://codeigniter.com).
 
-This repository holds the pre-alpha code for CodeIgniter 4 only. 
-Version 4 is a complete rewrite to bring the quality and the code into a more modern version, 
-while still keeping as many of the things intact that has made people love the framework over the years. 
+This repository holds the pre-alpha code for CodeIgniter 4 only.
+Version 4 is a complete rewrite to bring the quality and the code into a more modern version,
+while still keeping as many of the things intact that has made people love the framework over the years.
 
 **This is pre-release code and should not be used in production sites.**
 
@@ -42,7 +42,7 @@ be closed! If you are not sure if you have found a bug, raise a thread on the fo
 someone else may have encountered the same thing.
 
 Before raising a new Github issue, please check that your bug hasn't already
-been reported or fixed. 
+been reported or fixed.
 
 We use pull requests (PRs) for CONTRIBUTIONS to the repository.
 We are looking for contributions that address one of the reported bugs or
@@ -57,8 +57,8 @@ to optional packages, with their own repository.
 ## Contributing
 We **are** accepting contributions from the community, specifically those identified as part of phase 2.
 
-We will try to manage the process somewhat, by adding a "Help wanted" label to those that we are 
-specifically interested in at any point in time. Join the discussion for those issues, and let us know 
+We will try to manage the process somewhat, by adding a "Help wanted" label to those that we are
+specifically interested in at any point in time. Join the discussion for those issues, and let us know
 if you want to take the lead for one of them.
 
 We are not looking for out-of-scope contributions, only those that would be considered part of our controlled evolution!
@@ -66,7 +66,7 @@ We are not looking for out-of-scope contributions, only those that would be cons
 Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/CodeIgniter4/blob/develop/contributing.md) section in the user guide
 
 ## Server Requirements
-PHP version 7.1 or higher is required, with the following extensions installed: 
+PHP version 7.1 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library


### PR DESCRIPTION
Before and after in diff commit:

![screen shot 2018-11-12 at 3 34 18 am](https://user-images.githubusercontent.com/459648/48317960-e719a580-e62b-11e8-9eea-dd5a59c85f84.png)


**Checklist:**
- [x] Securely signed commits
