### PR TITLE
Use full table name with schema for SQLSRV

### DIFF
--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -76,7 +76,7 @@ class Builder extends BaseBuilder
 	 */
 	protected function _truncate(string $table): string
 	{
-		return 'TRUNCATE TABLE ' . $table;
+		return 'TRUNCATE TABLE ' . $this->getFullName($table);
 	}
 
 	/**
@@ -122,10 +122,12 @@ class Builder extends BaseBuilder
 			$valstr[] = $key . ' = ' . $val;
 		}
 
-		$statement = 'UPDATE ' . (empty($this->QBLimit) ? '' : 'TOP(' . $this->QBLimit . ') ') . $table . ' SET '
+		$fullTableName = $this->getFullName($table);
+
+		$statement = 'UPDATE ' . (empty($this->QBLimit) ? '' : 'TOP(' . $this->QBLimit . ') ') . $fullTableName . ' SET '
 				. implode(', ', $valstr) . $this->compileWhereHaving('QBWhere') . $this->compileOrderBy();
 
-		return $this->keyPermission ? $this->addIdentity($this->getFullName($table), $statement) : $statement;
+		return $this->keyPermission ? $this->addIdentity($fullTableName, $statement) : $statement;
 	}
 
 	/**
@@ -355,7 +357,7 @@ class Builder extends BaseBuilder
 			return $this->db->escapeIdentifiers($item);
 		}, $keyFields);
 
-		return 'INSERT INTO ' . $table . ' (' . implode(',', $keys) . ') VALUES (' . implode(',', $values) . ');';
+		return 'INSERT INTO ' . $this->getFullName($table) . ' (' . implode(',', $keys) . ') VALUES (' . implode(',', $values) . ');';
 	}
 
 	/**
@@ -409,7 +411,7 @@ class Builder extends BaseBuilder
 	 */
 	protected function _delete(string $table): string
 	{
-		return 'DELETE' . (empty($this->QBLimit) ? '' : ' TOP (' . $this->QBLimit . ') ') . ' FROM ' . $table . $this->compileWhereHaving('QBWhere');
+		return 'DELETE' . (empty($this->QBLimit) ? '' : ' TOP (' . $this->QBLimit . ') ') . ' FROM ' . $this->getFullName($table) . $this->compileWhereHaving('QBWhere');
 	}
 
 	/**

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -198,7 +198,7 @@ Explanation of Values:
 **swapPre**		A default table prefix that should be swapped with dbprefix. This is useful for distributed
 			applications where you might run manually written queries, and need the prefix to still be
 			customizable by the end user.
-**schema**		The database schema, defaults to 'public'. Used by PostgreSQL and ODBC drivers.
+**schema**		The database schema, default value varies by driver. Used by PostgreSQL and SQLSRV drivers.
 **encrypt**		Whether or not to use an encrypted connection.
 
 			  - 'sqlsrv' and 'pdo/sqlsrv' drivers accept TRUE/FALSE


### PR DESCRIPTION
**Description**
This PR changes the behavior of the `Builder` class for SQLSRV to always use the full table name - with a schema.

Ref #3881

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
