### PR TITLE
Remove invalid @runTestsInSeparateProcesses

### DIFF
--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -58,9 +58,6 @@ final class MigrationIntegrationTest extends CIUnitTestCase
         stream_filter_remove($this->streamFilter);
     }
 
-    /**
-     * @runTestsInSeparateProcesses
-     */
     public function testMigrationWithRollbackHasSameNameFormat(): void
     {
         command('migrate -n App');


### PR DESCRIPTION
**Description**
Remove invalid `@runTestsInSeparateProcesses`.
It needs to be in class doc comment.
https://phpunit.readthedocs.io/en/9.5/annotations.html#runtestsinseparateprocesses


**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
