### PR TITLE
chore: add PHP 8.3 to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,7 @@ body:
         - '8.0'
         - '8.1'
         - '8.2'
+        - '8.3'
     validations:
       required: true
 


### PR DESCRIPTION
**Description**
This PR adds PHP 8.3 to the bug report template.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
