### PR TITLE
Rename toolbar loader to be a regular JS file

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -434,11 +434,10 @@ class Toolbar
         if ($request->getGet('debugbar') !== null) {
             header('Content-Type: application/javascript');
 
-            echo sprintf("window.appUrl = '%s';%s", rtrim(site_url(), '/'), PHP_EOL);
-
             ob_start();
             include $this->config->viewsPath . 'toolbarloader.js';
             $output = ob_get_clean();
+            $output = str_replace('{url}', rtrim(site_url(), '/'), $output);
             echo $output;
 
             exit;

--- a/system/Debug/Toolbar/Views/toolbarloader.js
+++ b/system/Debug/Toolbar/Views/toolbarloader.js
@@ -8,7 +8,7 @@ function loadDoc(time) {
 
     localStorage.setItem('debugbar-time-new', time);
 
-    let url = window.appUrl;
+    let url = '{url}';
     let xhttp = new XMLHttpRequest();
 
     xhttp.onreadystatechange = function() {


### PR DESCRIPTION
**Description**
Fixes #5215 

This renames toolbar loader from a PHP file to a JS file to dispense with (1) environment check, (2) CRLF incompat from substr

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
