### PR TITLE
Run tests also with push for Coveralls

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -1,6 +1,10 @@
 name: PHPUnit
 
 on:
+  push:
+    branches:
+      - develop
+      - '4.*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - develop
       - '4.*'
+    paths:
+      - 'app/**'
+      - 'public/**'
+      - 'system/**'
+      - 'tests/**'
+      - composer.json
+      - spark
+      - '**.php'
+      - .github/workflows/test-phpunit.yml
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
**Description**
This PR adds PHPUnit testing for `push` because otherwise, we can’t record the results on the Coveralls webpage.

**Checklist:**
- [x] Securely signed commits
