### PR TITLE
Fix loss of escape value and data in the model

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -20,6 +20,7 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Services;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionProperty;
@@ -715,31 +716,7 @@ abstract class BaseModel
 	{
 		$this->insertID = 0;
 
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('insert');
-		}
-
-		// If $data is using a custom class with public or protected
-		// properties representing the collection elements, we need to grab
-		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
-			$data = $this->objectToArray($data, false, true);
-		}
-
-		// If it's still a stdClass, go ahead and convert to
-		// an array so doProtectFields and other model methods
-		// don't have to do special checks.
-		if (is_object($data))
-		{
-			$data = (array) $data;
-		}
-
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('insert');
-		}
+		$data = $this->transformDataToArray($data, 'insert');
 
 		// Validate data before saving.
 		if (! $this->skipValidation && ! $this->cleanRules()->validate($data))
@@ -877,32 +854,7 @@ abstract class BaseModel
 			$id = [$id];
 		}
 
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('update');
-		}
-
-		// If $data is using a custom class with public or protected
-		// properties representing the collection elements, we need to grab
-		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
-			$data = $this->objectToArray($data, true, true);
-		}
-
-		// If it's still a stdClass, go ahead and convert to
-		// an array so doProtectFields and other model methods
-		// don't have to do special checks.
-		if (is_object($data))
-		{
-			$data = (array) $data;
-		}
-
-		// If it's still empty here, means $data is no change or is empty object
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('update');
-		}
+		$data = $this->transformDataToArray($data, 'update');
 
 		// Validate data before saving.
 		if (! $this->skipValidation && ! $this->cleanRules(true)->validate($data))
@@ -1690,6 +1642,55 @@ abstract class BaseModel
 		}
 
 		return $properties;
+	}
+
+	/**
+	 * Transform data to array
+	 *
+	 * @param array|object|null $data Data
+	 * @param string            $type Type of data (insert|update)
+	 *
+	 * @return array
+	 *
+	 * @throws DataException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 */
+	protected function transformDataToArray($data, string $type): array
+	{
+		if (! in_array($type, ['insert', 'update'], true))
+		{
+			throw new InvalidArgumentException(sprintf('Invalid type "%s" used upon transforming data to array.', $type));
+		}
+
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset($type);
+		}
+
+		// If $data is using a custom class with public or protected
+		// properties representing the collection elements, we need to grab
+		// them as an array.
+		if (is_object($data) && ! $data instanceof stdClass)
+		{
+			$data = $this->objectToArray($data, true, true);
+		}
+
+		// If it's still a stdClass, go ahead and convert to
+		// an array so doProtectFields and other model methods
+		// don't have to do special checks.
+		if (is_object($data))
+		{
+			$data = (array) $data;
+		}
+
+		// If it's still empty here, means $data is no change or is empty object
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset($type);
+		}
+
+		return $data;
 	}
 
 	// endregion

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -235,8 +235,8 @@ final class InsertModelTest extends LiveModelTestCase
 		$this->model->set('country', '1+1', false)->set('email', '2+2')->insert($userData);
 
 		$this->assertGreaterThan(0, $this->model->getInsertID());
+		$result = $this->model->where('name', 'Scott')->where('country', '2')->where('email', '2+2')->first();
 
-		$result = $this->model->where('name', 'Scott')->where('country', 2)->where('email', '2+2')->first();
 		$this->assertCloseEnough(time(), strtotime($result->created_at));
 	}
 }

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -218,4 +218,25 @@ final class InsertModelTest extends LiveModelTestCase
 		$this->assertSame($insert['key'], $this->model->getInsertID());
 		$this->seeInDatabase('without_auto_increment', $insert);
 	}
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4087
+	 */
+	public function testInsertWithSetAndEscape(): void
+	{
+		$userData = [
+			'name' => 'Scott',
+		];
+
+		$this->createModel(UserModel::class);
+
+		$this->setPrivateProperty($this->model, 'useTimestamps', true);
+
+		$this->model->set('country', '1+1', false)->set('email', '2+2')->insert($userData);
+
+		$this->assertGreaterThan(0, $this->model->getInsertID());
+
+		$result = $this->model->where('name', 'Scott')->where('country', 2)->where('email', '2+2')->first();
+		$this->assertCloseEnough(time(), strtotime($result->created_at));
+	}
 }

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -2,6 +2,8 @@
 
 namespace CodeIgniter\Models;
 
+use CodeIgniter\Database\Exceptions\DataException;
+use InvalidArgumentException;
 use Tests\Support\Models\EntityModel;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SimpleEntity;
@@ -80,5 +82,25 @@ final class MiscellaneousModelTest extends LiveModelTestCase
 
 		$error = $this->model->errors();
 		$this->assertTrue(isset($error['description']));
+	}
+
+	public function testUndefinedTypeInTransformDataToArray(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid type "whatever" used upon transforming data to array.');
+
+		$this->createModel(JobModel::class);
+		$method = $this->getPrivateMethodInvoker($this->model, 'transformDataToArray');
+		$method([], 'whatever');
+	}
+
+	public function testEmptyDataInTransformDataToArray(): void
+	{
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to insert.');
+
+		$this->createModel(JobModel::class);
+		$method = $this->getPrivateMethodInvoker($this->model, 'transformDataToArray');
+		$method([], 'insert');
 	}
 }

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -286,4 +286,24 @@ final class UpdateModelTest extends LiveModelTestCase
 		$this->createModel(WithoutAutoIncrementModel::class)->update($key, $update);
 		$this->seeInDatabase('without_auto_increment', ['key' => $key, 'value' => $update['value']]);
 	}
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4087
+	 */
+	public function testUpdateWithSetAndEscape(): void
+	{
+		$userData = [
+			'name' => 'Scott',
+		];
+
+		$this->createModel(UserModel::class);
+
+		$this->assertTrue($this->model->set('country', '2+2', false)->set('email', '1+1')->update(1, $userData));
+
+		$this->seeInDatabase('user', [
+			'name' => 'Scott',
+			'country' => 4,
+			'email' => '1+1',
+		]);
+	}
 }

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -302,7 +302,7 @@ final class UpdateModelTest extends LiveModelTestCase
 
 		$this->seeInDatabase('user', [
 			'name' => 'Scott',
-			'country' => 4,
+			'country' => '4',
 			'email' => '1+1',
 		]);
 	}


### PR DESCRIPTION
**Description**
This PR tries to fix some issues with current Model behavior.

The main change is that `$tempData['escape']` is no longer a boolean value but an array that holds all of the escape values for data. Since this variable is internal and wasn't never really used anywhere (in events for example), then I think changing it is fine.

After all, we're fixing a bug here. But if anyone sees a better idea to solve this, I'm all ears. 

Fixes #4087

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide