### PR TITLE
docs: calling cells without a full namespace

### DIFF
--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -43,6 +43,8 @@ If you do not include the full namespace for the class, it will assume in can be
 
 .. literalinclude:: view_cells/002.php
 
+Please note that if you don't use the full namespace, we will use Factories to load your class. This means that any subsequent use of the same cell will return a shared instance rather than a new class.
+
 Passing Parameters as Key/Value String
 ======================================
 


### PR DESCRIPTION
**Description**
This PR adds a note about calling cells without a full namespace.

Fixes #8326

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
