### PR TITLE
Fix DOMParser rules to search also outside the body tag

### DIFF
--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -237,19 +237,19 @@ class DOMParser
 		{
 			$path = empty($selector['tag'])
 				? "id(\"{$selector['id']}\")"
-				: "//body//{$selector['tag']}[@id=\"{$selector['id']}\"]";
+				: "//{$selector['tag']}[@id=\"{$selector['id']}\"]";
 		}
 		// By Class
 		elseif (! empty($selector['class']))
 		{
 			$path = empty($selector['tag'])
 				? "//*[@class=\"{$selector['class']}\"]"
-				: "//body//{$selector['tag']}[@class=\"{$selector['class']}\"]";
+				: "//{$selector['tag']}[@class=\"{$selector['class']}\"]";
 		}
 		// By tag only
 		elseif (! empty($selector['tag']))
 		{
-			$path = "//body//{$selector['tag']}";
+			$path = "//{$selector['tag']}";
 		}
 
 		if (! empty($selector['attr']))

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -97,6 +97,19 @@ class DOMParserTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($dom->see('<h1>'));
 	}
 
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/3984
+	 */
+	public function testSeeHTMLOutsideBodyTag()
+	{
+		$dom = new DOMParser();
+
+		$html = '<html><head><title>My Title</title></head><body><h1>Hello World</h1></body></html>';
+		$dom->withString($html);
+
+		$this->assertTrue($dom->see('My Title', 'title'));
+	}
+
 	public function testSeeFail()
 	{
 		$dom = new DOMParser();


### PR DESCRIPTION
**Description**
Fixes #3984

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
