### PR TITLE
Improve `model()` auto-completion

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -23,6 +23,7 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\URI;
+use CodeIgniter\Model;
 use CodeIgniter\Session\Session;
 use CodeIgniter\Test\TestLogger;
 use Config\App;
@@ -776,7 +777,12 @@ if (! function_exists('model')) {
     /**
      * More simple way of getting model instances from Factories
      *
-     * @return mixed
+     * @template T of Model
+     *
+     * @param class-string<T> $name
+     *
+     * @return T
+     * @phpstan-return Model
      */
     function model(string $name, bool $getShared = true, ?ConnectionInterface &$conn = null)
     {


### PR DESCRIPTION
**Description**
- improve `model()` auto-completion for PhpStorm

![Screenshot 2021-10-08 8 59 19](https://user-images.githubusercontent.com/87955/136479388-ce21573b-c022-43f6-90cb-05efe08e6097.png)

`@phpstan-return` is to suppress the following PHPStan error. I don't know why the error occurs.
```
 ------ -------------------------------------------------------------------------------------- 
  Line   system/Common.php                                                                     
 ------ -------------------------------------------------------------------------------------- 
  787    Function model() should return T of CodeIgniter\Model but returns CodeIgniter\Model.  
 ------ -------------------------------------------------------------------------------------- 
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
