### PR TITLE
feat(entity): deep change tracking for objects and arrays

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -385,6 +385,15 @@ class Entity implements JsonSerializable
                 ];
             } else {
                 $objectData = get_object_vars($data);
+
+                // Fallback for value objects with __toString()
+                // when properties are not accessible
+                if ($objectData === [] && method_exists($data, '__toString')) {
+                    return [
+                        '__class'  => $data::class,
+                        '__string' => (string) $data,
+                    ];
+                }
             }
 
             return [

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -54,6 +54,8 @@ for objects and arrays instead of shallow comparison. This means:
   including timezone information.
 - **Collections** (``Traversable``) such as ``ArrayObject`` and ``ArrayIterator`` are converted
   to arrays for comparison.
+- **Value objects** with ``__toString()`` method are compared by their string representation when
+  properties are not accessible (fallback for objects with private properties).
 - **Nested entities** (using ``toRawArray()``), ``JsonSerializable`` objects, and objects with
   ``toArray()`` methods are recursively normalized for accurate change detection.
 - **Scalar values** (strings, integers, floats, booleans, null) continue to use direct comparison

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -397,5 +397,5 @@ Objects and Arrays
 
 For objects and arrays, the Entity JSON-encodes and normalizes the values for comparison. This means that modifications
 to nested structures, object properties, array elements, nested entities (using ``toRawArray()``), enums (``BackedEnum``
-and ``UnitEnum``), datetime objects (``DateTimeInterface``), collections (``Traversable``), and objects implementing
-``JsonSerializable`` or ``toArray()`` will be properly detected.
+and ``UnitEnum``), datetime objects (``DateTimeInterface``), collections (``Traversable``), value objects with
+``__toString()``, and objects implementing ``JsonSerializable`` or ``toArray()`` will be properly detected.


### PR DESCRIPTION
**Description**
This PR implements deep comparison for objects and arrays in `Entity::hasChanged()` and `Entity::syncOriginal()`.

Previously, only shallow reference comparison was performed, meaning changes to object properties, array elements, or nested structures were not detected. This PR adds proper deep comparison using JSON normalization.

This may be considered a BC break, as existing applications that use objects within entities may now behave differently. For entities using only scalar types, there is no change in behavior.

Fixes #9777

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
