### PR TITLE
refactor: do not use future-deprecated `DATE_RFC7231` constant

### DIFF
--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -57,7 +57,7 @@ interface CookieInterface
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
      * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
      */
-    public const EXPIRES_FORMAT = DATE_RFC7231;
+    public const EXPIRES_FORMAT = 'D, d M Y H:i:s T';
 
     /**
      * Returns a unique identifier for the cookie consisting

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -99,7 +99,7 @@ Message Changes
 Changes
 *******
 
-- **Cookie:** The ``CookieInterface::EXPIRES_FORMAT`` has been changed to ``D, d M Y H:i:s \G\M\T`` to follow the recommended format in RFC 7231.
+- **Cookie:** The ``CookieInterface::EXPIRES_FORMAT`` has been changed to ``D, d M Y H:i:s T`` to follow the recommended format in RFC 7231.
 - **Format:** Added support for configuring ``json_encode()`` maximum depth via ``Config\Format::$jsonEncodeDepth``.
 - **Paths:** Added support for changing the location of the ``.env`` file via the ``Paths::$envDirectory`` property.
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
It will be deprecated in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_date_rfc7231_and_datetimeinterfacerfc7231

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
