### PR TITLE
Fix bug in Parser with similar variable names

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -333,7 +333,7 @@ class Parser extends View
 	 */
 	protected function parseSingle(string $key, string $val): array
 	{
-		$pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*!?' . $this->rightDelimiter . '#ms';
+		$pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#ms';
 
 		return [$pattern => $val];
 	}
@@ -415,7 +415,7 @@ class Parser extends View
 						$val = 'Resource';
 					}
 
-					$temp['#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*!?' . $this->rightDelimiter . '#s'] = $val;
+					$temp['#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#s'] = $val;
 				}
 
 				// Now replace our placeholders with the new content.
@@ -632,9 +632,9 @@ class Parser extends View
 
 		// Our regex earlier will leave all chained values on a single line
 		// so we need to break them apart so we can apply them all.
-		$filters = isset($matches[0]) ? explode('|', $matches[0]) : [];
+		$filters = ! empty($matches[1]) ? explode('|', $matches[1]) : [];
 
-		if ($escape && ! isset($matches[0]))
+		if ($escape && empty($filters))
 		{
 			if ($context = $this->shouldAddEscaping($orig))
 			{

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -416,6 +416,40 @@ class ParserTest extends \CodeIgniter\Test\CIUnitTestCase
 	//------------------------------------------------------------------------
 
 	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/3726
+	 */
+	public function testParseSimilarVariableNames()
+	{
+		$parser = new Parser($this->config, $this->viewsDir, $this->loader);
+
+		$template = '{ foo } { foo_bar}';
+
+		$parser->setData(['foo' => 'bar', 'foo_bar' => 'foo-bar'], 'raw');
+		$this->assertEquals('bar foo-bar', $parser->renderString($template));
+	}
+
+	public function testParsePairSimilarVariableNames()
+	{
+		$parser = new Parser($this->config, $this->viewsDir, $this->loader);
+
+		$data = [
+			'title'  => '<script>Heroes</script>',
+			'powers' => [
+				[
+					'link'        => "<a href='test'>Link</a>",
+					'link_second' => "<a href='test2'>Link second</a>",
+				],
+			],
+		];
+
+		$template = '{title} {powers}{link} {link_second}{/powers}';
+		$parser->setData($data);
+		$this->assertEquals('&lt;script&gt;Heroes&lt;/script&gt; &lt;a href=&#039;test&#039;&gt;Link&lt;/a&gt; &lt;a href=&#039;test2&#039;&gt;Link second&lt;/a&gt;', $parser->renderString($template));
+	}
+
+	//------------------------------------------------------------------------
+
+	/**
 	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/788
 	 */
 	public function testEscapingRespectsSetDataRaw()


### PR DESCRIPTION
**Description**
This PR fixes error in `Parser` when similar variable names would be treated as the same.

Fixes #3726

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
