### PR TITLE
feat: domparser - ability to write more advanced expressions

### DIFF
--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -176,6 +176,24 @@ class DOMParser
     }
 
     /**
+     * Checks to see if the XPath can be found.
+     */
+    public function seeXPath(string $path): bool
+    {
+        $xpath = new DOMXPath($this->dom);
+
+        return (bool) $xpath->query($path)->length;
+    }
+
+    /**
+     * Checks to see if the XPath can't be found.
+     */
+    public function dontSeeXPath(string $path): bool
+    {
+        return ! $this->seeXPath($path);
+    }
+
+    /**
      * Search the DOM using an XPath expression.
      *
      * @return DOMNodeList|false

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -416,4 +416,48 @@ final class DOMParserTest extends CIUnitTestCase
         $this->assertTrue($dom->see(null, '*[ name = user ]'));
         $this->assertFalse($dom->see(null, '*[ name = notthere ]'));
     }
+
+    public function testSeeXPathSuccess(): void
+    {
+        $dom = new DOMParser();
+
+        $html = '<html><body><h1 class="heading gap-2">Hello World Wide Web</h1></body></html>';
+        $dom->withString($html);
+
+        $this->assertTrue($dom->seeXPath('//h1[contains(@class, "heading")]'));
+        $this->assertTrue($dom->seeXPath('//h1[contains(@class, "heading")][contains(.,"Hello World")]'));
+    }
+
+    public function testSeeXPathFail(): void
+    {
+        $dom = new DOMParser();
+
+        $html = '<html><body><h1 class="heading gap-2">Hello World Wide Web</h1></body></html>';
+        $dom->withString($html);
+
+        $this->assertFalse($dom->seeXPath('//h1[contains(@class, "heading123")]'));
+        $this->assertFalse($dom->seeXPath('//h1[contains(@class, "heading")][contains(.,"Hello World 123")]'));
+    }
+
+    public function testDontSeeXPathSuccess(): void
+    {
+        $dom = new DOMParser();
+
+        $html = '<html><body><h1 class="heading gap-2">Hello World Wide Web</h1></body></html>';
+        $dom->withString($html);
+
+        $this->assertTrue($dom->dontSeeXPath('//h1[contains(@class, "heading123")]'));
+        $this->assertTrue($dom->dontSeeXPath('//h1[contains(@class, "heading")][contains(.,"Hello World 123")]'));
+    }
+
+    public function testDontSeeXPathFail(): void
+    {
+        $dom = new DOMParser();
+
+        $html = '<html><body><h1 class="heading gap-2">Hello World Wide Web</h1></body></html>';
+        $dom->withString($html);
+
+        $this->assertFalse($dom->dontSeeXPath('//h1[contains(@class, "heading")]'));
+        $this->assertFalse($dom->dontSeeXPath('//h1[contains(@class, "heading")][contains(.,"Hello World")]'));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -22,6 +22,8 @@ Changes
   command was removed. It did not work from the beginning. Also, the rollback
   command returns the database(s) state to a specified batch number and cannot
   specify only a specific database group.
+- **DomParser:** The new methods were added ``seeXPath()`` and ``dontSeeXPath()``
+  which allows users to work directly with DOMXPath object, using complex expressions.
 
 Deprecations
 ************

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -22,8 +22,6 @@ Changes
   command was removed. It did not work from the beginning. Also, the rollback
   command returns the database(s) state to a specified batch number and cannot
   specify only a specific database group.
-- **DomParser:** The new methods were added ``seeXPath()`` and ``dontSeeXPath()``
-  which allows users to work directly with DOMXPath object, using complex expressions.
 
 Deprecations
 ************

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -50,6 +50,9 @@ Commands
 Testing
 =======
 
+- **DomParser:** The new methods were added ``seeXPath()`` and ``dontSeeXPath()``
+  which allows users to work directly with DOMXPath object, using complex expressions.
+
 Database
 ========
 

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -224,7 +224,7 @@ Finally, you can check if a checkbox exists and is checked with the ``seeCheckbo
    :lines: 2-
 
 seeXPath()
----------
+----------
 
 You can use ``seeXPath()`` to take advantage of the full power that xpath gives you.
 This method is aimed at more advanced users who want to write a more complex expressions

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -227,7 +227,7 @@ seeXPath()
 ---------
 
 You can use ``seeXPath()`` to take advantage of the full power that xpath gives you.
-This method is aimed at more advanced users who want to write a more complex query
+This method is aimed at more advanced users who want to write a more complex expressions
 using the DOMXPath object directly:
 
 .. literalinclude:: response/033.php

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -240,8 +240,6 @@ The ``dontSeeXPath()`` method is the exact opposite:
 .. literalinclude:: response/034.php
    :lines: 2-
 
-.. note:: This method was introduced in v4.5.0.
-
 DOM Assertions
 ==============
 

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -226,6 +226,8 @@ Finally, you can check if a checkbox exists and is checked with the ``seeCheckbo
 seeXPath()
 ----------
 
+.. versionadded:: 4.5.0
+
 You can use ``seeXPath()`` to take advantage of the full power that xpath gives you.
 This method is aimed at more advanced users who want to write a more complex expressions
 using the DOMXPath object directly:

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -238,6 +238,8 @@ The ``dontSeeXPath()`` method is the exact opposite:
 .. literalinclude:: response/034.php
    :lines: 2-
 
+.. note:: This method was introduced in v4.5.0.
+
 DOM Assertions
 ==============
 

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -223,6 +223,21 @@ Finally, you can check if a checkbox exists and is checked with the ``seeCheckbo
 .. literalinclude:: response/023.php
    :lines: 2-
 
+seeXPath()
+---------
+
+You can use ``seeXPath()`` to take advantage of the full power that xpath gives you.
+This method is aimed at more advanced users who want to write a more complex query
+using the DOMXPath object directly:
+
+.. literalinclude:: response/033.php
+   :lines: 2-
+
+The ``dontSeeXPath()`` method is the exact opposite:
+
+.. literalinclude:: response/034.php
+   :lines: 2-
+
 DOM Assertions
 ==============
 

--- a/user_guide_src/source/testing/response/033.php
+++ b/user_guide_src/source/testing/response/033.php
@@ -1,0 +1,11 @@
+<?php
+
+// Check that h1 element which contains class "heading" is on the page
+if ($results->seeXPath('//h1[contains(@class, "heading")]')) {
+    // ...
+}
+
+// Check that h1 element which contains class "heading" have a text "Hello World"
+if ($results->seeXPath('//h1[contains(@class, "heading")][contains(.,"Hello world")]')) {
+    // ...
+}

--- a/user_guide_src/source/testing/response/034.php
+++ b/user_guide_src/source/testing/response/034.php
@@ -1,0 +1,11 @@
+<?php
+
+// Check that h1 element which contains class "heading" does NOT exist on the page
+if ($results->dontSeeXPath('//h1[contains(@class, "heading")]')) {
+    // ...
+}
+
+// Check that h1 element which contains class "heading" and text "Hello World" does NOT exist on the page
+if ($results->dontSeeXPath('//h1[contains(@class, "heading")][contains(.,"Hello world")]')) {
+    // ...
+}


### PR DESCRIPTION
**Description**
The `DomParser` class is great for simple expressions, but if we want to check something more complicated, it unfortunately doesn't give us that option.

Therefore, this PR adds the ability to write an expression that will be executed directly by the `DOMXPath` class.
This way we can handle more advanced scenarios, like searching for nested elements in the DOM.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
