### PR TITLE
Replace unused Entity private method

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -78,7 +78,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         // private method called via getPrivateMethodInvoker
         RemoveUnusedPrivateMethodRector::class => [
-            __DIR__ . '/system/Entity/Entity.php',
             __DIR__ . '/tests/system/Test/ReflectionHelperTest.php',
         ],
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -390,20 +390,6 @@ class Entity implements JsonSerializable
     }
 
     /**
-     * Cast as JSON
-     *
-     * @param mixed $value
-     *
-     * @throws CastException
-     *
-     * @return mixed
-     */
-    private function castAsJson($value, bool $asArray = false)
-    {
-        return JsonCast::get($value, $asArray ? ['array'] : []);
-    }
-
-    /**
      * Support for json_encode()
      *
      * @return array|mixed

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Entity;
 
+use Closure;
 use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\I18n\Time;
@@ -589,54 +590,60 @@ final class EntityTest extends CIUnitTestCase
 
     public function testCastAsJSONSyntaxError()
     {
-        $entity = new Entity();
-
-        $method = $this->getPrivateMethodInvoker($entity, 'castAsJson');
-
         $this->expectException(CastException::class);
         $this->expectExceptionMessage('Syntax error, malformed JSON');
 
-        $method('{ this is bad string', true);
+        (Closure::bind(static function (string $value) {
+            $entity = new Entity();
+            $entity->casts['dummy'] = 'json[array]';
+
+            return $entity->castAs($value, 'dummy');
+        }, null, Entity::class))('{ this is bad string');
     }
 
     public function testCastAsJSONAnotherErrorDepth()
     {
-        $entity = new Entity();
-
-        $method = $this->getPrivateMethodInvoker($entity, 'castAsJson');
-
         $this->expectException(CastException::class);
         $this->expectExceptionMessage('Maximum stack depth exceeded');
 
         $string = '{' . str_repeat('"test":{', 513) . '"test":"value"' . str_repeat('}', 513) . '}';
 
-        $method($string, true);
+        (Closure::bind(static function (string $value) {
+            $entity = new Entity();
+            $entity->casts['dummy'] = 'json[array]';
+
+            return $entity->castAs($value, 'dummy');
+        }, null, Entity::class))($string);
     }
 
     public function testCastAsJSONControlCharCheck()
     {
-        $entity = new Entity();
-        $method = $this->getPrivateMethodInvoker($entity, 'castAsJson');
-
         $this->expectException(CastException::class);
         $this->expectExceptionMessage('Unexpected control character found');
 
         $string = "{\n\t\"property1\": \"The quick brown fox\njumps over the lazy dog\",\n\t\"property2\":\"value2\"\n}";
 
-        $method($string, true);
+        (Closure::bind(static function (string $value) {
+            $entity = new Entity();
+            $entity->casts['dummy'] = 'json[array]';
+
+            return $entity->castAs($value, 'dummy');
+        }, null, Entity::class))($string);
     }
 
     public function testCastAsJSONStateMismatch()
     {
-        $entity = new Entity();
-        $method = $this->getPrivateMethodInvoker($entity, 'castAsJson');
-
         $this->expectException(CastException::class);
         $this->expectExceptionMessage('Underflow or the modes mismatch');
 
         $string = '[{"name":"jack","product_id":"1234"]';
 
-        $method($string, true);
+        (Closure::bind(static function (string $value) {
+            $entity = new Entity();
+            $entity->casts['dummy'] = 'json[array]';
+
+            return $entity->castAs($value, 'dummy');
+        }, null, Entity::class))($string);
     }
 
     public function testCastSetter()


### PR DESCRIPTION
**Description**
The private method `Entity::castAsJson()` is only used in 4 tests but unused elsewhere. This swaps it with the dedicated `castAs()` method.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
