### PR TITLE
refactor: Deprecated method of returning `void' in Сommands

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -102,6 +102,8 @@ abstract class BaseCommand
      * @param array<int|string, string|null> $params
      *
      * @return int|void
+     *
+     * @deprecated 4.6.1 Using `void` as a return value is deprecated. Use `int` to return the exit code.
      */
     abstract public function run(array $params);
 
@@ -113,6 +115,8 @@ abstract class BaseCommand
      * @return int|void
      *
      * @throws ReflectionException
+     *
+     * @deprecated 4.6.1 Using `void` as a return value is deprecated. Use `int` to return the exit code.
      */
     protected function call(string $command, array $params = [])
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -31,6 +31,8 @@ class Console
      * @return int|void Exit code
      *
      * @throws Exception
+     *
+     * @deprecated 4.6.1 Using `void` as a return value is deprecated. Use `int` to return the exit code.
      */
     public function run()
     {


### PR DESCRIPTION
**Description**
I see that the commands must follow the style in which the numeric status code is returned. Now many commands have an deprecated solution - `int|void`. I suggest gradually rewriting the commands and tests for them.

I want to ask which type is preferable to return?
https://github.com/codeigniter4/CodeIgniter4/blob/af6835887823c3045657df78b065ed8ac80e3e99/system/Commands/Database/MigrateRefresh.php#L70

```php
define('EXIT_SUCCESS', 0);        // no errors
define('EXIT_ERROR', 1);          // generic error
define('EXIT_USER_INPUT', 7);     // invalid user input
define('EXIT_DATABASE', 8);       // database error
```

This always applies to `EXIT_ERROR`, `EXIT_DATABASE` or  `EXIT_USER_INPUT`? Because the parameters are set by the user.
In all other cases, return `EXIT_SUCCESS`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
