### PR TITLE
Cast getBatches() result array

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -850,7 +850,7 @@ class MigrationRunner
 						  ->get()
 						  ->getResultArray();
 
-		return array_column($batches, 'batch');
+		return array_map('intval', array_column($batches, 'batch'));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
This PR fixes the error when `MigrationRunner::getBatches()` return array of `string` instead of `int`.

Fixes #3620

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
