### PR TITLE
docs: add sample to helpers.rst

### DIFF
--- a/user_guide_src/source/general/helpers.rst
+++ b/user_guide_src/source/general/helpers.rst
@@ -93,6 +93,10 @@ use the following command to load the helper for us:
 
 .. literalinclude:: helpers/004.php
 
+You can also use the following way:
+
+.. literalinclude:: helpers/007.php
+
 .. note:: The functions within files loaded this way are not truly namespaced.
     The namespace is simply used as a convenient way to locate the files.
 

--- a/user_guide_src/source/general/helpers/007.php
+++ b/user_guide_src/source/general/helpers/007.php
@@ -1,0 +1,3 @@
+<?php
+
+helper('Example\Blog\Helpers\blog');


### PR DESCRIPTION
**Description**
- add sample `helper('Example\Blog\Helpers\blog')`
  - `helper('Example\Blog\blog')`: The notation is not consistent. It feels strange to me.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
