### PR TITLE
Fix update query to return false on error

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2452,7 +2452,9 @@ class BaseBuilder
 		{
 			$this->resetWrite();
 
-			if ($this->db->query($sql, $this->binds, false))
+			$result = $this->db->query($sql, $this->binds, false);
+
+			if ($result->resultID)
 			{
 				// Clear our binds so we don't eat up memory
 				$this->binds = [];

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1120,11 +1120,38 @@ class ModelTest extends CIDatabaseTestCase
 			'deleted' => 0,
 		];
 
-		$id = $model->insert($data);
-		$model->update([1, 2], ['name' => 'Foo Bar']);
+		$id     = $model->insert($data);
+		$result = $model->update([1, 2], ['name' => 'Foo Bar']);
+
+		$this->assertTrue($result);
 
 		$this->seeInDatabase('user', ['id' => 1, 'name' => 'Foo Bar']);
 		$this->seeInDatabase('user', ['id' => 2, 'name' => 'Foo Bar']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testUpdateResultFail()
+	{
+		$this->setPrivateProperty($this->db, 'DBDebug', false);
+
+		$model = new EventModel();
+
+		$data = [
+			'name'    => 'Foo',
+			'email'   => 'foo@example.com',
+			'country' => 'US',
+			'deleted' => 0,
+		];
+
+		$id = $model->insert($data);
+
+		$this->setPrivateProperty($model, 'allowedFields', ['name123']);
+		$result = $model->update(1, ['name123' => 'Foo Bar 1']);
+
+		$this->assertFalse($result);
+
+		$this->dontSeeInDatabase('user', ['id' => 1, 'name' => 'Foo Bar 1']);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
The `update` query always returned `true`, even if there was an error in the query.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide