### PR TITLE
style: global_namespace_import true

### DIFF
--- a/tests/_support/Commands/AppInfo.php
+++ b/tests/_support/Commands/AppInfo.php
@@ -14,6 +14,7 @@ namespace Tests\Support\Commands;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CodeIgniter;
+use RuntimeException;
 
 class AppInfo extends BaseCommand
 {
@@ -31,7 +32,7 @@ class AppInfo extends BaseCommand
     {
         try {
             CLI::color('test', 'white', 'Background');
-        } catch (\RuntimeException $oops) {
+        } catch (RuntimeException $oops) {
             $this->showError($oops);
         }
     }

--- a/tests/_support/Commands/InvalidCommand.php
+++ b/tests/_support/Commands/InvalidCommand.php
@@ -14,6 +14,7 @@ namespace Tests\Support\Commands;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CodeIgniter;
+use ReflectionException;
 
 class InvalidCommand extends BaseCommand
 {
@@ -23,7 +24,7 @@ class InvalidCommand extends BaseCommand
 
     public function __construct()
     {
-        throw new \ReflectionException();
+        throw new ReflectionException();
     }
 
     public function run(array $params)

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -13,6 +13,7 @@ namespace Tests\Support\Controllers;
 
 use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Controller;
+use RuntimeException;
 
 /**
  * This is a testing only controller, intended to blow up in multiple
@@ -34,7 +35,7 @@ class Popcorn extends Controller
 
     public function popper()
     {
-        throw new \RuntimeException('Surprise', 500);
+        throw new RuntimeException('Surprise', 500);
     }
 
     public function weasel()

--- a/tests/_support/Widgets/SomeWidget.php
+++ b/tests/_support/Widgets/SomeWidget.php
@@ -11,7 +11,9 @@
 
 namespace Tests\Support\Widgets;
 
+use stdClass;
+
 // Extends a trivial class to test the instanceOf directive
-class SomeWidget extends \stdClass
+class SomeWidget extends stdClass
 {
 }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -90,7 +90,7 @@ final class TimeTest extends CIUnitTestCase
             'yyyy-MM-dd HH:mm:ss'
         );
 
-        $time = new Time('now', new \DateTimeZone('Europe/London'), 'fr_FR');
+        $time = new Time('now', new DateTimeZone('Europe/London'), 'fr_FR');
 
         $this->assertSame($formatter->format($time), (string) $time);
     }
@@ -101,13 +101,13 @@ final class TimeTest extends CIUnitTestCase
 
         $obj = $time->toDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $obj);
+        $this->assertInstanceOf(DateTime::class, $obj);
     }
 
     public function testNow()
     {
         $time  = Time::now();
-        $time1 = new \DateTime();
+        $time1 = new DateTime();
 
         $this->assertInstanceOf(Time::class, $time);
         $this->assertSame($time->getTimestamp(), $time1->getTimestamp());
@@ -116,7 +116,7 @@ final class TimeTest extends CIUnitTestCase
     public function testParse()
     {
         $time  = Time::parse('next Tuesday', 'America/Chicago');
-        $time1 = new \DateTime('now', new \DateTimeZone('America/Chicago'));
+        $time1 = new DateTime('now', new DateTimeZone('America/Chicago'));
         $time1->modify('next Tuesday');
 
         $this->assertSame($time->getTimestamp(), $time1->getTimestamp());
@@ -134,7 +134,7 @@ final class TimeTest extends CIUnitTestCase
     {
         $time = Time::parse('2017-01-12 00:00', 'Europe/London');
 
-        $expects = new \DateTime('2017-01-12', new \DateTimeZone('Europe/London'));
+        $expects = new DateTime('2017-01-12', new DateTimeZone('Europe/London'));
 
         $this->assertSame($expects->format('Y-m-d H:i:s'), $time->toDateTimeString());
     }
@@ -204,7 +204,7 @@ final class TimeTest extends CIUnitTestCase
 
     public function testCreateFromFormat()
     {
-        $now = new \DateTime('now');
+        $now = new DateTime('now');
 
         Time::setTestNow($now);
         $time = Time::createFromFormat('F j, Y', 'January 15, 2017', 'America/Chicago');
@@ -222,7 +222,7 @@ final class TimeTest extends CIUnitTestCase
 
     public function testCreateFromFormatWithTimezoneObject()
     {
-        $tz = new \DateTimeZone('Europe/London');
+        $tz = new DateTimeZone('Europe/London');
 
         $time = Time::createFromFormat('F j, Y', 'January 15, 2017', $tz);
 
@@ -422,7 +422,7 @@ final class TimeTest extends CIUnitTestCase
     {
         $instance = Time::now()->getTimezone();
 
-        $this->assertInstanceOf(\DateTimeZone::class, $instance);
+        $this->assertInstanceOf(DateTimeZone::class, $instance);
     }
 
     public function testGetTimezonename()
@@ -776,7 +776,7 @@ final class TimeTest extends CIUnitTestCase
     public function testEqualWithDateTime()
     {
         $time1 = Time::parse('January 10, 2017 21:50:00', 'America/Chicago');
-        $time2 = new \DateTime('January 11, 2017 03:50:00', new \DateTimeZone('Europe/London'));
+        $time2 = new DateTime('January 11, 2017 03:50:00', new DateTimeZone('Europe/London'));
 
         $this->assertTrue($time1->equals($time2));
     }
@@ -784,7 +784,7 @@ final class TimeTest extends CIUnitTestCase
     public function testEqualWithSameDateTime()
     {
         $time1 = Time::parse('January 10, 2017 21:50:00', 'America/Chicago');
-        $time2 = new \DateTime('January 10, 2017 21:50:00', new \DateTimeZone('America/Chicago'));
+        $time2 = new DateTime('January 10, 2017 21:50:00', new DateTimeZone('America/Chicago'));
 
         $this->assertTrue($time1->equals($time2));
     }


### PR DESCRIPTION
**Description**
- change `global_namespace_import` to `true`
  - import global class only
  - see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.19/doc/rules/import/global_namespace_import.rst
- update only test code

```diff
--- a/src/CodeIgniter4.php
+++ b/src/CodeIgniter4.php
@@ -171,7 +171,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'fix_inline'     => true,
                 'replacements'   => ['inheritDocs' => 'inheritDoc'],
             ],
-            'global_namespace_import'     => false,
+            'global_namespace_import'     => true,
             'group_import'                => false,
             'header_comment'              => false, // false by default
             'heredoc_indentation'         => ['indentation' => 'start_plus_one'],

```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

