### PR TITLE
refactor: add array<> param docblock on tests/ based on array dim fetch

### DIFF
--- a/tests/_support/Entity/CustomUser.php
+++ b/tests/_support/Entity/CustomUser.php
@@ -38,6 +38,9 @@ final class CustomUser
     ) {
     }
 
+    /**
+     * @param array<string, int|list<string>|string|Time|null> $data
+     */
     public static function reconstruct(array $data): static
     {
         return new self(

--- a/tests/_support/Log/Handlers/TestHandler.php
+++ b/tests/_support/Log/Handlers/TestHandler.php
@@ -35,6 +35,8 @@ class TestHandler extends FileHandler
 
     /**
      * Where would the log be written?
+     *
+     * @param array<string, mixed> $config
      */
     public function __construct(array $config)
     {

--- a/tests/_support/Models/EventModel.php
+++ b/tests/_support/Models/EventModel.php
@@ -129,6 +129,9 @@ class EventModel extends Model
         return $data;
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     protected function beforeFindMethod(array $data)
     {
         $this->tokens[]  = 'beforeFind';

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -114,6 +114,9 @@ final class UpdateTest extends CIUnitTestCase
         }
     }
 
+    /**
+     * @param array<int, mixed> $expected
+     */
     #[DataProvider('provideUpdateBatch')]
     public function testUpdateBatch(string $constraints, array $data, array $expected): void
     {

--- a/tests/system/HTTP/CURLRequestShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestShareOptionsTest.php
@@ -28,6 +28,9 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class CURLRequestShareOptionsTest extends CURLRequestTest
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     protected function getRequest(array $options = []): MockCURLRequest
     {
         $uri = isset($options['baseURI']) ? new URI($options['baseURI']) : new URI();

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -1226,6 +1226,9 @@ class CreditCardRulesTest extends CIUnitTestCase
         return implode('', $digits);
     }
 
+    /**
+     * @param array<int, int|string> $digits
+     */
     protected static function calculateLuhnChecksum(array $digits, int $length): int
     {
         $parity = $length % 2;

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2790 errors
+# total 2788 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1378 errors
+# total 1376 errors
 
 parameters:
     ignoreErrors:
@@ -5613,11 +5613,6 @@ parameters:
             path: ../../tests/system/Database/Live/UpdateTest.php
 
         -
-            message: '#^Method CodeIgniter\\Database\\Live\\UpdateTest\:\:testUpdateBatch\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Database/Live/UpdateTest.php
-
-        -
             message: '#^Method CodeIgniter\\Debug\\ExceptionHandlerTest\:\:backupIniValues\(\) has parameter \$keys with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/Debug/ExceptionHandlerTest.php
@@ -6646,11 +6641,6 @@ parameters:
             message: '#^Method CodeIgniter\\Validation\\RulesTest\:\:testRequiredWithoutMultipleWithoutFields\(\) has parameter \$data with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/Validation/RulesTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\CreditCardRulesTest\:\:calculateLuhnChecksum\(\) has parameter \$digits with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Validation/StrictRules/CreditCardRulesTest.php
 
         -
             message: '#^Method CodeIgniter\\Validation\\StrictRules\\CreditCardRulesTest\:\:provideValidCCNumber\(\) return type has no value type specified in iterable type iterable\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**

Add `@param array<>` docblock based on its array dim fetch. This use `mixed` item type if it can pass mixed data.


**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
