### PR TITLE
Fix for deleting session flash data in php8

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -425,9 +425,8 @@ class Session implements SessionInterface
 			{
 				$_SESSION['__ci_vars'][$key] = 'old';
 			}
-			// Hacky, but 'old' will (implicitly) always be less than time() ;)
 			// DO NOT move this above the 'new' check!
-			elseif ($value < $currentTime)
+			elseif ($value === 'old' || $value < $currentTime)
 			{
 				unset($_SESSION[$key], $_SESSION['__ci_vars'][$key]);
 			}


### PR DESCRIPTION
**Description**
Due to the string-number comparison changes in PHP 8, we need a fix for deleting session flash data.

Closes #3974

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

  
