### PR TITLE
Add unit test to ensure named binds don't get replaced in binded values

### DIFF
--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -294,6 +294,20 @@ final class BaseQueryTest extends CIUnitTestCase
         $this->assertSame($expected, $query->getQuery());
     }
 
+    public function testNamedBindsDontGetReplacedAgain()
+    {
+        $query = new Query($this->db);
+
+        $query->setQuery(
+            'SELECT * FROM posts WHERE content = :content: OR foobar = :foobar:',
+            ['content' => 'a placeholder looks like :foobar:', 'foobar' => 'bazqux']
+        );
+
+        $expected = "SELECT * FROM posts WHERE content = 'a placeholder looks like :foobar:' OR foobar = 'bazqux'";
+
+        $this->assertSame($expected, $query->getQuery());
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1705
      */


### PR DESCRIPTION
Using `str_replace()` instead of `strtr()` in `Database\Query->matchNamedBinds()` would make this test fail.

For this test to be effective, the overlapping marker (here :foobar:) has to be after the replaced string (here :content:) in the binds array.