### PR TITLE
Refactoring Filter::run() - Changed the way after method runs

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -161,7 +161,7 @@ class Filters
     public function run(string $uri, string $position = 'before')
     {
         $this->initialize(strtolower($uri));
-        //reversing after filters
+        // reversing after filters
         if($position === 'after') {
             $this->filtersClass[$position] = array_reverse($this->filtersClass[$position]);
         }
@@ -234,8 +234,6 @@ class Filters
         $this->processGlobals($uri);
         $this->processMethods();
         $this->processFilters($uri);
-        //reversing after filters
-        $this->filters['after'] = array_reverse($this->filters['after']);
         // Set the toolbar filter to the last position to be executed
         if (in_array('toolbar', $this->filters['after'], true)
             && ($count = count($this->filters['after'])) > 1

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -161,6 +161,10 @@ class Filters
     public function run(string $uri, string $position = 'before')
     {
         $this->initialize(strtolower($uri));
+        //reversing after filters
+        if($position === 'after') {
+            $this->filtersClass[$position] = array_reverse($this->filtersClass[$position]);
+        }
 
         foreach ($this->filtersClass[$position] as $className) {
             $class = new $className();
@@ -230,7 +234,8 @@ class Filters
         $this->processGlobals($uri);
         $this->processMethods();
         $this->processFilters($uri);
-
+        //reversing after filters
+        $this->filters['after'] = array_reverse($this->filters['after']);
         // Set the toolbar filter to the last position to be executed
         if (in_array('toolbar', $this->filters['after'], true)
             && ($count = count($this->filters['after'])) > 1

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -162,7 +162,7 @@ class Filters
     {
         $this->initialize(strtolower($uri));
         // reversing after filters
-        if($position === 'after') {
+        if ($position === 'after') {
             $this->filtersClass[$position] = array_reverse($this->filtersClass[$position]);
         }
 


### PR DESCRIPTION
**Description**
Changed run() method in `System/Filters/Filters.php`

> With current functionality, execution of multi filters are sequential. First it runs all the before method and later afters.
> Consider this scenario, If we are walking through 2 doors, we go through door 1 and then door 2 and If we want to walk back, we come through door 2 first and then door 1 and this completely make sense. Similarly, with multiple filters. The last executed before should execute it's after first. It's easy to handle responses if we follow this flow.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide