### PR TITLE
fix: Fixed `Entity::injectRawData()`

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -308,7 +308,7 @@ class Entity implements JsonSerializable
      */
     public function injectRawData(array $data)
     {
-        $this->attributes = $data;
+        $this->attributes = array_merge($this->attributes, $data);
 
         $this->syncOriginal();
 

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -1296,6 +1296,52 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame(json_encode($entity->toArray()), json_encode($entity));
     }
 
+    public function testInjectRawArray(): void
+    {
+        $entity = new class () extends Entity {
+            // The "user" property is not for DB
+            protected $attributes = [
+                'type'    => 'Normal',
+                'limit'   => 10,
+                'user'    => 'John',
+                '_secure' => 'High',
+            ];
+            protected $original = [
+                'type'    => 'None',
+                'limit'   => 0,
+                'user'    => null,
+                '_secure' => 'Low',
+            ];
+        };
+
+        $entity->injectRawData([
+            'type'    => 'High',
+            'limit'   => 15,
+            '_secure' => 'Normal',
+            'extra'   => 'undefined',
+        ]);
+
+        $this->assertSame(
+            [
+                'type'    => 'High',
+                'limit'   => 15,
+                'user'    => 'John',
+                '_secure' => 'Normal',
+                'extra'   => 'undefined',
+            ],
+            $entity->toRawArray(),
+        );
+        $this->assertSame(
+            [
+                'type'  => 'High',
+                'limit' => 15,
+                'user'  => 'John',
+                'extra' => 'undefined',
+            ],
+            $entity->toArray(),
+        );
+    }
+
     private function getEntity(): object
     {
         return new class () extends Entity {

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -165,6 +165,7 @@ Bugs Fixed
 
 - **Cookie:** The ``CookieInterface::SAMESITE_STRICT``, ``CookieInterface::SAMESITE_LAX``, and ``CookieInterface::SAMESITE_NONE`` constants are now written in ucfirst style to be consistent with usage in the rest of the framework.
 - **Cache:** Changed ``WincacheHandler::increment()`` and ``WincacheHandler::decrement()`` to return ``bool`` instead of ``mixed``.
+- **Entity:** Fixed a bug in ``Entity::injectRawArray()`` where the default values of ``$attributes`` values disappear. In the case when, after the DB query, the result did not contain all the values for the properties.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
After a DB query, the entity may break if the result does not contain all the "fields == properties".
Example, do we need a "virtual" `$entity->user` property, which stores by default `?User`. It may not be necessary to insert it into the database, but it's important in other work.

There are other questions:
1. ~~Why doesn't the documentation describe the case of underlining properties? They are skipped when calling `Entity::toArray()` but allowed in `Entity::toRawArray()`~~
2. The behavior of superfluous properties is not described. How they will be shown for the entity and when working with the DB.

I would add this to the current PR. Answering questions may require correction if we find abnormal behavior.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
