### PR TITLE
feat: add option to change default behaviour of `JSONFormatter` max depth

### DIFF
--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -64,10 +64,10 @@ class Format extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
-     * JSON Formatters Depth
+     * Maximum depth for JSON encoding.
      * --------------------------------------------------------------------------
      *
-     * Additional options to adjust default depth JSON Encode.
+     * This value determines how deep the JSON encoder will traverse nested structures.
      */
-    public int $jsonDepthOptions = 512;
+    public int $jsonEncodeDepth = 512;
 }

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -41,7 +41,7 @@ class JSONFormatter implements FormatterInterface
             $options |= JSON_PRETTY_PRINT;
         }
 
-        $result = json_encode($data, $options, $config->jsonDepthOptions ?? 512);
+        $result = json_encode($data, $options, $config->jsonEncodeDepth ?? 512);
 
         if (! in_array(json_last_error(), [JSON_ERROR_NONE, JSON_ERROR_RECURSION], true)) {
             throw FormatException::forInvalidJSON(json_last_error_msg());

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -85,7 +85,7 @@ Changes
 *******
 
 - **Cookie:** The ``CookieInterface::EXPIRES_FORMAT`` has been changed to ``D, d M Y H:i:s \G\M\T`` to follow the recommended format in RFC 7231.
-- **Format:** The ``Format::$jsonDepthOptions`` options to change default behavior JSON Encode.
+- **Format:** Added support for configuring ``json_encode()`` maximum depth via ``Config\Format::$jsonEncodeDepth``.
 
 ************
 Deprecations

--- a/user_guide_src/source/outgoing/api_responses.rst
+++ b/user_guide_src/source/outgoing/api_responses.rst
@@ -49,7 +49,7 @@ format both XML and JSON responses:
 
 .. literalinclude:: api_responses/003.php
 
-.. note:: Since ``v4.7.0``, you can change the default JSON formatting depth by editing **app/Config/Format.php**. The ``$jsonDepthOptions`` value defines the maximum depth, with a default of ``512``.
+.. note:: Since ``v4.7.0``, you can change the default JSON encoding depth by editing **app/Config/Format.php** file. The ``$jsonEncodeDepth`` value defines the maximum depth, with a default of ``512``.
 
 This is the array that is used during :doc:`Content Negotiation </incoming/content_negotiation>` to determine which
 type of response to return. If no matches are found between what the client requested and what you support, the first


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Added option change behaviour depth JSON Formatter

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
