### PR TITLE
refactor: fix phpstan issues on magic properties

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -142,7 +142,7 @@ abstract class BaseCommand
     {
         CLI::write(lang('CLI.helpUsage'), 'yellow');
 
-        if (isset($this->usage)) {
+        if ($this->usage !== null) {
             $usage = $this->usage;
         } else {
             $usage = $this->name;
@@ -154,7 +154,7 @@ abstract class BaseCommand
 
         CLI::write($this->setPad($usage, 0, 0, 2));
 
-        if (isset($this->description)) {
+        if ($this->description !== null) {
             CLI::newLine();
             CLI::write(lang('CLI.helpDescription'), 'yellow');
             CLI::write($this->setPad($this->description, 0, 0, 2));

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -129,7 +129,7 @@ class Commands
 
                 $class = new $className($this->logger, $this);
 
-                if (isset($class->group) && ! isset($this->commands[$class->name])) {
+                if ($class->group !== null && ! isset($this->commands[$class->name])) {
                     $this->commands[$class->name] = [
                         'class'       => $className,
                         'file'        => $file,

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -123,7 +123,7 @@ class Connection extends BaseConnection
             $this->mysqli->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, 1);
         }
 
-        if (isset($this->strictOn)) {
+        if ($this->strictOn !== null) {
             if ($this->strictOn) {
                 $this->mysqli->options(
                     MYSQLI_INIT_COMMAND,

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -107,7 +107,7 @@ class Connection extends BaseConnection
                 $this->database = WRITEPATH . $this->database;
             }
 
-            $sqlite = (! isset($this->password) || $this->password !== '')
+            $sqlite = ($this->password === null || $this->password !== '')
                 ? new SQLite3($this->database)
                 : new SQLite3($this->database, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $this->password);
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -404,7 +404,7 @@ trait FeatureTestTrait
             );
         }
 
-        $_SESSION = $this->session ?? [];
+        $_SESSION = $this->session;
 
         return $request;
     }

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -36,14 +36,14 @@ final class BaseCommandTest extends CIUnitTestCase
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertTrue(isset($command->group));
+        $this->assertSame($command->group !== null, isset($command->group)); // @phpstan-ignore isset.property
     }
 
     public function testMagicIssetFalse(): void
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertFalse(isset($command->foobar));
+        $this->assertFalse(isset($command->foobar)); // @phpstan-ignore property.notFound
     }
 
     public function testMagicGet(): void
@@ -57,6 +57,6 @@ final class BaseCommandTest extends CIUnitTestCase
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertNull($command->foobar);
+        $this->assertNull($command->foobar); // @phpstan-ignore property.notFound
     }
 }

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -169,14 +169,14 @@ final class BaseConnectionTest extends CIUnitTestCase
     {
         $db = new MockConnection($this->options);
 
-        $this->assertTrue(isset($db->charset));
+        $this->assertSame($db->charset !== null, isset($db->charset)); // @phpstan-ignore isset.property
     }
 
     public function testMagicIssetFalse(): void
     {
         $db = new MockConnection($this->options);
 
-        $this->assertFalse(isset($db->foobar));
+        $this->assertFalse(isset($db->foobar)); // @phpstan-ignore property.notFound
     }
 
     public function testMagicGet(): void
@@ -190,7 +190,7 @@ final class BaseConnectionTest extends CIUnitTestCase
     {
         $db = new MockConnection($this->options);
 
-        $this->assertNull($db->foobar);
+        $this->assertNull($db->foobar); // @phpstan-ignore property.notFound
     }
 
     /**

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -245,7 +245,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $this->assertSame(8, $diff->getDays());
         $this->assertSame(8, $diff->days);
         $this->assertSame(-8, (int) round($diff->getDays(true)));
-        $this->assertNull($diff->nonsense);
+        $this->assertNull($diff->nonsense); // @phpstan-ignore property.notFound
     }
 
     public function testGetterDST(): void
@@ -259,7 +259,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
 
         // The raw value does not take Daylight Saving Time into account.
         $this->assertSame(-8, (int) round($diff->getDays(true)));
-        $this->assertNull($diff->nonsense);
+        $this->assertNull($diff->nonsense); // @phpstan-ignore property.notFound
     }
 
     public function testMagicIssetTrue(): void
@@ -267,8 +267,8 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 18, 2017', 'America/Chicago');
 
-        $this->assertTrue(isset($diff->days));
-        $this->assertFalse(isset($diff->nonsense));
+        $this->assertTrue(isset($diff->days)); // @phpstan-ignore isset.property
+        $this->assertFalse(isset($diff->nonsense)); // @phpstan-ignore property.notFound
     }
 
     public function testMagicIssetFalse(): void
@@ -276,6 +276,6 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 18, 2017', 'America/Chicago');
 
-        $this->assertFalse(isset($diff->nonsense));
+        $this->assertFalse(isset($diff->nonsense)); // @phpstan-ignore property.notFound
     }
 }

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,5 @@
-# total 2808 errors
+# total 2800 errors
+
 includes:
     - argument.type.neon
     - assign.propertyType.neon

--- a/utils/phpstan-baseline/property.notFound.neon
+++ b/utils/phpstan-baseline/property.notFound.neon
@@ -1,4 +1,4 @@
-# total 59 errors
+# total 51 errors
 
 parameters:
     ignoreErrors:
@@ -26,16 +26,6 @@ parameters:
             message: '#^Access to an undefined property Config\\Session\:\:\$lockWait\.$#'
             count: 1
             path: ../../system/Session/Handlers/RedisHandler.php
-
-        -
-            message: '#^Access to an undefined property Tests\\Support\\Commands\\AppInfo\:\:\$foobar\.$#'
-            count: 2
-            path: ../../tests/system/Commands/BaseCommandTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Test\\Mock\\MockConnection\:\:\$foobar\.$#'
-            count: 2
-            path: ../../tests/system/Database/BaseConnectionTest.php
 
         -
             message: '#^Access to an undefined property CodeIgniter\\Database\\BaseConnection\:\:\$mysqli\.$#'
@@ -101,11 +91,6 @@ parameters:
             message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$key\.$#'
             count: 1
             path: ../../tests/system/Encryption/Handlers/SodiumHandlerTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\I18n\\TimeDifference\:\:\$nonsense\.$#'
-            count: 4
-            path: ../../tests/system/I18n/TimeDifferenceTest.php
 
         -
             message: '#^Access to an undefined property CodeIgniter\\I18n\\TimeLegacy\:\:\$foobar\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
Fixing some phpstan issues related to access of protected properties via magic `__get()` and `__isset()`.
- PHPStan does not want to use `isset()` so I just compared them to `null` instead.
- For tests, I just ignored them as the tests are testing those magic methods.
- For FeatureTestTrait, I checked CIUnitTestCase declares the `$session` property with default empty array so I think the change is fine.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
