### PR TITLE
chore: added new rules RemoveReflectionSetAccessibleCallsRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -35,6 +35,7 @@ use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\RemoveDataProviderParamKeysRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -173,6 +174,7 @@ return RectorConfig::configure()
     // auto import fully qualified class names
     ->withImportNames(removeUnusedImports: true)
     ->withRules([
+        RemoveReflectionSetAccessibleCallsRector::class,
         DeclareStrictTypesRector::class,
         UnderscoreToCamelCaseVariableNameRector::class,
         SimplifyUselessVariableRector::class,


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
> As of PHP 8.1.0, calling Reflection*::setAccessible() [has no effect](https://www.php.net/manual/en/reflectionproperty.setaccessible.php); all properties are accessible by default. Currently, there is a [RFC](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible) which proposes to issue a deprecation warning starting with Php 8.5.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
