### PR TITLE
Fix routes options to be recognizable via used HTTP request method

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -558,7 +558,7 @@ class RouteCollection implements RouteCollectionInterface
 	 * Returns one or all routes options
 	 *
 	 * @param string $from
-	 * @param string $verb
+       * @param string|null $verb
 	 *
 	 * @return array
 	 */
@@ -1288,7 +1288,7 @@ class RouteCollection implements RouteCollectionInterface
 	 * Checks a route (using the "from") to see if it's filtered or not.
 	 *
 	 * @param string $search
-	 * @param string $verb
+       * @param string|null $verb
 	 *
 	 * @return boolean
 	 */
@@ -1312,7 +1312,7 @@ class RouteCollection implements RouteCollectionInterface
 	 * has a filter of "role", with parameters of ['admin', 'manager'].
 	 *
 	 * @param string $search
-	 * @param string $verb
+       * @param string|null $verb
 	 *
 	 * @return string
 	 */
@@ -1591,16 +1591,13 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Load routes options based on verb
 	 *
-	 * @param string $verb
+       * @param string|null $verb
 	 *
 	 * @return array
 	 */
 	protected function loadRoutesOptions(string $verb = null): array
 	{
-		if (empty($verb))
-		{
-			$verb = $this->getHTTPVerb();
-		}
+		$verb = $verb ?: $this->getHTTPVerb();
 
 		$options = $this->routesOptions[$verb] ?? [];
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -514,7 +514,7 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Returns the raw array of available routes.
 	 *
-	 * @param mixed $verb
+	 * @param string|null $verb
 	 *
 	 * @return array
 	 */
@@ -557,8 +557,8 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Returns one or all routes options
 	 *
-	 * @param string $from
-       * @param string|null $verb
+	 * @param string      $from
+	 * @param string|null $verb
 	 *
 	 * @return array
 	 */
@@ -1287,8 +1287,8 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Checks a route (using the "from") to see if it's filtered or not.
 	 *
-	 * @param string $search
-       * @param string|null $verb
+	 * @param string      $search
+	 * @param string|null $verb
 	 *
 	 * @return boolean
 	 */
@@ -1311,8 +1311,8 @@ class RouteCollection implements RouteCollectionInterface
 	 *
 	 * has a filter of "role", with parameters of ['admin', 'manager'].
 	 *
-	 * @param string $search
-       * @param string|null $verb
+	 * @param string      $search
+	 * @param string|null $verb
 	 *
 	 * @return string
 	 */
@@ -1591,7 +1591,7 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Load routes options based on verb
 	 *
-       * @param string|null $verb
+	 * @param string|null $verb
 	 *
 	 * @return array
 	 */
@@ -1605,9 +1605,15 @@ class RouteCollection implements RouteCollectionInterface
 		{
 			foreach ($this->routesOptions['*'] as $key => $val)
 			{
-				$options[$key] = $options[$key] ?? [];
-				$extraOptions  = array_diff_key($val, $options[$key]);
-				$options[$key] = array_merge($options[$key], $extraOptions);
+				if (isset($options[$key]))
+				{
+					$extraOptions  = array_diff_key($val, $options[$key]);
+					$options[$key] = array_merge($options[$key], $extraOptions);
+				}
+				else
+				{
+					$options[$key] = $val;
+				}
 			}
 		}
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -251,7 +251,7 @@ class RouteCollection implements RouteCollectionInterface
 	 * multiple placeholders added at once.
 	 *
 	 * @param string|array $placeholder
-	 * @param string       $pattern
+	 * @param string|null  $pattern
 	 *
 	 * @return \CodeIgniter\Router\RouteCollectionInterface
 	 */
@@ -518,7 +518,7 @@ class RouteCollection implements RouteCollectionInterface
 	 *
 	 * @return array
 	 */
-	public function getRoutes($verb = null): array
+	public function getRoutes(string $verb = null): array
 	{
 		if (empty($verb))
 		{
@@ -557,7 +557,7 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Returns one or all routes options
 	 *
-	 * @param string      $from
+	 * @param string|null $from
 	 * @param string|null $verb
 	 *
 	 * @return array
@@ -603,8 +603,8 @@ class RouteCollection implements RouteCollectionInterface
 	 * It does not allow any options to be set on the route, or to
 	 * define the method used.
 	 *
-	 * @param array $routes
-	 * @param array $options
+	 * @param array      $routes
+	 * @param array|null $options
 	 *
 	 * @return RouteCollectionInterface
 	 */

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1246,6 +1246,48 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($options, ['as' => 'admin', 'foo' => 'baz']);
 	}
 
+	public function testRoutesOptionsForDifferentVerbs()
+	{
+		$routes = $this->getCollector();
+
+		// options need to be declared separately, to not confuse PHPCBF
+		$options1 = [
+			'as'  => 'admin1',
+			'foo' => 'baz1',
+		];
+		$options2 = [
+			'as'  => 'admin2',
+			'foo' => 'baz2',
+		];
+		$options3 = [
+			'bar' => 'baz',
+		];
+		$routes->get(
+				'administrator', function () {
+				}, $options1
+		);
+		$routes->post(
+				'administrator', function () {
+				}, $options2
+		);
+		$routes->add(
+				'administrator', function () {
+				}, $options3
+		);
+
+		$options = $routes->getRoutesOptions('administrator');
+
+		$this->assertEquals($options, ['as' => 'admin1', 'foo' => 'baz1', 'bar' => 'baz']);
+
+		$options = $routes->setHTTPVerb('post')->getRoutesOptions('administrator');
+
+		$this->assertEquals($options, ['as' => 'admin2', 'foo' => 'baz2', 'bar' => 'baz']);
+
+		$options = $routes->setHTTPVerb('get')->getRoutesOptions('administrator', 'post');
+
+		$this->assertEquals($options, ['as' => 'admin2', 'foo' => 'baz2', 'bar' => 'baz']);
+	}
+
 	public function testRouteGroupWithFilterSimple()
 	{
 		Services::request()->setMethod('get');


### PR DESCRIPTION
**Description**
This PR fixes routes options to be recognizable via used HTTP request method. Right now routes options are shared - one instance per route. It leads to problems like: wrong named route name returned or firing incorrect filter.

I don't think this will introduce any BC, rather will fix buggy behavior, but if anyone notices the problem please let me know.

Fixes #3700 
Fixes #3733

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] N/A User guide updated
- [x] Conforms to style guide
