### PR TITLE
[Debug] Improve keyword highlighting and escaping of query strings. 

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -407,13 +407,13 @@ class Query implements QueryInterface
             $this->compileBinds(); // @codeCoverageIgnore
         }
 
-        $sql = htmlspecialchars($this->finalQueryString, ENT_COMPAT);
+        $sql = esc($this->finalQueryString);
 
         /**
          * @see https://stackoverflow.com/a/20767160
-         * @see https://regex101.com/r/hUlrGN/1
+         * @see https://regex101.com/r/hUlrGN/4
          */
-        $search = '/\b(?:' . implode('|', $highlight) . ')\b(?![^\']*\'(?:(?:[^\']*\'){2})*[^\']*$)/';
+        $search = '/\b(?:' . implode('|', $highlight) . ')\b(?![^(&#039;)]*&#039;(?:(?:[^(&#039;)]*&#039;){2})*[^(&#039;)]*$)/';
 
         return preg_replace_callback($search, static function ($matches) {
             return '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>';

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -368,15 +368,15 @@ final class BaseQueryTest extends CIUnitTestCase
     {
         return [
             'highlightKeyWords' => [
-                '<strong>SELECT</strong> `a`.*, `b`.`id` <strong>AS</strong> `b_id` <strong>FROM</strong> `a` <strong>LEFT</strong> <strong>JOIN</strong> `b` <strong>ON</strong> `b`.`a_id` = `a`.`id` <strong>WHERE</strong> `b`.`id` <strong>IN</strong> (\'1\') <strong>AND</strong> `a`.`deleted_at` <strong>IS</strong> <strong>NOT</strong> <strong>NULL</strong> <strong>LIMIT</strong> 1',
+                '<strong>SELECT</strong> `a`.*, `b`.`id` <strong>AS</strong> `b_id` <strong>FROM</strong> `a` <strong>LEFT</strong> <strong>JOIN</strong> `b` <strong>ON</strong> `b`.`a_id` = `a`.`id` <strong>WHERE</strong> `b`.`id` <strong>IN</strong> (&#039;1&#039;) <strong>AND</strong> `a`.`deleted_at` <strong>IS</strong> <strong>NOT</strong> <strong>NULL</strong> <strong>LIMIT</strong> 1',
                 'SELECT `a`.*, `b`.`id` AS `b_id` FROM `a` LEFT JOIN `b` ON `b`.`a_id` = `a`.`id` WHERE `b`.`id` IN (\'1\') AND `a`.`deleted_at` IS NOT NULL LIMIT 1',
             ],
             'ignoreKeyWordsInValues' => [
-                '<strong>SELECT</strong> * <strong>FROM</strong> `a` <strong>WHERE</strong> `a`.`col` = \'SELECT escaped keyword in value\' <strong>LIMIT</strong> 1',
+                '<strong>SELECT</strong> * <strong>FROM</strong> `a` <strong>WHERE</strong> `a`.`col` = &#039;SELECT escaped keyword in value&#039; <strong>LIMIT</strong> 1',
                 'SELECT * FROM `a` WHERE `a`.`col` = \'SELECT escaped keyword in value\' LIMIT 1',
             ],
             'escapeHtmlValues' => [
-                '<strong>SELECT</strong> \'&lt;s&gt;\' <strong>FROM</strong> dual',
+                '<strong>SELECT</strong> &#039;&lt;s&gt;&#039; <strong>FROM</strong> dual',
                 'SELECT \'<s>\' FROM dual',
             ],
         ];


### PR DESCRIPTION
**Description**
~This PR adds a few more composite query keywords to the highlight list for the debug toolbar.~
~I also decided to sort the keywords alphabetically, as it was a pain checking which ones are missing. (This is debatable of course.)~

- Deconstruct composite keywords.
- Sort kewords alphabetically.
- Modify regex pattern to ignore kewords within escaped string values (`''`).
- [WIP] Add HTML escaping.

Depends on #5196.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide

**Before:**
![2](https://user-images.githubusercontent.com/40514119/136916581-aea48928-7592-4c3b-975d-0d096581b6de.png)

**After:**
![1](https://user-images.githubusercontent.com/40514119/136916576-45950357-28e6-440a-a511-832f0903be9a.png)