### PR TITLE
Enable `no_alternative_syntax` rule

### DIFF
--- a/.no-header.php-cs-fixer.dist.php
+++ b/.no-header.php-cs-fixer.dist.php
@@ -27,7 +27,10 @@ $finder = Finder::create()
     ])
     ->notName('#Logger\.php$#');
 
-$overrides = [];
+$overrides = [
+    // @TODO Remove once live in coding-standard
+    'no_alternative_syntax' => ['fix_non_monolithic_code' => false],
+];
 
 $options = [
     'cacheFile'    => 'build/.no-header.php-cs-fixer.cache',

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,7 +34,10 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [];
+$overrides = [
+    // @TODO Remove once live in coding-standard
+    'no_alternative_syntax' => ['fix_non_monolithic_code' => false],
+];
 
 $options = [
     'cacheFile'    => 'build/.php-cs-fixer.cache',


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe no_alternative_syntax
Description of no_alternative_syntax rule.
Replace control structure alternative syntax to use braces.

Fixer is configurable using following option:
* fix_non_monolithic_code (bool): whether to also fix code with inline HTML; defaults to true

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -if(true):echo 't';else:echo 'f';endif;
   +if(true) { echo 't';} else { echo 'f';}

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['fix_non_monolithic_code' => true].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,3 +1,3 @@
   -<?php if ($condition): ?>
   +<?php if ($condition) { ?>
    Lorem ipsum.
   -<?php endif; ?>
   +<?php } ?>

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
