### PR TITLE
fix: correct `getHostname()` fallback logic in `Email` class

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -2142,12 +2142,16 @@ class Email
      */
     protected function getHostname()
     {
-        if (isset($_SERVER['SERVER_NAME'])) {
-            return $_SERVER['SERVER_NAME'];
+        $superglobals = service('superglobals');
+
+        $serverName = $superglobals->server('SERVER_NAME');
+        if (! in_array($serverName, [null, ''], true)) {
+            return $serverName;
         }
 
-        if (isset($_SERVER['SERVER_ADDR'])) {
-            return '[' . $_SERVER['SERVER_ADDR'] . ']';
+        $serverAddr = $superglobals->server('SERVER_ADDR');
+        if (! in_array($serverAddr, [null, ''], true)) {
+            return '[' . $serverAddr . ']';
         }
 
         $hostname = gethostname();

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -37,6 +37,7 @@ Bugs Fixed
 
 - **Cache:** Fixed a bug where a corrupted or unreadable cache file could cause an unhandled exception in ``FileHandler::getItem()``.
 - **Database:** Fixed a bug where ``when()`` and ``whenNot()`` in ``ConditionalTrait`` incorrectly evaluated certain falsy values (such as ``[]``, ``0``, ``0.0``, and ``'0'``) as truthy, causing callbacks to be executed unexpectedly. These methods now cast the condition to a boolean using ``(bool)`` to ensure consistent behavior with PHP's native truthiness.
+- **Email:** Fixed a bug where ``Email::getHostname()`` failed to use ``$_SERVER['SERVER_ADDR']`` when ``$_SERVER['SERVER_NAME']`` was not set.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
 

--- a/utils/phpstan-baseline/codeigniter.superglobalAccess.neon
+++ b/utils/phpstan-baseline/codeigniter.superglobalAccess.neon
@@ -1,4 +1,4 @@
-# total 83 errors
+# total 79 errors
 
 parameters:
     ignoreErrors:
@@ -66,16 +66,6 @@ parameters:
             message: '#^Accessing offset ''SERVER_PROTOCOL'' directly on \$_SERVER is discouraged\.$#'
             count: 1
             path: ../../system/Config/Services.php
-
-        -
-            message: '#^Accessing offset ''SERVER_ADDR'' directly on \$_SERVER is discouraged\.$#'
-            count: 2
-            path: ../../system/Email/Email.php
-
-        -
-            message: '#^Accessing offset ''SERVER_NAME'' directly on \$_SERVER is discouraged\.$#'
-            count: 2
-            path: ../../system/Email/Email.php
 
         -
             message: '#^Accessing offset ''HTTP_USER_AGENT'' directly on \$_SERVER is discouraged\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 3149 errors
+# total 3145 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon


### PR DESCRIPTION
**Description**
This PR fixes the `getHostname()` method in the `Email` class to ensure it correctly falls back to the server address or system hostname in order of availability. In some environments, such as Google App Engine, `$_SERVER['SERVER_NAME']` may be set but empty.

Problem reported here: https://github.com/codeigniter4/CodeIgniter4/issues/9448#issuecomment-2918167813

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
