### PR TITLE
Add setSilent() method to URI class

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -153,6 +153,13 @@ class URI
 	 */
 	protected $showPassword = false;
 
+	/**
+	 * If true, will continue instead of throwing exceptions.
+	 *
+	 * @var boolean
+	 */
+	protected $silent = false;
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -173,6 +180,23 @@ class URI
 	//--------------------------------------------------------------------
 
 	/**
+	 * If $silent == true, then will not throw exceptions and will
+	 * attempt to continue gracefully.
+	 *
+	 * @param boolean $silent
+	 *
+	 * @return URI
+	 */
+	public function setSilent(bool $silent = true)
+	{
+		$this->silent = $silent;
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Sets and overwrites any current URI information.
 	 *
 	 * @param string|null $uri
@@ -187,6 +211,11 @@ class URI
 
 			if ($parts === false)
 			{
+				if ($this->silent)
+				{
+					return $this;
+				}
+
 				throw HTTPException::forUnableToParseURI($uri);
 			}
 
@@ -480,7 +509,7 @@ class URI
 		// but we still have to deal with a zero-based array.
 		$number -= 1;
 
-		if ($number > count($this->segments))
+		if ($number > count($this->segments) && ! $this->silent)
 		{
 			throw HTTPException::forURISegmentOutOfRange($number);
 		}
@@ -505,6 +534,11 @@ class URI
 
 		if ($number > count($this->segments) + 1)
 		{
+			if ($this->silent)
+			{
+				return $this;
+			}
+
 			throw HTTPException::forURISegmentOutOfRange($number);
 		}
 
@@ -689,6 +723,11 @@ class URI
 
 		if ($port <= 0 || $port > 65535)
 		{
+			if ($this->silent)
+			{
+				return $this;
+			}
+
 			throw HTTPException::forInvalidPort($port);
 		}
 
@@ -749,6 +788,11 @@ class URI
 	{
 		if (strpos($query, '#') !== false)
 		{
+			if ($this->silent)
+			{
+				return $this;
+			}
+
 			throw HTTPException::forMalformedQueryString();
 		}
 

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -65,6 +65,15 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testSegmentOutOfRangeWithSilent()
+	{
+		$url = 'http://abc.com/a123/b/c';
+		$uri = new URI($url);
+		$this->assertEquals('', $uri->setSilent()->getSegment(22));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testCanCastAsString()
 	{
 		$url = 'http://username:password@hostname:9090/path?arg=value#anchor';
@@ -225,6 +234,18 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testSetPortInvalidValuesSilent()
+	{
+		$url = 'http://example.com/path';
+		$uri = new URI($url);
+
+		$uri->setSilent()->setPort(70000);
+
+		$this->assertEquals(null, $uri->getPort());
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testSetPortTooSmall()
 	{
 		$url = 'http://example.com/path';
@@ -368,6 +389,18 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->expectException(HTTPException::class);
 		$uri->setQuery('?key=value#fragment');
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetQueryThrowsErrorWhenFragmentPresentSilent()
+	{
+		$url = 'http://example.com/path';
+		$uri = new URI($url);
+
+		$uri->setSilent()->setQuery('?key=value#fragment');
+
+		$this->assertEquals('', $uri->getQuery());
 	}
 
 	//--------------------------------------------------------------------
@@ -783,6 +816,18 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 		$uri->setSegment(6, 'banana');
 	}
 
+	public function testSetBadSegmentSilent()
+	{
+		$base = 'http://example.com/foo/bar/baz';
+
+		$uri = new URI($base);
+
+		$segments = $uri->getSegments();
+		$uri->setSilent()->setSegment(6, 'banana');
+
+		$this->assertEquals($segments, $uri->getSegments());
+	}
+
 	//--------------------------------------------------------------------
 	// Exploratory testing, investigating https://github.com/codeigniter4/CodeIgniter4/issues/2016
 
@@ -854,6 +899,26 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 		$uri = new URI($url);
 		$this->assertEquals([], $uri->getSegments());
 		$this->assertEquals(0, $uri->getTotalSegments());
+	}
+
+	public function testSetURI()
+	{
+		$url = ':';
+		$uri = new URI();
+
+		$this->expectException(HTTPException::class);
+		$this->expectExceptionMessage(lang('HTTP.cannotParseURI', [$url]));
+
+		$uri->setURI($url);
+	}
+
+	public function testSetURISilent()
+	{
+		$url = ':';
+		$uri = new URI();
+		$uri->setSilent()->setURI($url);
+
+		$this->assertTrue(true);
 	}
 
 }

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -248,3 +248,17 @@ Finally, you can retrieve an array of all of the segments::
 		1 => '15',
 		2 => 'profile'
 	]
+
+===========================
+Disable Throwing Exceptions
+===========================
+
+By default, some methods of this class may throw an exception. If you want to disable it, you can set a special flag
+that will prevent throwing exceptions.
+::
+
+	// Disable throwing exceptions
+	$request->setSilent();
+
+	// Enable throwing exceptions
+	$request->setSilent(false);

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -260,5 +260,5 @@ that will prevent throwing exceptions.
 	// Disable throwing exceptions
 	$uri->setSilent();
 
-	// Enable throwing exceptions
+	// Enable throwing exceptions (default)
 	$uri->setSilent(false);

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -258,7 +258,7 @@ that will prevent throwing exceptions.
 ::
 
 	// Disable throwing exceptions
-	$request->setSilent();
+	$uri->setSilent();
 
 	// Enable throwing exceptions
-	$request->setSilent(false);
+	$uri->setSilent(false);


### PR DESCRIPTION
**Description**
Using `$uri->setSilent()` method will disable throwing exceptions. May be handy for using with methods like `getSegment()`.

Ref: #2952, #2949

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide