### PR TITLE
docs: fix outdated documentation on how to exclude multiple test groups

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -105,7 +105,7 @@ Individual tests can be run by including the relative path to the test file.
 You can run the tests without running the live database and the live cache tests.
 
 ```console
-./phpunit --exclude-group DatabaseLive,CacheLive
+./phpunit --exclude-group DatabaseLive --exclude-group CacheLive
 ```
 
 ## Generating Code Coverage


### PR DESCRIPTION
**Description**  
This PR updates the documentation on running PHPUnit tests in the CodeIgniter 4 framework.

The currently documented syntax is **deprecated** and will be **removed in PHPUnit version 12**.
PHPUnit has updated the way test groups are excluded via the CLI, requiring different arguments than before. While I couldn’t pinpoint exactly when the new syntax was introduced, I found [this discussion](https://user.phpunit.narkive.com/IOYos52p/how-to-use-exclude-group-with-multiple-groups) from 15 years ago that demonstrates its use.

I’ve reported the issue here: https://github.com/codeigniter4/CodeIgniter4/issues/9619

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
