### PR TITLE
Always return a new instance of a Cell

### DIFF
--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -181,8 +181,7 @@ class Cell
         }
 
         // locate and return an instance of the cell
-        // @TODO extend Factories to be able to load classes with the same short name.
-        $object = class_exists($class) ? new $class() : Factories::cells($class);
+        $object = Factories::cells($class, ['getShared' => false]);
 
         if (! is_object($object)) {
             throw ViewException::forInvalidCellClass($class);


### PR DESCRIPTION
**Description**
This PR introduces a change in how we load Cells. Right now we can return either a new instance when we use the full namespace or a shared one when we don't use the FQCN.

This may lead to many problems. This change seems to mitigate all the issues. Also returning a new instance class for every Cell call seems right.

Supersedes #8327
Fixes #8326

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
