### PR TITLE
Improvements to the mb_url_title() helper

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -618,7 +618,7 @@ if (! function_exists('url_title'))
 if (! function_exists('mb_url_title'))
 {
 	/**
-	 * Create URL Title that takes into account accented characters
+	 * Create URL Title that takes into account Unicode and accented characters
 	 *
 	 * Takes a "title" string as input and creates a
 	 * human-friendly URL string with a "separator" string
@@ -633,7 +633,26 @@ if (! function_exists('mb_url_title'))
 	{
 		helper('text');
 
-		return url_title(convert_accented_characters($str), $separator, $lowercase);
+		$q_separator = preg_quote($separator, '#');
+
+		$trans = [
+			'[^\pL\pM\d _-]'          => '',
+			'\s+'                     => $separator,
+			'(' . $q_separator . ')+' => $separator,
+		];
+
+		$str = strip_tags(convert_accented_characters($str));
+		foreach ($trans as $key => $val)
+		{
+			$str = preg_replace('#' . $key . '#iu', $val, $str);
+		}
+
+		if ($lowercase === true)
+		{
+			$str = mb_strtolower($str);
+		}
+
+		return trim(trim($str, $separator));
 	}
 }
 

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1154,6 +1154,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 			'\  testing 12'   => 'testing-12',
 			'Éléphant de PHP' => 'elephant-de-php',
 			'ä ö ü Ĝ β ę'     => 'ae-oe-ue-g-v-e',
+			'মশিউর রহমান'     => 'মশিউর-রহমান',
 		];
 
 		foreach ($words as $in => $out)
@@ -1171,6 +1172,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 			'_What\'s wrong with CSS?_' => 'Whats_wrong_with_CSS',
 			'Éléphant de PHP'           => 'Elephant_de_PHP',
 			'ä ö ü Ĝ β ę'               => 'ae_oe_ue_G_v_e',
+			'মশিউর রহমান'               => 'মশিউর_রহমান',
 		];
 
 		foreach ($words as $in => $out)

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -345,8 +345,8 @@ The following functions are available:
     :returns: URL-formatted string
     :rtype: string
 
-    This function works the same as :php:func:`url_title()` but it converts all
-    accented characters automatically.
+    This function works the same as :php:func:`url_title()` but it supports Unicode
+    and converts all accented characters automatically.
 
 .. php:function:: prep_url($str = '')
 


### PR DESCRIPTION
**Description**
This PR adds Unicode support to the `mb_url_title()` helper. See: #3180

I don't want to sound totally ignorant, but it would be great if someone with better knowledge of the non-Latin alphabet could check if this is working as it should. Right now this is purely based on feedback from @mmrtonmoybd.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
