### PR TITLE
Fix URI class for proper subfolders handling

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -597,12 +597,13 @@ class URI
 		// segments that show up prior to the URI path we just
 		// grabbed from the request, so add it on if necessary.
 		$baseUri  = new self(config(\Config\App::class)->baseURL);
-		$basePath = rtrim($baseUri->getPath(), '/') . '/';
+		$basePath = trim($baseUri->getPath(), '/') . '/';
 		$path     = $this->getPath();
+		$trimPath = ltrim($path, '/');
 
-              if ($basePath !== '/' && strpos($path, $basePath) !== 0)
+		if ($basePath !== '/' && strpos($trimPath, $basePath) !== 0)
 		{
-			$path = $basePath . $path;
+			$path = $basePath . $trimPath;
 		}
 
 		return static::createURIString(

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -328,14 +328,15 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testBaseURLHasSubfolder()
 	{
 		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/test';
+		$_SERVER['REQUEST_URI'] = '/subfolder/test';
+		$_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
 
 		// Since we're on a CLI, we must provide our own URI
 		$config          = new App();
 		$config->baseURL = 'http://example.com/subfolder';
-		$request         = Services::request($config, false);
-		$request->uri    = new URI('http://example.com/subfolder/test');
+		Config::injectMock('App', $config);
 
+		$request = Services::request($config, false);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com/subfolder/foo', base_url('foo'));
@@ -383,14 +384,15 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testCurrentURLEquivalence()
 	{
 		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
+		$_SERVER['REQUEST_URI'] = '/public';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 		// Since we're on a CLI, we must provide our own URI
 		$config          = new App();
 		$config->baseURL = 'http://example.com/';
-		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/public');
+		Config::injectMock('App', $config);
 
+		$request = Services::request($config);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals(base_url(uri_string()), current_url());


### PR DESCRIPTION
**Description**
This PR continue fixing the URI class when subfolders are used. These changes concerns `site_url()` and `base_url()` helper functions.

```php
// example:
$baseURL = 'http://localhost/subfolder';
site_url('test');
// produces:
// http://localhost/subfolder/subfolder/test
```

We had tests for this but they didn't really work as the URI was hardcoded and CI was recognizing it as regular URL segments. Now we're sure this is tested properly and works.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
