### PR TITLE
Switch PHPCPD to tool

### DIFF
--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -34,10 +34,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          tools: phive
-          extensions: intl, json, mbstring, xml
+          tools: phpcpd
+          extensions: dom, mbstring
 
       - name: Detect code duplication
-        run: |
-            sudo phive --no-progress install --global --trust-gpg-keys 4AA394086372C20A phpcpd 
-            phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php app/ public/ system/
+        run: phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php -- app/ public/ system/


### PR DESCRIPTION
**Description**
`shivammathur/setup-php` supports [a number of tools natively](https://github.com/shivammathur/setup-php#wrench-tools-support) that saves needing to mess with Phive and importing keys ourselves. This PR switched the `phpcpd` workflow to use the version available from tools.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
