### PR TITLE
Fix select queries in SQLSRV when using different schema

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2380,7 +2380,7 @@ class BaseBuilder
 	 * Groups tables in FROM clauses if needed, so there is no confusion
 	 * about operator precedence.
 	 *
-	 * Note: This is only used (and overridden) by MySQL and CUBRID.
+	 * Note: This is only used (and overridden) by MySQL and SQLSRV.
 	 *
 	 * @return string
 	 */

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Database\Seeder;
@@ -158,6 +159,22 @@ abstract class CIDatabaseTestCase extends CIUnitTestCase
 			$this->seeder = Database::seeder($this->DBGroup);
 			$this->seeder->setSilent(true);
 		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Loads the Builder class appropriate for the current database.
+	 *
+	 * @param string $tableName
+	 *
+	 * @return BaseBuilder
+	 */
+	public function loadBuilder(string $tableName)
+	{
+		$builderClass = str_replace('Connection', 'Builder', get_class($this->db));
+
+		return new $builderClass($tableName, $this->db);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -1,6 +1,7 @@
 <?php namespace Builder;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\Mock\MockConnection;
 
 class FromTest extends \CodeIgniter\Test\CIUnitTestCase
@@ -93,6 +94,21 @@ class FromTest extends \CodeIgniter\Test\CIUnitTestCase
 		$expectedSQL = 'SELECT * FROM "jobs"';
 
 		$builder->from('jobs');
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testFromWithMultipleTablesAsStringWithSQLSRV()
+	{
+		$this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+		$builder = new SQLSRVBuilder('user', $this->db);
+
+		$builder->from(['jobs, roles']);
+
+		$expectedSQL = 'SELECT * FROM "test"."dbo"."user", "test"."dbo"."jobs", "test"."dbo"."roles"';
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -2,6 +2,7 @@
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Postgre\Builder as PostgreBuilder;
+use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\Mock\MockConnection;
 
 class JoinTest extends \CodeIgniter\Test\CIUnitTestCase
@@ -78,6 +79,21 @@ class JoinTest extends \CodeIgniter\Test\CIUnitTestCase
 		$builder->join('users as u', 'users.id = jobs.id', 'full outer');
 
 		$expectedSQL = 'SELECT * FROM "jobs" FULL OUTER JOIN "users" as "u" ON "users"."id" = "jobs"."id"';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testJoinWithAlias()
+	{
+		$this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+		$builder = new SQLSRVBuilder('jobs', $this->db);
+		$builder->testMode();
+		$builder->join('users u', 'u.id = jobs.id', 'LEFT');
+
+		$expectedSQL = 'SELECT * FROM "test"."dbo"."jobs" LEFT JOIN "test"."dbo"."users" "u" ON "u"."id" = "jobs"."id"';
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -2,6 +2,7 @@
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\Mock\MockConnection;
 
 class SelectTest extends \CodeIgniter\Test\CIUnitTestCase
@@ -258,6 +259,19 @@ class SelectTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->expectExceptionMessage('You must provide a valid column name not separated by comma.');
 
 		$builder->selectSum('name,role');
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSimpleSelectWithSQLSRV()
+	{
+		$this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+		$builder = new SQLSRVBuilder('users', $this->db);
+
+		$expected = 'SELECT * FROM "test"."dbo"."users"';
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -68,7 +68,8 @@ class OrderTest extends CIDatabaseTestCase
 			->orderBy('name', 'random')
 			->getCompiledSelect();
 
-		$key = 'RANDOM()';
+		$key   = 'RANDOM()';
+		$table = $this->db->protectIdentifiers('job', true);
 
 		if ($this->db->DBDriver === 'MySQLi')
 		{
@@ -76,10 +77,11 @@ class OrderTest extends CIDatabaseTestCase
 		}
 		elseif ($this->db->DBDriver === 'SQLSRV')
 		{
-			$key = 'NEWID()';
+			$key   = 'NEWID()';
+			$table = '"' . $this->db->getDatabase() . '"."' . $this->db->schema . '".' . $table;
 		}
 
-		$expected = 'SELECT * FROM ' . $this->db->protectIdentifiers('job', true) . ' ORDER BY ' . $key;
+		$expected = 'SELECT * FROM ' . $table . ' ORDER BY ' . $key;
 
 		$this->assertEquals($expected, str_replace("\n", ' ', $sql));
 	}

--- a/tests/system/Models/CountAllModelTest.php
+++ b/tests/system/Models/CountAllModelTest.php
@@ -31,7 +31,7 @@ final class CountAllModelTest extends LiveModelTestCase
 
 	public function testcountAllResultsFalseWithDeletedTrue(): void
 	{
-		$builder     = new BaseBuilder('user', $this->db);
+		$builder     = $this->loadBuilder('user');
 		$expectedSQL = $builder->testMode()->countAllResults();
 
 		$this->createModel(UserModel::class);
@@ -47,7 +47,7 @@ final class CountAllModelTest extends LiveModelTestCase
 
 	public function testcountAllResultsFalseWithDeletedFalse(): void
 	{
-		$builder     = new BaseBuilder('user', $this->db);
+		$builder     = $this->loadBuilder('user');
 		$expectedSQL = $builder->testMode()->where('user.deleted_at', null)->countAllResults();
 
 		$this->createModel(UserModel::class);
@@ -63,7 +63,7 @@ final class CountAllModelTest extends LiveModelTestCase
 
 	public function testcountAllResultsFalseWithDeletedTrueUseSoftDeletesFalse(): void
 	{
-		$builder     = new BaseBuilder('user', $this->db);
+		$builder     = $this->loadBuilder('user');
 		$expectedSQL = $builder->testMode()->countAllResults();
 
 		$this->createModel(UserModel::class);
@@ -80,7 +80,7 @@ final class CountAllModelTest extends LiveModelTestCase
 
 	public function testcountAllResultsFalseWithDeletedFalseUseSoftDeletesFalse(): void
 	{
-		$builder     = new BaseBuilder('user', $this->db);
+		$builder     = $this->loadBuilder('user');
 		$expectedSQL = $builder->testMode()->where('user.deleted_at', null)->countAllResults();
 
 		$this->createModel(UserModel::class);


### PR DESCRIPTION
**Description**
This PR fixes SQLSRV `Builder` class behavior when select queries don't include declared database schema in the query.

Closes #4241

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide