### PR TITLE
docs: fix installation/upgrade_4xx.rst

### DIFF
--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -30,7 +30,7 @@ General Adjustments
 
 **Downloads**
 
-- CI4 is still available as a ready-to-run zip or tarball, which includes the user guide (though in the `docs` subfolder).
+- CI4 is still available as a ready-to-run zip or tarball.
 - It can also be installed using Composer.
 
 **Namespaces**


### PR DESCRIPTION
**Description**
- Zip file does not contain the user guide

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
