### PR TITLE
fix: type error in controlled cell

### DIFF
--- a/system/View/Cells/Cell.php
+++ b/system/View/Cells/Cell.php
@@ -85,7 +85,7 @@ class Cell implements Stringable
             $viewName  = decamelize(class_basename(static::class));
             $directory = dirname((new ReflectionClass($this))->getFileName()) . DIRECTORY_SEPARATOR;
 
-            $possibleView1 = $directory . substr($viewName, 0, strrpos($viewName, '_cell')) . '.php';
+            $possibleView1 = $directory . substr($viewName, 0, (int) strrpos($viewName, '_cell')) . '.php';
             $possibleView2 = $directory . $viewName . '.php';
         }
 


### PR DESCRIPTION
**Description**
This PR resolves a type error that occurred in the Controlled Cell while loading the view file.

Fixes #9781

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
