### PR TITLE
feat(view): add default value support for renderSection()

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -446,10 +446,10 @@ class View implements RendererInterface
      * @param bool $saveData If true, saves data for subsequent calls,
      *                       if false, cleans the data after displaying.
      */
-    public function renderSection(string $sectionName, bool $saveData = false): string
+    public function renderSection(string $sectionName, bool $saveData = false, string $defaultContent= ""): string
     {
         if (! isset($this->sections[$sectionName])) {
-            return '';
+            return $defaultContent;
         }
 
         $output = '';


### PR DESCRIPTION
This commit extends the View::renderSection() method to allow an optional  default value parameter when a section is not found or is empty.

- Added a new `$defaultContent` argument to renderSection()
- If the requested section is missing or empty, the method will return the provided default value instead of an empty string
- Preserves existing behavior when `$defaultContent` is not set

This improvement makes it easier to provide fallback content in layouts without requiring additional wrapper logic in user applications.

Example usage:
    <?= $this->renderSection('example', false, '<p>Default form content</p>') ?>

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
