### PR TITLE
Add mime type for rar files

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -148,6 +148,7 @@ class Mimes
 			'multipart/x-zip',
 		],
 		'rar'   => [
+			'application/vnd.rar',
 			'application/x-rar',
 			'application/rar',
 			'application/x-rar-compressed',


### PR DESCRIPTION
**Description**
This PR adds yet another mime type for `rar` files. 

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types

Most likely will fix #3979

**Checklist:**
- [x] Securely signed commits
