### PR TITLE
Add support for DSN universal prototype

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -341,10 +341,7 @@ abstract class BaseConnection implements ConnectionInterface
 	{
 		foreach ($params as $key => $value)
 		{
-			if (property_exists($this, $key))
-			{
-				$this->$key = $value;
-			}
+			$this->$key = $value;
 		}
 	}
 

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -148,7 +148,7 @@ class Database
 	 * @param array $params
 	 *
 	 * @return array
-	 * @throws InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	protected function parseDSN(array $params): array
 	{

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -150,7 +150,7 @@ class Database
 	 * @return array
 	 * @throws InvalidArgumentException
 	 */
-	protected function parseDSN($params): array
+	protected function parseDSN(array $params): array
 	{
 		if (($dsn = parse_url($params['DSN'])) === false)
 		{

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -72,6 +72,12 @@ class Database
 	 */
 	public function load(array $params = [], string $alias)
 	{
+		// Handle universal DSN connection string
+		if (! empty($params['DSN']) && strpos($params['DSN'], '://') !== false)
+		{
+			$params = $this->parseDSN($params);
+		}
+
 		// No DB specified? Beat them senseless...
 		if (empty($params['DBDriver']))
 		{
@@ -132,6 +138,52 @@ class Database
 		}
 
 		return new $className($db);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Parse universal DSN string
+	 *
+	 * @param array $params
+	 *
+	 * @return array
+	 * @throws InvalidArgumentException
+	 */
+	protected function parseDSN($params): array
+	{
+		if (($dsn = parse_url($params['DSN'])) === false)
+		{
+			throw new \InvalidArgumentException('Your DSN connection string is invalid.');
+		}
+
+		$dsnParams = [
+			'DSN'      => '',
+			'DBDriver' => $dsn['scheme'],
+			'hostname' => isset($dsn['host']) ? rawurldecode($dsn['host']) : '',
+			'port'     => isset($dsn['port']) ? rawurldecode($dsn['port']) : '',
+			'username' => isset($dsn['user']) ? rawurldecode($dsn['user']) : '',
+			'password' => isset($dsn['pass']) ? rawurldecode($dsn['pass']) : '',
+			'database' => isset($dsn['path']) ? rawurldecode(substr($dsn['path'], 1)) : '',
+		];
+
+		// Do we have additional config items set?
+		if (! empty($dsn['query']))
+		{
+			parse_str($dsn['query'], $extra);
+
+			foreach ($extra as $key => $val)
+			{
+				if (is_string($val) && in_array(strtolower($val), ['true', 'false', 'null']))
+				{
+					$val = $val === 'null' ? null : filter_var($val, FILTER_VALIDATE_BOOLEAN);
+				}
+
+				$dsnParams[$key] = $val;
+			}
+		}
+
+		return array_merge($params, $dsnParams);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -174,7 +174,7 @@ class Database
 
 			foreach ($extra as $key => $val)
 			{
-				if (is_string($val) && in_array(strtolower($val), ['true', 'false', 'null']))
+                              if (is_string($val) && in_array(strtolower($val), ['true', 'false', 'null'], true))
 				{
 					$val = $val === 'null' ? null : filter_var($val, FILTER_VALIDATE_BOOLEAN);
 				}

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -561,7 +561,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 		// array, but they might be set by parse_url() if the configuration was
 		// provided via string> Example:
 		//
-		// postgre://username:password@localhost:5432/database?connect_timeout=5&sslmode=1
+		// Postgre://username:password@localhost:5432/database?connect_timeout=5&sslmode=1
 		foreach (['connect_timeout', 'options', 'sslmode', 'service'] as $key)
 		{
 			if (isset($this->{$key}) && is_string($this->{$key}) && $this->{$key} !== '')

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -32,7 +32,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 	];
 
 	protected $dsnGroup = [
-              'DSN'      => 'MySQLi://user:pass@localhost:3306/dbname?DBPrefix=test_&pConnect=true&charset=latin1&DBCollat=latin1_swedish_ci',
+		'DSN'      => 'MySQLi://user:pass@localhost:3306/dbname?DBPrefix=test_&pConnect=true&charset=latin1&DBCollat=latin1_swedish_ci',
 		'hostname' => '',
 		'username' => '',
 		'password' => '',
@@ -54,7 +54,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 	];
 
 	protected $dsnGroupPostgre = [
-              'DSN'      => 'Postgre://user:pass@localhost:5432/dbname?DBPrefix=test_&connect_timeout=5&sslmode=1',
+		'DSN'      => 'Postgre://user:pass@localhost:5432/dbname?DBPrefix=test_&connect_timeout=5&sslmode=1',
 		'hostname' => '',
 		'username' => '',
 		'password' => '',
@@ -81,7 +81,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'username' => '',
 		'password' => '',
 		'database' => '',
-              'DBDriver' => 'Postgres',
+		'DBDriver' => 'Postgre',
 		'DBPrefix' => 't_',
 		'pConnect' => false,
 		'DBDebug'  => (ENVIRONMENT !== 'production'),

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -32,7 +32,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 	];
 
 	protected $dsnGroup = [
-		'DSN'      => 'MySQLi://user:pass@localhost/dbname?DBPrefix=test_&pConnect=true&charset=latin1&DBCollat=latin1_swedish_ci',
+              'DSN'      => 'MySQLi://user:pass@localhost:3306/dbname?DBPrefix=test_&pConnect=true&charset=latin1&DBCollat=latin1_swedish_ci',
 		'hostname' => '',
 		'username' => '',
 		'password' => '',
@@ -54,7 +54,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 	];
 
 	protected $dsnGroupPostgre = [
-		'DSN'      => 'Postgre://user:pass@localhost/dbname?DBPrefix=test_&connect_timeout=5&sslmode=1',
+              'DSN'      => 'Postgre://user:pass@localhost:5432/dbname?DBPrefix=test_&connect_timeout=5&sslmode=1',
 		'hostname' => '',
 		'username' => '',
 		'password' => '',
@@ -81,7 +81,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'username' => '',
 		'password' => '',
 		'database' => '',
-		'DBDriver' => 'SQLite3',
+              'DBDriver' => 'Postgres',
 		'DBPrefix' => 't_',
 		'pConnect' => false,
 		'DBDebug'  => (ENVIRONMENT !== 'production'),

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -93,6 +93,11 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'failover' => [],
 	];
 
+	protected function tearDown(): void
+	{
+		$this->setPrivateProperty(Config::class, 'instances', []);
+	}
+
 	public function testConnectionGroup()
 	{
 		$conn = Config::connect($this->group, false);
@@ -175,10 +180,4 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
 	}
 
-	public function testConnectionInstances()
-	{
-		$this->assertEquals(4, count(Config::getConnections()));
-		$this->setPrivateProperty(Config::class, 'instances', []);
-		$this->assertEquals(0, count(Config::getConnections()));
-	}
 }

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -174,4 +174,11 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(true, $this->getPrivateProperty($conn, 'strictOn'));
 		$this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
 	}
+
+	public function testConnectionInstances()
+	{
+		$this->assertEquals(4, count(Config::getConnections()));
+		$this->setPrivateProperty(Config::class, 'instances', []);
+		$this->assertEquals(0, count(Config::getConnections()));
+	}
 }

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -1,0 +1,177 @@
+<?php
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Config;
+use CodeIgniter\Test\ReflectionHelper;
+
+class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
+{
+	use ReflectionHelper;
+
+	protected $group = [
+		'DSN'      => '',
+		'hostname' => 'localhost',
+		'username' => 'first',
+		'password' => 'last',
+		'database' => 'dbname',
+		'DBDriver' => 'MySQLi',
+		'DBPrefix' => 'test_',
+		'pConnect' => true,
+		'DBDebug'  => (ENVIRONMENT !== 'production'),
+		'cacheOn'  => false,
+		'cacheDir' => 'my/cacheDir',
+		'charset'  => 'utf8',
+		'DBCollat' => 'utf8_general_ci',
+		'swapPre'  => '',
+		'encrypt'  => false,
+		'compress' => false,
+		'strictOn' => true,
+		'failover' => [],
+	];
+
+	protected $dsnGroup = [
+		'DSN'      => 'MySQLi://user:pass@localhost/dbname?DBPrefix=test_&pConnect=true&charset=latin1&DBCollat=latin1_swedish_ci',
+		'hostname' => '',
+		'username' => '',
+		'password' => '',
+		'database' => '',
+		'DBDriver' => 'SQLite3',
+		'DBPrefix' => 't_',
+		'pConnect' => false,
+		'DBDebug'  => (ENVIRONMENT !== 'production'),
+		'cacheOn'  => false,
+		'cacheDir' => 'my/cacheDir',
+		'charset'  => 'utf8',
+		'DBCollat' => 'utf8_general_ci',
+		'swapPre'  => '',
+		'encrypt'  => false,
+		'compress' => false,
+		'strictOn' => true,
+		'failover' => [],
+	];
+
+	protected $dsnGroupPostgre = [
+		'DSN'      => 'Postgre://user:pass@localhost/dbname?DBPrefix=test_&connect_timeout=5&sslmode=1',
+		'hostname' => '',
+		'username' => '',
+		'password' => '',
+		'database' => '',
+		'DBDriver' => 'SQLite3',
+		'DBPrefix' => 't_',
+		'pConnect' => false,
+		'DBDebug'  => (ENVIRONMENT !== 'production'),
+		'cacheOn'  => false,
+		'cacheDir' => 'my/cacheDir',
+		'charset'  => 'utf8',
+		'DBCollat' => 'utf8_general_ci',
+		'swapPre'  => '',
+		'encrypt'  => false,
+		'compress' => false,
+		'strictOn' => true,
+		'failover' => [],
+	];
+
+	protected $dsnGroupPostgreNative = [
+		'DSN'      => 'pgsql:host=localhost;port=5432;dbname=database_name',
+		'hostname' => '',
+		'username' => '',
+		'password' => '',
+		'database' => '',
+		'DBDriver' => 'SQLite3',
+		'DBPrefix' => 't_',
+		'pConnect' => false,
+		'DBDebug'  => (ENVIRONMENT !== 'production'),
+		'cacheOn'  => false,
+		'cacheDir' => 'my/cacheDir',
+		'charset'  => 'utf8',
+		'DBCollat' => 'utf8_general_ci',
+		'swapPre'  => '',
+		'encrypt'  => false,
+		'compress' => false,
+		'strictOn' => true,
+		'failover' => [],
+	];
+
+	public function testConnectionGroup()
+	{
+		$conn = Config::connect($this->group, false);
+		$this->assertInstanceOf(BaseConnection::class, $conn);
+
+		$this->assertEquals($this->group['DSN'], $this->getPrivateProperty($conn, 'DSN'));
+		$this->assertEquals($this->group['hostname'], $this->getPrivateProperty($conn, 'hostname'));
+		$this->assertEquals($this->group['username'], $this->getPrivateProperty($conn, 'username'));
+		$this->assertEquals($this->group['password'], $this->getPrivateProperty($conn, 'password'));
+		$this->assertEquals($this->group['database'], $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals($this->group['DBDriver'], $this->getPrivateProperty($conn, 'DBDriver'));
+		$this->assertEquals($this->group['DBPrefix'], $this->getPrivateProperty($conn, 'DBPrefix'));
+		$this->assertEquals($this->group['pConnect'], $this->getPrivateProperty($conn, 'pConnect'));
+		$this->assertEquals($this->group['charset'], $this->getPrivateProperty($conn, 'charset'));
+		$this->assertEquals($this->group['DBCollat'], $this->getPrivateProperty($conn, 'DBCollat'));
+	}
+
+	public function testConnectionGroupWithDSN()
+	{
+		$conn = Config::connect($this->dsnGroup, false);
+		$this->assertInstanceOf(BaseConnection::class, $conn);
+
+		$this->assertEquals('', $this->getPrivateProperty($conn, 'DSN'));
+		$this->assertEquals('localhost', $this->getPrivateProperty($conn, 'hostname'));
+		$this->assertEquals('user', $this->getPrivateProperty($conn, 'username'));
+		$this->assertEquals('pass', $this->getPrivateProperty($conn, 'password'));
+		$this->assertEquals('dbname', $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals('MySQLi', $this->getPrivateProperty($conn, 'DBDriver'));
+		$this->assertEquals('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
+		$this->assertEquals(true, $this->getPrivateProperty($conn, 'pConnect'));
+		$this->assertEquals('latin1', $this->getPrivateProperty($conn, 'charset'));
+		$this->assertEquals('latin1_swedish_ci', $this->getPrivateProperty($conn, 'DBCollat'));
+		$this->assertEquals(true, $this->getPrivateProperty($conn, 'strictOn'));
+		$this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
+	}
+
+	public function testConnectionGroupWithDSNPostgre()
+	{
+		$conn = Config::connect($this->dsnGroupPostgre, false);
+		$this->assertInstanceOf(BaseConnection::class, $conn);
+
+		$this->assertEquals('', $this->getPrivateProperty($conn, 'DSN'));
+		$this->assertEquals('localhost', $this->getPrivateProperty($conn, 'hostname'));
+		$this->assertEquals('user', $this->getPrivateProperty($conn, 'username'));
+		$this->assertEquals('pass', $this->getPrivateProperty($conn, 'password'));
+		$this->assertEquals('dbname', $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
+		$this->assertEquals('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
+		$this->assertEquals(false, $this->getPrivateProperty($conn, 'pConnect'));
+		$this->assertEquals('utf8', $this->getPrivateProperty($conn, 'charset'));
+		$this->assertEquals('utf8_general_ci', $this->getPrivateProperty($conn, 'DBCollat'));
+		$this->assertEquals(true, $this->getPrivateProperty($conn, 'strictOn'));
+		$this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
+		$this->assertEquals('5', $this->getPrivateProperty($conn, 'connect_timeout'));
+		$this->assertEquals('1', $this->getPrivateProperty($conn, 'sslmode'));
+
+		$method = $this->getPrivateMethodInvoker($conn, 'buildDSN');
+		$method();
+
+		$expected = "host=localhost user=user password='pass' dbname=dbname connect_timeout='5' sslmode='1'";
+		$this->assertEquals($expected, $this->getPrivateProperty($conn, 'DSN'));
+	}
+
+	public function testConnectionGroupWithDSNPostgreNative()
+	{
+		$conn = Config::connect($this->dsnGroupPostgreNative, false);
+		$this->assertInstanceOf(BaseConnection::class, $conn);
+
+		$this->assertEquals('pgsql:host=localhost;port=5432;dbname=database_name', $this->getPrivateProperty($conn, 'DSN'));
+		$this->assertEquals('', $this->getPrivateProperty($conn, 'hostname'));
+		$this->assertEquals('', $this->getPrivateProperty($conn, 'username'));
+		$this->assertEquals('', $this->getPrivateProperty($conn, 'password'));
+		$this->assertEquals('', $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals('SQLite3', $this->getPrivateProperty($conn, 'DBDriver'));
+		$this->assertEquals('t_', $this->getPrivateProperty($conn, 'DBPrefix'));
+		$this->assertEquals(false, $this->getPrivateProperty($conn, 'pConnect'));
+		$this->assertEquals('utf8', $this->getPrivateProperty($conn, 'charset'));
+		$this->assertEquals('utf8_general_ci', $this->getPrivateProperty($conn, 'DBCollat'));
+		$this->assertEquals(true, $this->getPrivateProperty($conn, 'strictOn'));
+		$this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
+	}
+}

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -28,6 +28,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'compress' => false,
 		'strictOn' => true,
 		'failover' => [],
+		'port'     => 3306,
 	];
 
 	protected $dsnGroup = [
@@ -49,6 +50,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'compress' => false,
 		'strictOn' => true,
 		'failover' => [],
+		'port'     => 3306,
 	];
 
 	protected $dsnGroupPostgre = [
@@ -70,6 +72,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'compress' => false,
 		'strictOn' => true,
 		'failover' => [],
+		'port'     => 5432,
 	];
 
 	protected $dsnGroupPostgreNative = [
@@ -91,6 +94,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		'compress' => false,
 		'strictOn' => true,
 		'failover' => [],
+		'port'     => 5432,
 	];
 
 	protected function tearDown(): void
@@ -108,6 +112,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($this->group['username'], $this->getPrivateProperty($conn, 'username'));
 		$this->assertEquals($this->group['password'], $this->getPrivateProperty($conn, 'password'));
 		$this->assertEquals($this->group['database'], $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals($this->group['port'], $this->getPrivateProperty($conn, 'port'));
 		$this->assertEquals($this->group['DBDriver'], $this->getPrivateProperty($conn, 'DBDriver'));
 		$this->assertEquals($this->group['DBPrefix'], $this->getPrivateProperty($conn, 'DBPrefix'));
 		$this->assertEquals($this->group['pConnect'], $this->getPrivateProperty($conn, 'pConnect'));
@@ -125,6 +130,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('user', $this->getPrivateProperty($conn, 'username'));
 		$this->assertEquals('pass', $this->getPrivateProperty($conn, 'password'));
 		$this->assertEquals('dbname', $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals('3306', $this->getPrivateProperty($conn, 'port'));
 		$this->assertEquals('MySQLi', $this->getPrivateProperty($conn, 'DBDriver'));
 		$this->assertEquals('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
 		$this->assertEquals(true, $this->getPrivateProperty($conn, 'pConnect'));
@@ -144,6 +150,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('user', $this->getPrivateProperty($conn, 'username'));
 		$this->assertEquals('pass', $this->getPrivateProperty($conn, 'password'));
 		$this->assertEquals('dbname', $this->getPrivateProperty($conn, 'database'));
+		$this->assertEquals('5432', $this->getPrivateProperty($conn, 'port'));
 		$this->assertEquals('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
 		$this->assertEquals('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
 		$this->assertEquals(false, $this->getPrivateProperty($conn, 'pConnect'));
@@ -157,7 +164,7 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$method = $this->getPrivateMethodInvoker($conn, 'buildDSN');
 		$method();
 
-		$expected = "host=localhost user=user password='pass' dbname=dbname connect_timeout='5' sslmode='1'";
+		$expected = "host=localhost port=5432 user=user password='pass' dbname=dbname connect_timeout='5' sslmode='1'";
 		$this->assertEquals($expected, $this->getPrivateProperty($conn, 'DSN'));
 	}
 
@@ -171,7 +178,8 @@ class DatabaseConfig extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('', $this->getPrivateProperty($conn, 'username'));
 		$this->assertEquals('', $this->getPrivateProperty($conn, 'password'));
 		$this->assertEquals('', $this->getPrivateProperty($conn, 'database'));
-		$this->assertEquals('SQLite3', $this->getPrivateProperty($conn, 'DBDriver'));
+		$this->assertEquals('5432', $this->getPrivateProperty($conn, 'port'));
+		$this->assertEquals('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
 		$this->assertEquals('t_', $this->getPrivateProperty($conn, 'DBPrefix'));
 		$this->assertEquals(false, $this->getPrivateProperty($conn, 'pConnect'));
 		$this->assertEquals('utf8', $this->getPrivateProperty($conn, 'charset'));

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -63,9 +63,9 @@ To override default config values when connecting with a universal version of th
 add the config variables as a query string:
 
 	// MySQLi
-	$default['DSN'] = 'MySQLi://username:password@hostname/database?charset=utf8&DBCollat=utf8_general_ci';
+	$default['DSN'] = 'MySQLi://username:password@hostname:3306/database?charset=utf8&DBCollat=utf8_general_ci';
 	// Postgre
-	$default['DSN'] = 'Postgre://username:password@hostname/database?charset=utf8&connect_timeout=5&sslmode=1';
+	$default['DSN'] = 'Postgre://username:password@hostname:5432/database?charset=utf8&connect_timeout=5&sslmode=1';
 
 .. note:: If you provide a DSN string and it is missing some valid settings (e.g. the
 	database character set), which are present in the rest of the configuration

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -57,7 +57,7 @@ driver's underlying native PHP extension, like this::
 
 You can also set a Data Source Name in universal manner (URL like). In that case DSNs must have this prototype:
 	
-	$default['DSN'] = 'DBDriver://username:password@hostname/database';
+      $default['DSN'] = 'DBDriver://username:password@hostname:port/database';
 
 To override default config values when connecting with a universal version of the DSN string, 
 add the config variables as a query string:

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -55,6 +55,18 @@ driver's underlying native PHP extension, like this::
 .. note:: If you do not specify a DSN string for a driver that requires it, CodeIgniter
 	will try to build it with the rest of the provided settings.
 
+You can also set a Data Source Name in universal manner (URL like). In that case DSNs must have this prototype:
+	
+	$default['DSN'] = 'DBDriver://username:password@hostname/database';
+
+To override default config values when connecting with a universal version of the DSN string, 
+add the config variables as a query string:
+
+	// MySQLi
+	$default['DSN'] = 'MySQLi://username:password@hostname/database?charset=utf8&DBCollat=utf8_general_ci';
+	// Postgre
+	$default['DSN'] = 'Postgre://username:password@hostname/database?charset=utf8&connect_timeout=5&sslmode=1';
+
 .. note:: If you provide a DSN string and it is missing some valid settings (e.g. the
 	database character set), which are present in the rest of the configuration
 	fields, CodeIgniter will append them.


### PR DESCRIPTION
**Description**
This PR adds support for DSN string in a URL manner. This functionality was available in CI3 but disappeared during rewriting DB class for some reason.

There are no BC changes and using DSN in a native way still works fine. It could only be used for PostgreSQL though.

The universal DSN prototype looks like this:
```php
$default['DSN'] = 'DBDriver://username:password@hostname/database';
```
We can also add additional config parameters:
```php
$default['DSN'] = 'MySQLi://username:password@hostname/database?charset=utf8&DBCollat=utf8_general_ci';
```
Ref: #3456

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
