### PR TITLE
Fix CreateDatabaseTest::testCreateDatabase()

### DIFF
--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Database as DatabaseFactory;
 use CodeIgniter\Database\SQLite3\Connection as SQLite3Connection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
@@ -45,7 +46,11 @@ final class CreateDatabaseTest extends CIUnitTestCase
                 unlink($file);
             }
         } else {
-            Database::forge()->dropDatabase('foobar');
+            $util = (new DatabaseFactory())->loadUtils($this->connection);
+
+            if ($util->databaseExists('foobar')) {
+                Database::forge()->dropDatabase('foobar');
+            }
         }
     }
 


### PR DESCRIPTION
**Description**
If there is the database file, the test fails.

```
1) CodeIgniter\Commands\CreateDatabaseTest::testCreateDatabase
Failed asserting that 'Database ".../CodeIgniter4/writable/foobar.db" already exists.\n
\n
' contains "successfully created.".

.../CodeIgniter4/tests/system/Commands/CreateDatabaseTest.php:68
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
