### PR TITLE
docs: remove link to Model in routing.rst

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -68,7 +68,7 @@ Placeholders Description
 (:num)       will match any integer.
 (:alpha)     will match any string of alphabetic characters
 (:alphanum)  will match any string of alphabetic characters or integers, or any combination of the two.
-(:hash)      is the same as **(:segment)**, but can be used to easily see which routes use hashed ids (see the :doc:`Model </models/model>` docs).
+(:hash)      is the same as **(:segment)**, but can be used to easily see which routes use hashed ids.
 ============ ===========================================================================================================
 
 .. note:: **{locale}** cannot be used as a placeholder or other part of the route, as it is reserved for use


### PR DESCRIPTION
**Description**
- hashed id (`encodeID()`) in `CodeIgniter\Model` has been removed. See https://github.com/codeigniter4/CodeIgniter4/commit/f87ffec26b0d3dca7544a6e76e9110f03671dc54


**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
