### PR TITLE
docs: fix return type in BaseResult

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -261,7 +261,7 @@ abstract class BaseResult implements ResultInterface
      * @phpstan-param class-string<T>|'array'|'object' $type
      *
      * @return         array|float|int|object|stdClass|string|null
-     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null))
+     * @phpstan-return ($n is string ? float|int|string|null : ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null)))
      */
     public function getRow($n = 0, string $type = 'object')
     {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -260,7 +260,7 @@ abstract class BaseResult implements ResultInterface
      * @param         string                           $type The type of result object. 'array', 'object' or class name.
      * @phpstan-param class-string<T>|'array'|'object' $type
      *
-     * @return         array|object|stdClass|null|string
+     * @return         array|float|int|object|stdClass|string|null
      * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null))
      */
     public function getRow($n = 0, string $type = 'object')

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -260,7 +260,7 @@ abstract class BaseResult implements ResultInterface
      * @param         string                           $type The type of result object. 'array', 'object' or class name.
      * @phpstan-param class-string<T>|'array'|'object' $type
      *
-     * @return         array|object|stdClass|null
+     * @return         array|object|stdClass|null|string
      * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null))
      */
     public function getRow($n = 0, string $type = 'object')

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -63,8 +63,8 @@ interface ResultInterface
      * @param         string                           $type The type of result object. 'array', 'object' or class name.
      * @phpstan-param class-string<T>|'array'|'object' $type
      *
-     * @return         array|object|stdClass|null
-     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null))
+     * @return         array|float|int|object|stdClass|string|null
+     * @phpstan-return ($n is string ? float|int|string|null : ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null)))
      */
     public function getRow($n = 0, string $type = 'object');
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
when I use the getRow function in the query builder 
`$this->db->table("table_name")->getWhere(["id" => $id])->getRow("name")`, it works fine, but there is a notif or warning "Expected type 'string'...."

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
