### PR TITLE
docs: fix RST format or so in changelogs/v4.3.5.rst

### DIFF
--- a/user_guide_src/source/changelogs/v4.3.5.rst
+++ b/user_guide_src/source/changelogs/v4.3.5.rst
@@ -21,11 +21,11 @@ SECURITY
 Changes
 *******
 
-- **make:cell** When creating a new cell, the controller would always have the ``Cell`` suffixed to the class name.
-    For the view file, the final ``_cell`` is always removed.
-- **Cells** For compatibility with previous versions, view filenames ending with ``_cell`` can still be
-    located by the ``Cell`` as long as auto-detection of view file is enabled (via setting the ``$view`` property
-    to an empty string).
+- **make:cell command:** When creating a new cell, the controller would always have the ``Cell`` suffixed to the class name.
+  For the view file, the final ``_cell`` is always removed.
+- **View Cells:** For compatibility with previous versions, view filenames ending with ``_cell`` can still be
+  located by the ``Cell`` as long as auto-detection of view file is enabled (via setting the ``$view`` property
+  to an empty string).
 
 Deprecations
 ************
@@ -37,8 +37,8 @@ Bugs Fixed
 **********
 
 - **Validation:** Fixed a bug where a closure used in combination with ``permit_empty`` or ``if_exist`` rules was causing an error.
-- **make:cell** Fixed generating view files as classes.
-- **make:cell** Fixed treatment of single word class input for case-insensitive OS.
+- **make:cell command:** Fixed generating view files as classes.
+- **make:cell command:** Fixed treatment of single word class input for case-insensitive OS.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
Before:
![Screenshot 2023-06-08 21 40 29](https://github.com/codeigniter4/CodeIgniter4/assets/87955/8afa17f3-6c2c-4343-a9a3-c525b094aff6)

After:
![Screenshot 2023-06-08 21 41 05](https://github.com/codeigniter4/CodeIgniter4/assets/87955/320b8163-724f-4875-8f07-e3cd1d9d5485)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
