### PR TITLE
Prevent random test failure of testCreateAddsToDatabase

### DIFF
--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -15,6 +15,9 @@ class FabricatorLiveTest extends CIDatabaseTestCase
 	{
 		$fabricator = new Fabricator(UserModel::class);
 
+		// Some countries violate the 40 character limit so override that
+		$fabricator->setOverrides(['country' => 'Spain']);
+
 		$result = $fabricator->create();
 
 		$this->seeInDatabase('user', ['name' => $result->name]);


### PR DESCRIPTION
**Description**
Prevent random test failure for - testCreateAddsToDatabase

```cli
1) CodeIgniter\Database\Live\FabricatorLiveTest::testCreateAddsToDatabase
ErrorException: pg_query(): Query failed: ERROR:  value too long for type character varying(40)
```

**Checklist:**
- [x] Securely signed commits
