### PR TITLE
docs: add detailed explanation about `paginate()` and `beforeFind` model event

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -1032,6 +1032,15 @@ afterUpdateBatch  **data** = the key/value pairs being updated.
                   **result** = the results of the ``updateBatch()`` method used through the Query Builder.
 ================= =========================================================================================================
 
+.. note:: When using the ``paginate()`` method in combination with the ``beforeFind`` event to modify the query,
+   the results may not behave as expected.
+
+   This is because the ``beforeFind`` event only affects the actual retrieval of the results (``findAll()``),
+   but **not** the query used to count the total number of rows for pagination.
+
+   As a result, the total row count used for generating pagination links may not reflect the modified query conditions,
+   leading to inconsistencies in pagination.
+
 Modifying Find* Data
 ====================
 


### PR DESCRIPTION
**Description**
This PR adds a note explaining the potential inconsistency when using the `Model::paginate()` method in combination with the `beforeFind` event. It aims to help prevent confusion when `paginate()` is used alongside query-modifying events.

Resolving this issue is non-trivial, as it would require a careful redesign of the pagination logic or parts of the model to ensure consistent behavior across both data retrieval and counting queries.

Due to this complexity, we are not applying a framework-level fix at this time. Instead, this note provides clear guidance so that developers are aware of the behavior and can plan accordingly.

This note will remain in place to support users until a long-term solution is identified and adopted.

Closes #9617

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
