### PR TITLE
Add support for using raw query string

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -130,7 +130,7 @@ class CURLRequest extends Request
 		parent::__construct($config);
 
 		$this->response = $response;
-		$this->baseURI  = $uri;
+		$this->baseURI  = $uri->useRawQueryString();
 
 		$this->parseOptions($options);
 	}

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -641,14 +641,17 @@ class CURLRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$request = $this->getRequest([
 			'base_uri' => 'http://www.foo.com/api/v1/',
-			'query'    => ['name' => 'Henry'],
+			'query'    => [
+				'name' => 'Henry',
+				'd.t'  => 'value',
+			],
 		]);
 
 		$request->get('products');
 
 		$options = $request->curl_options;
 
-		$this->assertEquals('http://www.foo.com/api/v1/products?name=Henry', $options[CURLOPT_URL]);
+		$this->assertEquals('http://www.foo.com/api/v1/products?name=Henry&d.t=value', $options[CURLOPT_URL]);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -406,10 +406,24 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 		$url = 'http://example.com/path';
 		$uri = new URI($url);
 
-		$expected = 'http://example.com/path?key=value';
+		$expected = 'http://example.com/path?key=value&second_key=value.2';
 
-		$uri->setQuery('?key=value');
-		$this->assertEquals('key=value', $uri->getQuery());
+		$uri->setQuery('?key=value&second.key=value.2');
+		$this->assertEquals('key=value&second_key=value.2', $uri->getQuery());
+		$this->assertEquals($expected, (string) $uri);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetQuerySetsValueWithUseRawQueryString()
+	{
+		$url = 'http://example.com/path';
+		$uri = new URI($url);
+
+		$expected = 'http://example.com/path?key=value&second.key=value.2';
+
+		$uri->useRawQueryString()->setQuery('?key=value&second.key=value.2');
+		$this->assertEquals('key=value&second.key=value.2', $uri->getQuery());
 		$this->assertEquals($expected, (string) $uri);
 	}
 
@@ -420,10 +434,24 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 		$url = 'http://example.com/path';
 		$uri = new URI($url);
 
-		$expected = 'http://example.com/path?key=value';
+		$expected = 'http://example.com/path?key=value&second_key=value.2';
 
-		$uri->setQueryArray(['key' => 'value']);
-		$this->assertEquals('key=value', $uri->getQuery());
+		$uri->setQueryArray(['key' => 'value', 'second.key' => 'value.2']);
+		$this->assertEquals('key=value&second_key=value.2', $uri->getQuery());
+		$this->assertEquals($expected, (string) $uri);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetQueryArraySetsValueWithUseRawQueryString()
+	{
+		$url = 'http://example.com/path';
+		$uri = new URI($url);
+
+		$expected = 'http://example.com/path?key=value&second.key=value.2';
+
+		$uri->useRawQueryString()->setQueryArray(['key' => 'value', 'second.key' => 'value.2']);
+		$this->assertEquals('key=value&second.key=value.2', $uri->getQuery());
 		$this->assertEquals($expected, (string) $uri);
 	}
 

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -207,8 +207,8 @@ you can use the ``stripQuery()`` and ``keepQuery()`` methods to change the actua
     $uri->keepQuery('foo');
 
 .. note:: By default ``setQuery()`` and ``setQueryArray()`` methods uses native ``parse_str()`` function to prepare data. 
-If you want to use more liberal rules (which allow key names to contain dots), you can use a special method 
-``useRawQueryString()`` beforehand.
+	If you want to use more liberal rules (which allow key names to contain dots), you can use a special method 
+	``useRawQueryString()`` beforehand.
 
 Fragment
 --------

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -206,6 +206,10 @@ you can use the ``stripQuery()`` and ``keepQuery()`` methods to change the actua
     // Leaves just the 'foo' variable
     $uri->keepQuery('foo');
 
+.. note:: By default ``setQuery()`` and ``setQueryArray()`` methods uses native ``parse_str()`` function to prepare data. 
+If you want to use more liberal rules (which allow key names to contain dots), you can use a special method 
+``useRawQueryString()`` beforehand.
+
 Fragment
 --------
 


### PR DESCRIPTION
**Description**
This PR adds the ability to use raw query string data (key names with dots are allowed) when a special flag `URI::useRawQueryString()` is set. 

By default `URI::setQuery()` and `URI::setQueryArray()` methods uses native `parse_str()` function to prepare data which may cause problems when using "non standard" key names when working with `CURLRequest` class.

From now on `CURLRequest` class will always use `URI::useRawQueryString()` as default when working with a query string.

See: #3303

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
