### PR TITLE
Change behavior of `class_attributes_separation` rule

### DIFF
--- a/.no-header.php-cs-fixer.dist.php
+++ b/.no-header.php-cs-fixer.dist.php
@@ -30,14 +30,22 @@ $finder = Finder::create()
 $overrides = [
     // @TODO Remove once these are live in coding-standard
     'assign_null_coalescing_to_coalesce_equal' => false, // requires 7.4+
-    'control_structure_continuation_position'  => ['position' => 'same_line'],
-    'empty_loop_condition'                     => ['style' => 'while'],
-    'integer_literal_case'                     => true,
-    'modernize_strpos'                         => false, // requires 8.0+
-    'no_alternative_syntax'                    => ['fix_non_monolithic_code' => false],
-    'no_space_around_double_colon'             => true,
-    'octal_notation'                           => false, // requires 8.1+
-    'string_length_to_empty'                   => true,
+    'class_attributes_separation'              => [
+        'elements' => [
+            'const'        => 'none',
+            'property'     => 'none',
+            'method'       => 'one',
+            'trait_import' => 'none',
+        ],
+    ],
+    'control_structure_continuation_position' => ['position' => 'same_line'],
+    'empty_loop_condition'                    => ['style' => 'while'],
+    'integer_literal_case'                    => true,
+    'modernize_strpos'                        => false, // requires 8.0+
+    'no_alternative_syntax'                   => ['fix_non_monolithic_code' => false],
+    'no_space_around_double_colon'            => true,
+    'octal_notation'                          => false, // requires 8.1+
+    'string_length_to_empty'                  => true,
 ];
 
 $options = [

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -37,14 +37,22 @@ $finder = Finder::create()
 $overrides = [
     // @TODO Remove once these are live in coding-standard
     'assign_null_coalescing_to_coalesce_equal' => false, // requires 7.4+
-    'control_structure_continuation_position'  => ['position' => 'same_line'],
-    'empty_loop_condition'                     => ['style' => 'while'],
-    'integer_literal_case'                     => true,
-    'modernize_strpos'                         => false, // requires 8.0+
-    'no_alternative_syntax'                    => ['fix_non_monolithic_code' => false],
-    'no_space_around_double_colon'             => true,
-    'octal_notation'                           => false, // requires 8.1+
-    'string_length_to_empty'                   => true,
+    'class_attributes_separation'              => [
+        'elements' => [
+            'const'        => 'none',
+            'property'     => 'none',
+            'method'       => 'one',
+            'trait_import' => 'none',
+        ],
+    ],
+    'control_structure_continuation_position' => ['position' => 'same_line'],
+    'empty_loop_condition'                    => ['style' => 'while'],
+    'integer_literal_case'                    => true,
+    'modernize_strpos'                        => false, // requires 8.0+
+    'no_alternative_syntax'                   => ['fix_non_monolithic_code' => false],
+    'no_space_around_double_colon'            => true,
+    'octal_notation'                          => false, // requires 8.1+
+    'string_length_to_empty'                  => true,
 ];
 
 $options = [

--- a/admin/module/tests/_support/Models/ExampleModel.php
+++ b/admin/module/tests/_support/Models/ExampleModel.php
@@ -6,22 +6,18 @@ use CodeIgniter\Model;
 
 class ExampleModel extends Model
 {
-    protected $table      = 'factories';
-    protected $primaryKey = 'id';
-
+    protected $table          = 'factories';
+    protected $primaryKey     = 'id';
     protected $returnType     = 'object';
     protected $useSoftDeletes = false;
-
-    protected $allowedFields = [
+    protected $allowedFields  = [
         'name',
         'uid',
         'class',
         'icon',
         'summary',
     ];
-
-    protected $useTimestamps = true;
-
+    protected $useTimestamps      = true;
     protected $validationRules    = [];
     protected $validationMessages = [];
     protected $skipValidation     = false;

--- a/admin/starter/tests/_support/Models/ExampleModel.php
+++ b/admin/starter/tests/_support/Models/ExampleModel.php
@@ -6,22 +6,18 @@ use CodeIgniter\Model;
 
 class ExampleModel extends Model
 {
-    protected $table      = 'factories';
-    protected $primaryKey = 'id';
-
+    protected $table          = 'factories';
+    protected $primaryKey     = 'id';
     protected $returnType     = 'object';
     protected $useSoftDeletes = false;
-
-    protected $allowedFields = [
+    protected $allowedFields  = [
         'name',
         'uid',
         'class',
         'icon',
         'summary',
     ];
-
-    protected $useTimestamps = true;
-
+    protected $useTimestamps      = true;
     protected $validationRules    = [];
     protected $validationMessages = [];
     protected $skipValidation     = false;

--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -24,26 +24,19 @@ class Kint extends BaseConfig
     */
 
     public $plugins;
-
-    public $maxDepth = 6;
-
+    public $maxDepth          = 6;
     public $displayCalledFrom = true;
-
-    public $expanded = false;
+    public $expanded          = false;
 
     /*
     |--------------------------------------------------------------------------
     | RichRenderer Settings
     |--------------------------------------------------------------------------
     */
-    public $richTheme = 'aante-light.css';
-
+    public $richTheme  = 'aante-light.css';
     public $richFolder = false;
-
-    public $richSort = Renderer::SORT_FULL;
-
+    public $richSort   = Renderer::SORT_FULL;
     public $richObjectPlugins;
-
     public $richTabPlugins;
 
     /*
@@ -51,11 +44,8 @@ class Kint extends BaseConfig
     | CLI Settings
     |--------------------------------------------------------------------------
     */
-    public $cliColors = true;
-
-    public $cliForceUTF8 = false;
-
+    public $cliColors      = true;
+    public $cliForceUTF8   = false;
     public $cliDetectWidth = true;
-
-    public $cliMinWidth = 40;
+    public $cliMinWidth    = 40;
 }

--- a/system/Test/Mock/MockAppConfig.php
+++ b/system/Test/Mock/MockAppConfig.php
@@ -15,31 +15,25 @@ use Config\App;
 
 class MockAppConfig extends App
 {
-    public $baseURL = 'http://example.com/';
-
-    public $uriProtocol = 'REQUEST_URI';
-
-    public $cookiePrefix   = '';
-    public $cookieDomain   = '';
-    public $cookiePath     = '/';
-    public $cookieSecure   = false;
-    public $cookieHTTPOnly = false;
-    public $cookieSameSite = 'Lax';
-
-    public $proxyIPs = '';
-
-    public $CSRFProtection  = false;
-    public $CSRFTokenName   = 'csrf_test_name';
-    public $CSRFHeaderName  = 'X-CSRF-TOKEN';
-    public $CSRFCookieName  = 'csrf_cookie_name';
-    public $CSRFExpire      = 7200;
-    public $CSRFRegenerate  = true;
-    public $CSRFExcludeURIs = ['http://example.com'];
-    public $CSRFRedirect    = false;
-    public $CSRFSameSite    = 'Lax';
-
-    public $CSPEnabled = false;
-
+    public $baseURL          = 'http://example.com/';
+    public $uriProtocol      = 'REQUEST_URI';
+    public $cookiePrefix     = '';
+    public $cookieDomain     = '';
+    public $cookiePath       = '/';
+    public $cookieSecure     = false;
+    public $cookieHTTPOnly   = false;
+    public $cookieSameSite   = 'Lax';
+    public $proxyIPs         = '';
+    public $CSRFProtection   = false;
+    public $CSRFTokenName    = 'csrf_test_name';
+    public $CSRFHeaderName   = 'X-CSRF-TOKEN';
+    public $CSRFCookieName   = 'csrf_cookie_name';
+    public $CSRFExpire       = 7200;
+    public $CSRFRegenerate   = true;
+    public $CSRFExcludeURIs  = ['http://example.com'];
+    public $CSRFRedirect     = false;
+    public $CSRFSameSite     = 'Lax';
+    public $CSPEnabled       = false;
     public $defaultLocale    = 'en';
     public $negotiateLocale  = false;
     public $supportedLocales = [

--- a/system/Test/Mock/MockAutoload.php
+++ b/system/Test/Mock/MockAutoload.php
@@ -15,8 +15,7 @@ use Config\Autoload;
 
 class MockAutoload extends Autoload
 {
-    public $psr4 = [];
-
+    public $psr4     = [];
     public $classmap = [];
 
     public function __construct()

--- a/system/Test/Mock/MockCLIConfig.php
+++ b/system/Test/Mock/MockCLIConfig.php
@@ -15,29 +15,23 @@ use Config\App;
 
 class MockCLIConfig extends App
 {
-    public $baseURL = 'http://example.com/';
-
-    public $uriProtocol = 'REQUEST_URI';
-
-    public $cookiePrefix   = '';
-    public $cookieDomain   = '';
-    public $cookiePath     = '/';
-    public $cookieSecure   = false;
-    public $cookieHTTPOnly = false;
-    public $cookieSameSite = 'Lax';
-
-    public $proxyIPs = '';
-
-    public $CSRFProtection  = false;
-    public $CSRFTokenName   = 'csrf_test_name';
-    public $CSRFCookieName  = 'csrf_cookie_name';
-    public $CSRFExpire      = 7200;
-    public $CSRFRegenerate  = true;
-    public $CSRFExcludeURIs = ['http://example.com'];
-    public $CSRFSameSite    = 'Lax';
-
-    public $CSPEnabled = false;
-
+    public $baseURL          = 'http://example.com/';
+    public $uriProtocol      = 'REQUEST_URI';
+    public $cookiePrefix     = '';
+    public $cookieDomain     = '';
+    public $cookiePath       = '/';
+    public $cookieSecure     = false;
+    public $cookieHTTPOnly   = false;
+    public $cookieSameSite   = 'Lax';
+    public $proxyIPs         = '';
+    public $CSRFProtection   = false;
+    public $CSRFTokenName    = 'csrf_test_name';
+    public $CSRFCookieName   = 'csrf_cookie_name';
+    public $CSRFExpire       = 7200;
+    public $CSRFRegenerate   = true;
+    public $CSRFExcludeURIs  = ['http://example.com'];
+    public $CSRFSameSite     = 'Lax';
+    public $CSPEnabled       = false;
     public $defaultLocale    = 'en';
     public $negotiateLocale  = false;
     public $supportedLocales = [

--- a/system/Test/Mock/MockCURLRequest.php
+++ b/system/Test/Mock/MockCURLRequest.php
@@ -23,7 +23,6 @@ use CodeIgniter\HTTP\CURLRequest;
 class MockCURLRequest extends CURLRequest
 {
     public $curl_options;
-
     protected $output = '';
 
     public function setOutput($output)

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -19,9 +19,7 @@ use CodeIgniter\Database\Query;
 class MockConnection extends BaseConnection
 {
     protected $returnValues = [];
-
     public $database;
-
     public $lastQuery;
 
     public function shouldReturn(string $method, $return)

--- a/system/Test/Mock/MockServices.php
+++ b/system/Test/Mock/MockServices.php
@@ -19,7 +19,6 @@ class MockServices extends BaseService
     public $psr4 = [
         'Tests/Support' => TESTPATH . '_support/',
     ];
-
     public $classmap = [];
 
     public function __construct()

--- a/tests/_support/Models/EntityModel.php
+++ b/tests/_support/Models/EntityModel.php
@@ -15,17 +15,12 @@ use CodeIgniter\Model;
 
 class EntityModel extends Model
 {
-    protected $table = 'job';
-
-    protected $returnType = '\Tests\Support\Models\SimpleEntity';
-
+    protected $table          = 'job';
+    protected $returnType     = '\Tests\Support\Models\SimpleEntity';
     protected $useSoftDeletes = false;
-
-    protected $dateFormat = 'int';
-
-    protected $deletedField = 'deleted_at';
-
-    protected $allowedFields = [
+    protected $dateFormat     = 'int';
+    protected $deletedField   = 'deleted_at';
+    protected $allowedFields  = [
         'name',
         'description',
         'created_at',

--- a/tests/_support/Models/EventModel.php
+++ b/tests/_support/Models/EventModel.php
@@ -15,21 +15,16 @@ use CodeIgniter\Model;
 
 class EventModel extends Model
 {
-    protected $table = 'user';
-
-    protected $returnType = 'array';
-
+    protected $table          = 'user';
+    protected $returnType     = 'array';
     protected $useSoftDeletes = false;
-
-    protected $dateFormat = 'datetime';
-
-    protected $allowedFields = [
+    protected $dateFormat     = 'datetime';
+    protected $allowedFields  = [
         'name',
         'email',
         'country',
         'deleted_at',
     ];
-
     protected $beforeInsert = ['beforeInsertMethod'];
     protected $afterInsert  = ['afterInsertMethod'];
     protected $beforeUpdate = ['beforeUpdateMethod'];

--- a/tests/_support/Models/FabricatorModel.php
+++ b/tests/_support/Models/FabricatorModel.php
@@ -16,17 +16,12 @@ use Faker\Generator;
 
 class FabricatorModel extends Model
 {
-    protected $table = 'job';
-
-    protected $returnType = 'object';
-
+    protected $table          = 'job';
+    protected $returnType     = 'object';
     protected $useSoftDeletes = true;
-
-    protected $useTimestamps = true;
-
-    protected $dateFormat = 'int';
-
-    protected $allowedFields = [
+    protected $useTimestamps  = true;
+    protected $dateFormat     = 'int';
+    protected $allowedFields  = [
         'name',
         'description',
     ];

--- a/tests/_support/Models/JobModel.php
+++ b/tests/_support/Models/JobModel.php
@@ -15,20 +15,14 @@ use CodeIgniter\Model;
 
 class JobModel extends Model
 {
-    protected $table = 'job';
-
-    protected $returnType = 'object';
-
+    protected $table          = 'job';
+    protected $returnType     = 'object';
     protected $useSoftDeletes = false;
-
-    protected $dateFormat = 'int';
-
-    protected $allowedFields = [
+    protected $dateFormat     = 'int';
+    protected $allowedFields  = [
         'name',
         'description',
     ];
-
-    public $name = '';
-
+    public $name        = '';
     public $description = '';
 }

--- a/tests/_support/Models/SecondaryModel.php
+++ b/tests/_support/Models/SecondaryModel.php
@@ -15,17 +15,12 @@ use CodeIgniter\Model;
 
 class SecondaryModel extends Model
 {
-    protected $table = 'secondary';
-
-    protected $primaryKey = 'id';
-
-    protected $returnType = 'object';
-
+    protected $table          = 'secondary';
+    protected $primaryKey     = 'id';
+    protected $returnType     = 'object';
     protected $useSoftDeletes = false;
-
-    protected $dateFormat = 'int';
-
-    protected $allowedFields = [
+    protected $dateFormat     = 'int';
+    protected $allowedFields  = [
         'key',
         'value',
     ];

--- a/tests/_support/Models/UserModel.php
+++ b/tests/_support/Models/UserModel.php
@@ -15,24 +15,17 @@ use CodeIgniter\Model;
 
 class UserModel extends Model
 {
-    protected $table = 'user';
-
+    protected $table         = 'user';
     protected $allowedFields = [
         'name',
         'email',
         'country',
         'deleted_at',
     ];
-
-    protected $returnType = 'object';
-
+    protected $returnType     = 'object';
     protected $useSoftDeletes = true;
-
-    protected $dateFormat = 'datetime';
-
-    public $name = '';
-
-    public $email = '';
-
-    public $country = '';
+    protected $dateFormat     = 'datetime';
+    public $name              = '';
+    public $email             = '';
+    public $country           = '';
 }

--- a/tests/_support/Models/ValidErrorsModel.php
+++ b/tests/_support/Models/ValidErrorsModel.php
@@ -15,19 +15,14 @@ use CodeIgniter\Model;
 
 class ValidErrorsModel extends Model
 {
-    protected $table = 'job';
-
-    protected $returnType = 'object';
-
+    protected $table          = 'job';
+    protected $returnType     = 'object';
     protected $useSoftDeletes = false;
-
-    protected $dateFormat = 'int';
-
-    protected $allowedFields = [
+    protected $dateFormat     = 'int';
+    protected $allowedFields  = [
         'name',
         'description',
     ];
-
     protected $validationRules = [
         'name' => [
             'required',

--- a/tests/_support/Models/ValidModel.php
+++ b/tests/_support/Models/ValidModel.php
@@ -15,19 +15,14 @@ use CodeIgniter\Model;
 
 class ValidModel extends Model
 {
-    protected $table = 'job';
-
-    protected $returnType = 'object';
-
+    protected $table          = 'job';
+    protected $returnType     = 'object';
     protected $useSoftDeletes = false;
-
-    protected $dateFormat = 'int';
-
-    protected $allowedFields = [
+    protected $dateFormat     = 'int';
+    protected $allowedFields  = [
         'name',
         'description',
     ];
-
     protected $validationRules = [
         'name' => [
             'required',
@@ -35,7 +30,6 @@ class ValidModel extends Model
         ],
         'token' => 'permit_empty|in_list[{id}]',
     ];
-
     protected $validationMessages = [
         'name' => [
             'required'   => 'You forgot to name the baby.',

--- a/tests/_support/Models/WithoutAutoIncrementModel.php
+++ b/tests/_support/Models/WithoutAutoIncrementModel.php
@@ -15,14 +15,11 @@ use CodeIgniter\Model;
 
 class WithoutAutoIncrementModel extends Model
 {
-    protected $table = 'without_auto_increment';
-
-    protected $primaryKey = 'key';
-
+    protected $table         = 'without_auto_increment';
+    protected $primaryKey    = 'key';
     protected $allowedFields = [
         'key',
         'value',
     ];
-
     protected $useAutoIncrement = false;
 }

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -20,9 +20,7 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 final class EnvironmentCommandTest extends CIUnitTestCase
 {
     private $streamFilter;
-
-    private $envPath = ROOTPATH . '.env';
-
+    private $envPath       = ROOTPATH . '.env';
     private $backupEnvPath = ROOTPATH . '.env.backup';
 
     protected function setUp(): void

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -20,10 +20,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 final class MigrationIntegrationTest extends CIUnitTestCase
 {
     private $streamFilter;
-
     private $migrationFileFrom = SUPPORTPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
-
-    private $migrationFileTo = APPPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
+    private $migrationFileTo   = APPPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
 
     protected function setUp(): void
     {

--- a/tests/system/Config/fixtures/Encryption.php
+++ b/tests/system/Config/fixtures/Encryption.php
@@ -15,6 +15,7 @@ class Encryption extends EncryptionConfig
 {
     private const HEX2BIN = 'hex2bin:84cf2c0811d5daf9e1c897825a3debce91f9a33391e639f72f7a4740b30675a2';
     private const BASE64  = 'base64:Psf8bUHRh1UJYG2M7e+5ec3MdjpKpzAr0twamcAvOcI=';
+
     public $key;
     public $driver = 'MCrypt';
 

--- a/tests/system/Config/fixtures/SimpleConfig.php
+++ b/tests/system/Config/fixtures/SimpleConfig.php
@@ -25,7 +25,8 @@ class SimpleConfig extends \CodeIgniter\Config\BaseConfig
     public $simple = [
         'name' => null,
     ];
-    // properties for environment over-ride testing
+
+    // properties for environment override testing
     public $alpha   = 'one';
     public $bravo   = 'two';
     public $charlie = 'three';
@@ -41,7 +42,6 @@ class SimpleConfig extends \CodeIgniter\Config\BaseConfig
         'doctor'  => 'Bones',
         'comms'   => 'Uhuru',
     ];
-
     public $shortie;
     public $longie;
     public $onedeep_value;

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -56,6 +56,7 @@ final class ControllerTest extends CIUnitTestCase
      * @var Response
      */
     protected $response;
+
     /**
      * @var LoggerInterface
      */

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -39,7 +39,6 @@ final class BaseConnectionTest extends CIUnitTestCase
         'strictOn' => true,
         'failover' => [],
     ];
-
     protected $failoverOptions = [
         'DSN'      => '',
         'hostname' => 'localhost',

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -40,7 +40,6 @@ final class ConfigTest extends CIUnitTestCase
         'failover' => [],
         'port'     => 3306,
     ];
-
     protected $dsnGroup = [
         'DSN'      => 'MySQLi://user:pass@localhost:3306/dbname?DBPrefix=test_&pConnect=true&charset=latin1&DBCollat=latin1_swedish_ci',
         'hostname' => '',
@@ -60,7 +59,6 @@ final class ConfigTest extends CIUnitTestCase
         'failover' => [],
         'port'     => 3306,
     ];
-
     protected $dsnGroupPostgre = [
         'DSN'      => 'Postgre://user:pass@localhost:5432/dbname?DBPrefix=test_&connect_timeout=5&sslmode=1',
         'hostname' => '',
@@ -80,7 +78,6 @@ final class ConfigTest extends CIUnitTestCase
         'failover' => [],
         'port'     => 5432,
     ];
-
     protected $dsnGroupPostgreNative = [
         'DSN'      => 'pgsql:host=localhost;port=5432;dbname=database_name',
         'hostname' => '',

--- a/tests/system/Database/Live/AliasTest.php
+++ b/tests/system/Database/Live/AliasTest.php
@@ -24,8 +24,7 @@ final class AliasTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testAlias()
     {

--- a/tests/system/Database/Live/BadQueryTest.php
+++ b/tests/system/Database/Live/BadQueryTest.php
@@ -25,8 +25,7 @@ final class BadQueryTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
     protected static $origDebug;
 
     /**

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -27,9 +27,7 @@ final class ConnectTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $group1;
-
     protected $group2;
-
     protected $tests;
 
     protected function setUp(): void

--- a/tests/system/Database/Live/CountTest.php
+++ b/tests/system/Database/Live/CountTest.php
@@ -24,8 +24,7 @@ final class CountTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testCountReturnsZeroWithNoResults()
     {

--- a/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
+++ b/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
@@ -24,8 +24,7 @@ final class DatabaseTestTraitCaseTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testHasInDatabase()
     {

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -25,8 +25,7 @@ final class DeleteTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testDeleteThrowExceptionWithNoCriteria()
     {

--- a/tests/system/Database/Live/EmptyTest.php
+++ b/tests/system/Database/Live/EmptyTest.php
@@ -24,8 +24,7 @@ final class EmptyTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testEmpty()
     {

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -24,7 +24,6 @@ final class EscapeTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = false;
-
     protected $char;
 
     protected function setUp(): void

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -29,8 +29,7 @@ final class ForgeTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     /**
      * @var Forge

--- a/tests/system/Database/Live/FromTest.php
+++ b/tests/system/Database/Live/FromTest.php
@@ -24,8 +24,7 @@ final class FromTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testFromCanAddTables()
     {

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -22,8 +22,7 @@ final class GetNumRowsTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     /**
      * Added as instructed at https://codeigniter4.github.io/userguide/testing/database.html#the-test-class

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -25,8 +25,7 @@ final class GetTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testGet()
     {

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -24,8 +24,7 @@ final class GroupTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testGroupBy()
     {

--- a/tests/system/Database/Live/IncrementTest.php
+++ b/tests/system/Database/Live/IncrementTest.php
@@ -24,8 +24,7 @@ final class IncrementTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testIncrement()
     {

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -24,8 +24,7 @@ final class InsertTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testInsert()
     {

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -24,8 +24,7 @@ final class JoinTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testSimpleJoin()
     {

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -24,8 +24,7 @@ final class LikeTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testLikeDefault()
     {

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -22,9 +22,9 @@ use CodeIgniter\Test\DatabaseTestTrait;
 final class LimitTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
-    protected $refresh = true;
 
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $refresh = true;
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testLimit()
     {

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -24,8 +24,7 @@ final class OrderTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testOrderAscending()
     {

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -24,8 +24,7 @@ final class SelectTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testSelectAllByDefault()
     {

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -25,8 +25,7 @@ final class UpdateTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testUpdateSetsAllWithoutWhere()
     {

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -24,8 +24,7 @@ final class WhereTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testWhereSimpleKeyValue()
     {

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -25,8 +25,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     public function testSet()
     {

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -33,7 +33,6 @@ final class MigrationRunnerTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-
     protected $root;
     protected $start;
     protected $config;

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -930,14 +930,12 @@ final class EntityTest extends CIUnitTestCase
                 'default'    => 'sumfin',
                 'created_at' => null,
             ];
-
             protected $original = [
                 'foo'        => null,
                 'bar'        => null,
                 'default'    => 'sumfin',
                 'created_at' => null,
             ];
-
             protected $datamap = [
                 'createdAt' => 'created_at',
             ];
@@ -968,7 +966,6 @@ final class EntityTest extends CIUnitTestCase
                 'foo'    => null,
                 'simple' => null,
             ];
-
             protected $_original = [
                 'foo'    => null,
                 'simple' => null,
@@ -999,12 +996,10 @@ final class EntityTest extends CIUnitTestCase
                 'foo' => 'foo',
                 'bar' => 'bar',
             ];
-
             protected $_original = [
                 'foo' => 'foo',
                 'bar' => 'bar',
             ];
-
             protected $datamap = [
                 'bar'          => 'foo',
                 'foo'          => 'bar',
@@ -1031,7 +1026,6 @@ final class EntityTest extends CIUnitTestCase
                 'twelfth'    => null,
                 'thirteenth' => null,
             ];
-
             protected $_original = [
                 'first'      => null,
                 'second'     => null,
@@ -1082,7 +1076,6 @@ final class EntityTest extends CIUnitTestCase
                 'integer_0'             => null,
                 'string_value_not_null' => 'value',
             ];
-
             protected $_original = [
                 'string_null'           => null,
                 'string_empty'          => null,
@@ -1111,7 +1104,6 @@ final class EntityTest extends CIUnitTestCase
                 'third'  => null,
                 'fourth' => null,
             ];
-
             protected $_original = [
                 'first'  => null,
                 'second' => null,
@@ -1126,7 +1118,6 @@ final class EntityTest extends CIUnitTestCase
                 'third'  => 'type[param1, param2,param3]',
                 'fourth' => '?type',
             ];
-
             protected $castHandlers = [
                 'base64'   => CastBase64::class,
                 'someType' => NotExtendsBaseCast::class,

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -30,6 +30,7 @@ final class RedirectResponseTest extends CIUnitTestCase
      * @var RouteCollection
      */
     protected $routes;
+
     protected $request;
     protected $config;
 

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -165,7 +165,6 @@ final class InsertModelTest extends LiveModelTestCase
             protected $deleted;
             protected $created_at;
             protected $updated_at;
-
             protected $_options = [
                 'datamap' => [],
                 'dates'   => [
@@ -223,7 +222,6 @@ final class InsertModelTest extends LiveModelTestCase
             protected $deleted;
             protected $created_at;
             protected $updated_at;
-
             protected $_options = [
                 'datamap' => [],
                 'dates'   => [

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -216,7 +216,6 @@ final class SaveModelTest extends LiveModelTestCase
             protected $deleted;
             protected $created_at;
             protected $updated_at;
-
             protected $_options = [
                 'datamap' => [],
                 'dates'   => [

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -166,7 +166,6 @@ final class UpdateModelTest extends LiveModelTestCase
             protected $deleted;
             protected $created_at;
             protected $updated_at;
-
             protected $_options = [
                 'datamap' => [],
                 'dates'   => [
@@ -186,7 +185,6 @@ final class UpdateModelTest extends LiveModelTestCase
             protected $deleted;
             protected $created_at;
             protected $updated_at;
-
             protected $_options = [
                 'datamap' => [],
                 'dates'   => [
@@ -315,7 +313,6 @@ final class UpdateModelTest extends LiveModelTestCase
             protected $deleted;
             protected $created_at;
             protected $updated_at;
-
             protected $_options = [
                 'datamap' => [],
                 'dates'   => [

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -29,6 +29,7 @@ final class PagerTest extends CIUnitTestCase
      * @var \CodeIgniter\Pager\Pager
      */
     protected $pager;
+
     protected $config;
 
     protected function setUp(): void

--- a/tests/system/Session/Handlers/DatabaseHandlerTest.php
+++ b/tests/system/Session/Handlers/DatabaseHandlerTest.php
@@ -26,8 +26,7 @@ final class DatabaseHandlerTest extends CIUnitTestCase
     use ReflectionHelper;
 
     protected $refresh = true;
-
-    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     protected function setUp(): void
     {

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -24,6 +24,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
      * @var Validation
      */
     protected $validation;
+
     protected $config = [
         'ruleSets' => [
             Rules::class,

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -24,6 +24,7 @@ final class FileRulesTest extends CIUnitTestCase
      * @var Validation
      */
     protected $validation;
+
     protected $config = [
         'ruleSets' => [
             Rules::class,

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -27,6 +27,7 @@ final class FormatRulesTest extends CIUnitTestCase
      * @var Validation
      */
     protected $validation;
+
     protected $config = [
         'ruleSets' => [
             Rules::class,

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -31,6 +31,7 @@ final class RulesTest extends CIUnitTestCase
      * @var Validation
      */
     protected $validation;
+
     protected $config = [
         'ruleSets' => [
             Rules::class,

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -29,6 +29,7 @@ final class ValidationTest extends CIUnitTestCase
      * @var Validation
      */
     protected $validation;
+
     protected $config = [
         'ruleSets' => [
             Rules::class,

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -24,6 +24,7 @@ final class ParserPluginTest extends CIUnitTestCase
      * @var Parser
      */
     protected $parser;
+
     /**
      * @var Validation
      */


### PR DESCRIPTION
**Description**
This PR proposes to change how we use the `class_attributes_separation` rule. Currently, we only activate changing the separation between class `method`s to always have a single blank line. This now includes class constants, properties, and trait uses in the picture by using this logic:

1. If the const, property, or trait use has metadata (PHPDoc or Attribute) attached to it, it gets one line.
2. If none, then no blank lines are enforced.
3. If preceding class attribute has metadata while the current has none, there will still be a blank line.
```diff
class Foo
{
    /** @var Foo */
    public $bar;
+
    public $baz;
-
    public $qux;
}
```
4. There are blank lines in between attributes:
```diff
class Foo
{
    use FooTrait;
    use BarTrait;
+
    public $bar;
    public $baz;
}
```

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
