### PR TITLE
Fix for retrieving migration history

### DIFF
--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -84,11 +84,6 @@ class MigrateStatus extends BaseCommand
 		$runner = Services::migrations();
 		$group  = $params['g'] ?? CLI::getOption('g');
 
-		if (is_string($group))
-		{
-			$runner->setGroup($group);
-		}
-
 		// Get all namespaces
 		$namespaces = Services::autoloader()->getNamespace();
 
@@ -120,7 +115,7 @@ class MigrateStatus extends BaseCommand
 				continue;
 			}
 
-			$history = $runner->getHistory();
+			$history = $runner->getHistory((string) $group);
 			ksort($migrations);
 
 			foreach ($migrations as $uid => $migration)

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -190,7 +190,7 @@ class MigrationRunner
 		}
 
 		// Remove any migrations already in the history
-		foreach ($this->getHistory($this->group) as $history)
+		foreach ($this->getHistory((string) $group) as $history)
 		{
 			unset($migrations[$this->getObjectUid($history)]);
 		}
@@ -790,18 +790,21 @@ class MigrationRunner
 	{
 		$this->ensureTable();
 
-		$criteria = ['group' => $group];
+		$builder = $this->db->table($this->table);
+
+		// If group was specified then use it
+		if (! empty($group))
+		{
+			$builder->where('group', $group);
+		}
 
 		// If a namespace was specified then use it
 		if ($this->namespace)
 		{
-			$criteria['namespace'] = $this->namespace;
+			$builder->where('namespace', $this->namespace);
 		}
 
-		$query = $this->db->table($this->table)
-						  ->where($criteria)
-						  ->orderBy('id', 'ASC')
-						  ->get();
+		$query = $builder->orderBy('id', 'ASC')->get();
 
 		return ! empty($query) ? $query->getResultObject() : [];
 	}


### PR DESCRIPTION
**Description**
This PR fixes the way we loading the history of migrations so that all migrations can be checked and not only these from the `default`  group.

Fixes #4142

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
