### PR TITLE
[Userguide] Fix make:migration command options

### DIFF
--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -261,8 +261,11 @@ creates is the Pascal case version of the filename.
 
 You can use (make:migration) with the following options:
 
-- ``-n`` - to choose namespace, otherwise the value of ``APP_NAMESPACE`` will be used.
-- ``-force`` - If a similarly named migration file is present in destination, this will be overwritten.
+- ``--session``   - Generates the migration file for database sessions.
+- ``--table``     - Table name to use for database sessions. Default: ``ci_sessions``.
+- ``--dbgroup``   - Database group to use for database sessions. Default: ``default``.
+- ``--namespace`` - Set root namespace. Default: ``APP_NAMESPACE``.
+- ``--suffix``    - Append the component title to the class name.
 
 *********************
 Migration Preferences


### PR DESCRIPTION
Fix `make:migration` generator command supplied options in userguide.

- [x] User guide updated