### PR TITLE
Fix _flatten() call in BaseHandler for Image class

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -414,7 +414,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 		$this->width  = $this->image()->origWidth;
 		$this->height = $this->image()->origHeight;
 
-		return $this->_flatten();
+		return $this->_flatten($red, $green, $blue);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Fixes #3728

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide

