### PR TITLE
Fix TimeTest::testToFormattedDateString()

### DIFF
--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -28,7 +28,7 @@ final class TimeTest extends CIUnitTestCase
         parent::setUp();
 
         helper('date');
-        Locale::setDefault('America/Chicago');
+        Locale::setDefault('en_US');
     }
 
     public function testNewTimeNow()


### PR DESCRIPTION

**Description**

```
2) CodeIgniter\I18n\TimeTest::testToFormattedDateString
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'May 10, 2017'
+'5月 10, 2017'

.../CodeIgniter4/tests/system/I18n/TimeTest.php:643
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

