### PR TITLE
feat: `DataCaster` class

### DIFF
--- a/system/Entity/DataCaster.php
+++ b/system/Entity/DataCaster.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Entity;
+
+use CodeIgniter\Entity\Cast\ArrayCast;
+use CodeIgniter\Entity\Cast\BooleanCast;
+use CodeIgniter\Entity\Cast\CastInterface;
+use CodeIgniter\Entity\Cast\CSVCast;
+use CodeIgniter\Entity\Cast\DatetimeCast;
+use CodeIgniter\Entity\Cast\FloatCast;
+use CodeIgniter\Entity\Cast\IntBoolCast;
+use CodeIgniter\Entity\Cast\IntegerCast;
+use CodeIgniter\Entity\Cast\JsonCast;
+use CodeIgniter\Entity\Cast\ObjectCast;
+use CodeIgniter\Entity\Cast\StringCast;
+use CodeIgniter\Entity\Cast\TimestampCast;
+use CodeIgniter\Entity\Cast\URICast;
+use CodeIgniter\Entity\Exceptions\CastException;
+
+class DataCaster
+{
+    /**
+     * Array of field names and the type of value to cast them as when
+     * they are accessed.
+     *
+     * @var array<string, string>
+     */
+    protected array $casts = [];
+
+    /**
+     * Default convert handlers
+     *
+     * @var array<string, string>
+     */
+    private array $castHandlers = [
+        'array'     => ArrayCast::class,
+        'bool'      => BooleanCast::class,
+        'boolean'   => BooleanCast::class,
+        'csv'       => CSVCast::class,
+        'datetime'  => DatetimeCast::class,
+        'double'    => FloatCast::class,
+        'float'     => FloatCast::class,
+        'int'       => IntegerCast::class,
+        'integer'   => IntegerCast::class,
+        'int-bool'  => IntBoolCast::class,
+        'json'      => JsonCast::class,
+        'object'    => ObjectCast::class,
+        'string'    => StringCast::class,
+        'timestamp' => TimestampCast::class,
+        'uri'       => URICast::class,
+    ];
+
+    public function __construct(array $castHandlers, ?array $casts = null)
+    {
+        $this->castHandlers = array_merge($this->castHandlers, $castHandlers);
+
+        if ($casts !== null) {
+            $this->setCasts($casts);
+        }
+    }
+
+    public function setCasts(array $casts): static
+    {
+        $this->casts = $casts;
+
+        return $this;
+    }
+
+    /**
+     * Provides the ability to cast an item as a specific data type.
+     * Add ? at the beginning of $type  (i.e. ?string) to get NULL
+     * instead of casting $value if $value === null
+     *
+     * @param bool|float|int|string|null $value     Attribute value
+     * @param string                     $attribute Attribute name
+     * @param string                     $method    Allowed to "get" and "set"
+     *
+     * @return array|bool|float|int|object|string|null
+     *
+     * @throws CastException
+     */
+    public function castAs($value, string $attribute, string $method = 'get')
+    {
+        if (! isset($this->casts[$attribute])) {
+            return $value;
+        }
+
+        $type = $this->casts[$attribute];
+
+        $isNullable = false;
+
+        if (str_starts_with($type, '?')) {
+            $isNullable = true;
+
+            if ($value === null) {
+                return null;
+            }
+
+            $type = substr($type, 1);
+        }
+
+        // In order not to create a separate handler for the
+        // json-array type, we transform the required one.
+        $type = $type === 'json-array' ? 'json[array]' : $type;
+
+        if (! in_array($method, ['get', 'set'], true)) {
+            throw CastException::forInvalidMethod($method);
+        }
+
+        $params = [];
+
+        // Attempt to retrieve additional parameters if specified
+        // type[param, param2,param3]
+        if (preg_match('/^(.+)\[(.+)\]$/', $type, $matches)) {
+            $type   = $matches[1];
+            $params = array_map('trim', explode(',', $matches[2]));
+        }
+
+        if ($isNullable) {
+            $params[] = 'nullable';
+        }
+
+        $type = trim($type, '[]');
+
+        $handlers = $this->castHandlers;
+
+        if (! isset($handlers[$type])) {
+            return $value;
+        }
+
+        if (! is_subclass_of($handlers[$type], CastInterface::class)) {
+            throw CastException::forInvalidInterface($handlers[$type]);
+        }
+
+        return $handlers[$type]::$method($value, $params);
+    }
+}


### PR DESCRIPTION
**Description**
This is my general idea about casting. In this PR I basically extracted the casting functionality we have in the `Entity` and added it to a separate class which will serve as a starting point.

Here, we can add all the features @kenjis implemented in his `DataConverter` class, this way we will have:

* One class that would handle the process of casting the data
* One group of handlers responsible for casting

I guess the namespace for all these classes responsible for casting is not ideal, but that's not a deal breaker for me.

Not sure if you guys will like it or not, but having two classes that are doing the same job (and separate groups of casting classes for each class) is really the only thing I don't like in [Kenjis idea](https://github.com/codeigniter4/CodeIgniter4/pull/8230).

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
