### PR TITLE
docs: decorate `.env` with `**`

### DIFF
--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -9,7 +9,7 @@ Database Configuration
 CodeIgniter has a config file that lets you store your database
 connection values (username, password, database name, etc.). The config
 file is located at **app/Config/Database.php**. You can also set
-database connection values in the .env file. See below for more details.
+database connection values in the **.env** file. See below for more details.
 
 The config settings are stored in a class property that is an array with this
 prototype::
@@ -162,7 +162,7 @@ within the class' constructor::
 Configuring With .env File
 --------------------------
 
-You can also save your configuration values within a ``.env`` file with the current server's
+You can also save your configuration values within a **.env** file with the current server's
 database settings. You only need to enter the values that change from what is in the
 default group's configuration settings. The values should be name following this format, where
 ``default`` is the group name::

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -63,7 +63,7 @@ Service Accessors
     or return a default value if it is not found. Will format boolean values
     to actual booleans instead of string representations.
 
-    Especially useful when used in conjunction with .env files for setting
+    Especially useful when used in conjunction with **.env** files for setting
     values that are specific to the environment itself, like database
     settings, API keys, etc.
 

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -191,15 +191,15 @@ Environment Variables as Replacements for Data
 ==============================================
 
 It is very important to always remember that environment variables contained in your **.env** are
-**only replacements for existing data**. This means that you cannot expect to fill your ``.env`` with all
+**only replacements for existing data**. This means that you cannot expect to fill your **.env** with all
 the replacements for your configurations but have nothing to receive these replacements in the
 related configuration file(s).
 
-The ``.env`` only serves to fill or replace the values in your configuration files. That said, your
+The **.env** only serves to fill or replace the values in your configuration files. That said, your
 configuration files should have a container or receiving property for those. Adding so many variables in
-your ``.env`` with nothing to contain them in the receiving end is useless.
+your **.env** with nothing to contain them in the receiving end is useless.
 
-Simply put, you cannot just put ``app.myNewConfig = foo`` in your ``.env`` and expect your ``Config\App``
+Simply put, you cannot just put ``app.myNewConfig = foo`` in your **.env** and expect your ``Config\App``
 to magically have that property and value at run time.
 
 Treating Environment Variables as Arrays

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -55,7 +55,7 @@ Configuration
 
 By default, CodeIgniter will display all errors in the ``development`` and ``testing`` environments, and will not
 display any errors in the ``production`` environment. You can change this by setting the ``CI_ENVIRONMENT`` variable
-in the ``.env`` file.
+in the **.env** file.
 
 .. important:: Disabling error reporting DOES NOT stop logs from being written if there are errors.
 

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -17,11 +17,11 @@ Initial Configuration & Set Up
 
 #. Open the **app/Config/App.php** file with a text editor and
    set your base URL. If you need more flexibility, the baseURL may
-   be set within the ``.env`` file as **app.baseURL="http://example.com/"**.
+   be set within the **.env** file as ``app.baseURL="http://example.com/"``.
    (Always use a trailing slash on your base URL!)
 #. If you intend to use a database, open the
    **app/Config/Database.php** file with a text editor and set your
-   database settings. Alternately, these could be set in your ``.env`` file.
+   database settings. Alternately, these could be set in your **.env** file.
 
 One additional measure to take in production environments is to disable
 PHP error reporting and any other development-only functionality. In

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -65,7 +65,7 @@ unrecoverable error, which we don't want to show to the viewer of
 the webapp, for better security.
 
 You can see the error in the debug toolbar display by setting your environment to
-"development" (in `.env`), and reloading the page.
+"development" (in **.env**), and reloading the page.
 
 Don't forget to reset the environment to "production" once you fix the problem!
 

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -153,7 +153,7 @@ the library.
     // or
     public $key = 'base64:<your-base64-encoded-key>'
 
-Similarly, you can use these prefixes in your ``.env`` file, too!
+Similarly, you can use these prefixes in your **.env** file, too!
 ::
 
     // For hex2bin

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -36,7 +36,7 @@ Customizing Honeypot
 =====================
 
 Honeypot can be customized. The fields below can be set either in
-**app/Config/Honeypot.php** or in ``.env``.
+**app/Config/Honeypot.php** or in **.env**.
 
 * ``hidden`` - true|false to control visibility of the honeypot field; default is ``true``
 * ``label`` - HTML label for the honeypot field, default is 'Fill This Field'


### PR DESCRIPTION
**Description**
- it seems as a general rule, file names are decorated with `**`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
