### PR TITLE
Refactor: Extract IP address detection logic to dedicated IPAddress

### DIFF
--- a/system/HTTP/IPAddressDetector.php
+++ b/system/HTTP/IPAddressDetector.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Exceptions\ConfigException;
+use CodeIgniter\Validation\FormatRules;
+
+/**
+ * IP Address Detector
+ *
+ * Handles detection of client IP addresses, including support for
+ * proxy servers and subnet matching for trusted proxies.
+ */
+class IPAddressDetector
+{
+    /**
+     * IP validator callable.
+     *
+     * @var callable
+     */
+    private $ipValidator;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->ipValidator = [
+            new FormatRules(),
+            'valid_ip',
+        ];
+    }
+
+    /**
+     * Detects the client's IP address.
+     *
+     * @param string                $remoteAddr The REMOTE_ADDR value from the server
+     * @param array<string, string> $proxyIPs   Array of proxy IP addresses with their corresponding headers
+     * @param callable              $headerGetter Callback to get header values by name
+     *
+     * @return string The detected IP address, or '0.0.0.0' if invalid
+     *
+     * @throws ConfigException
+     */
+    public function detect(string $remoteAddr, array $proxyIPs, callable $headerGetter): string
+    {
+        // Validate proxy IPs configuration
+        if (! empty($proxyIPs) && (! is_array($proxyIPs) || is_int(array_key_first($proxyIPs)))) {
+            throw new ConfigException(
+                'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.',
+            );
+        }
+
+        $ipAddress = $remoteAddr;
+
+        // Check if the request is coming from a trusted proxy
+        foreach ($proxyIPs as $proxyIP => $header) {
+            if ($this->isFromTrustedProxy($ipAddress, $proxyIP)) {
+                $clientIP = $this->extractClientIP($header, $headerGetter);
+
+                if ($clientIP !== null) {
+                    $ipAddress = $clientIP;
+                    break;
+                }
+            }
+        }
+
+        // Validate the final IP address
+        if (! ($this->ipValidator)($ipAddress)) {
+            return '0.0.0.0';
+        }
+
+        return $ipAddress;
+    }
+
+    /**
+     * Checks if the current IP address is from a trusted proxy.
+     *
+     * @param string $ipAddress The IP address to check
+     * @param string $proxyIP   The trusted proxy IP or subnet (e.g., '192.168.1.1' or '192.168.1.0/24')
+     */
+    private function isFromTrustedProxy(string $ipAddress, string $proxyIP): bool
+    {
+        // Check if we have an IP address or a subnet
+        if (! str_contains($proxyIP, '/')) {
+            // An IP address (and not a subnet) is specified.
+            // We can compare right away.
+            return $proxyIP === $ipAddress;
+        }
+
+        // We have a subnet ... now the heavy lifting begins
+        return $this->isIPInSubnet($ipAddress, $proxyIP);
+    }
+
+    /**
+     * Checks if an IP address is within a given subnet.
+     *
+     * @param string $ipAddress The IP address to check
+     * @param string $subnet    The subnet in CIDR notation (e.g., '192.168.1.0/24')
+     */
+    private function isIPInSubnet(string $ipAddress, string $subnet): bool
+    {
+        // Determine if we're dealing with IPv4 or IPv6
+        $separator = ($this->ipValidator)($ipAddress, 'ipv6') ? ':' : '.';
+
+        // If the proxy entry doesn't match the IP protocol - skip it
+        if (! str_contains($subnet, $separator)) {
+            return false;
+        }
+
+        // Convert the IP address to binary
+        $ipBinary = $this->convertIPToBinary($ipAddress, $separator);
+
+        // Split the netmask length off the network address
+        sscanf($subnet, '%[^/]/%d', $netaddr, $masklen);
+
+        // Convert the network address to binary
+        $netaddrBinary = $this->convertIPToBinary($netaddr, $separator);
+
+        // Compare the binary representations
+        return strncmp($ipBinary, $netaddrBinary, $masklen) === 0;
+    }
+
+    /**
+     * Converts an IP address to its binary representation.
+     *
+     * @param string $ipAddress The IP address to convert
+     * @param string $separator The separator character (':' for IPv6, '.' for IPv4)
+     */
+    private function convertIPToBinary(string $ipAddress, string $separator): string
+    {
+        if ($separator === ':') {
+            // IPv6 address
+            // Make sure we're having the "full" IPv6 format
+            $ip = explode(':', str_replace('::', str_repeat(':', 9 - substr_count($ipAddress, ':')), $ipAddress));
+
+            for ($j = 0; $j < 8; $j++) {
+                $ip[$j] = intval($ip[$j], 16);
+            }
+
+            $sprintf = '%016b%016b%016b%016b%016b%016b%016b%016b';
+        } else {
+            // IPv4 address
+            $ip      = explode('.', $ipAddress);
+            $sprintf = '%08b%08b%08b%08b';
+        }
+
+        return vsprintf($sprintf, $ip);
+    }
+
+    /**
+     * Extracts the client IP address from an HTTP header.
+     *
+     * @param string   $headerName   The name of the header to check
+     * @param callable $headerGetter Callback to get header values by name
+     *
+     * @return string|null The client IP address, or null if not found or invalid
+     */
+    private function extractClientIP(string $headerName, callable $headerGetter): ?string
+    {
+        $headerValue = $headerGetter($headerName);
+
+        if ($headerValue === null) {
+            return null;
+        }
+
+        // Some proxies typically list the whole chain of IP
+        // addresses through which the client has reached us.
+        // e.g. client_ip, proxy_ip1, proxy_ip2, etc.
+        sscanf($headerValue, '%[^,]', $clientIP);
+
+        if (! ($this->ipValidator)($clientIP)) {
+            return null;
+        }
+
+        return $clientIP;
+    }
+}

--- a/tests/system/HTTP/IPAddressDetectorTest.php
+++ b/tests/system/HTTP/IPAddressDetectorTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Exceptions\ConfigException;
+use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class IPAddressDetectorTest extends CIUnitTestCase
+{
+    private IPAddressDetector $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = new IPAddressDetector();
+    }
+
+    public function testDetectWithNoProxies(): void
+    {
+        $remoteAddr = '192.168.1.100';
+        $proxyIPs   = [];
+        $headerGetter = static fn(string $name): ?string => null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        $this->assertSame('192.168.1.100', $result);
+    }
+
+    public function testDetectWithInvalidIP(): void
+    {
+        $remoteAddr = 'invalid-ip';
+        $proxyIPs   = [];
+        $headerGetter = static fn(string $name): ?string => null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        $this->assertSame('0.0.0.0', $result);
+    }
+
+    public function testDetectWithTrustedProxyExactMatch(): void
+    {
+        $remoteAddr = '192.168.1.1';
+        $proxyIPs   = ['192.168.1.1' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        $this->assertSame('203.0.113.5', $result);
+    }
+
+    public function testDetectWithUntrustedProxy(): void
+    {
+        $remoteAddr = '192.168.1.100';
+        $proxyIPs   = ['192.168.1.1' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should return the original IP since it's not from a trusted proxy
+        $this->assertSame('192.168.1.100', $result);
+    }
+
+    public function testDetectWithTrustedProxySubnet(): void
+    {
+        $remoteAddr = '192.168.1.50';
+        $proxyIPs   = ['192.168.1.0/24' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        $this->assertSame('203.0.113.5', $result);
+    }
+
+    public function testDetectWithIPOutsideSubnet(): void
+    {
+        $remoteAddr = '192.168.2.50';
+        $proxyIPs   = ['192.168.1.0/24' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should return the original IP since it's outside the trusted subnet
+        $this->assertSame('192.168.2.50', $result);
+    }
+
+    public function testDetectWithMultipleIPsInHeader(): void
+    {
+        $remoteAddr = '192.168.1.1';
+        $proxyIPs   = ['192.168.1.1' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5, 198.51.100.1, 192.0.2.1' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should extract only the first IP from the comma-separated list
+        $this->assertSame('203.0.113.5', $result);
+    }
+
+    public function testDetectWithInvalidClientIP(): void
+    {
+        $remoteAddr = '192.168.1.1';
+        $proxyIPs   = ['192.168.1.1' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? 'invalid-ip' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should return the original IP since the client IP in the header is invalid
+        $this->assertSame('192.168.1.1', $result);
+    }
+
+    public function testDetectWithMissingHeader(): void
+    {
+        $remoteAddr = '192.168.1.1';
+        $proxyIPs   = ['192.168.1.1' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should return the original IP since the header is not present
+        $this->assertSame('192.168.1.1', $result);
+    }
+
+    public function testDetectWithIPv6(): void
+    {
+        $remoteAddr = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+        $proxyIPs   = [];
+        $headerGetter = static fn(string $name): ?string => null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        $this->assertSame('2001:0db8:85a3:0000:0000:8a2e:0370:7334', $result);
+    }
+
+    public function testDetectWithIPv6Subnet(): void
+    {
+        $remoteAddr = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+        $proxyIPs   = ['2001:0db8:85a3::/64' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '2001:0db8:1234::1' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        $this->assertSame('2001:0db8:1234::1', $result);
+    }
+
+    public function testDetectWithIPv6OutsideSubnet(): void
+    {
+        $remoteAddr = '2001:0db8:1234:0000:0000:0000:0000:0001';
+        $proxyIPs   = ['2001:0db8:85a3::/64' => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '2001:0db8:5678::1' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should return the original IP since it's outside the trusted subnet
+        $this->assertSame('2001:0db8:1234:0000:0000:0000:0000:0001', $result);
+    }
+
+    public function testDetectWithMixedIPv4AndIPv6Proxies(): void
+    {
+        $remoteAddr = '192.168.1.50';
+        $proxyIPs   = [
+            '2001:0db8:85a3::/64' => 'X-Real-IP',
+            '192.168.1.0/24'      => 'X-Forwarded-For',
+        ];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should match the IPv4 subnet and extract the client IP
+        $this->assertSame('203.0.113.5', $result);
+    }
+
+    public function testDetectWithInvalidProxyIPsConfiguration(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.');
+
+        $remoteAddr = '192.168.1.100';
+        $proxyIPs   = ['192.168.1.1']; // Invalid: indexed array instead of associative
+        $headerGetter = static fn(string $name): ?string => null;
+
+        $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+    }
+
+    public function testDetectWithMultipleTrustedProxies(): void
+    {
+        $remoteAddr = '192.168.1.1';
+        $proxyIPs   = [
+            '192.168.1.1' => 'X-Forwarded-For',
+            '10.0.0.1'    => 'X-Real-IP',
+        ];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        // Should match the first trusted proxy and extract the client IP
+        $this->assertSame('203.0.113.5', $result);
+    }
+
+    #[DataProvider('provideSubnetTestCases')]
+    public function testSubnetMatching(string $remoteAddr, string $subnet, bool $shouldMatch): void
+    {
+        $proxyIPs = [$subnet => 'X-Forwarded-For'];
+        $headerGetter = static fn(string $name): ?string => $name === 'X-Forwarded-For' ? '203.0.113.5' : null;
+
+        $result = $this->detector->detect($remoteAddr, $proxyIPs, $headerGetter);
+
+        if ($shouldMatch) {
+            $this->assertSame('203.0.113.5', $result, "Expected IP from header for {$remoteAddr} in {$subnet}");
+        } else {
+            $this->assertSame($remoteAddr, $result, "Expected original IP for {$remoteAddr} not in {$subnet}");
+        }
+    }
+
+    public static function provideSubnetTestCases(): iterable
+    {
+        return [
+            'IPv4 /24 match'      => ['192.168.1.50', '192.168.1.0/24', true],
+            'IPv4 /24 no match'   => ['192.168.2.50', '192.168.1.0/24', false],
+            'IPv4 /16 match'      => ['192.168.50.1', '192.168.0.0/16', true],
+            'IPv4 /16 no match'   => ['192.169.1.1', '192.168.0.0/16', false],
+            'IPv4 /8 match'       => ['10.50.100.200', '10.0.0.0/8', true],
+            'IPv4 /8 no match'    => ['11.0.0.1', '10.0.0.0/8', false],
+            'IPv4 /32 exact'      => ['192.168.1.1', '192.168.1.1/32', true],
+            'IPv4 /32 no match'   => ['192.168.1.2', '192.168.1.1/32', false],
+        ];
+    }
+}


### PR DESCRIPTION
## Description

This PR addresses a long-standing TODO comment in [RequestTrait.php](cci:7://file:///d:/Ninja_Work/Git_work/CodeIgniter4/system/HTTP/RequestTrait.php:0:0-0:0) by extracting all IP address detection logic into a dedicated [IPAddressDetector](cci:2://file:///d:/Ninja_Work/Git_work/CodeIgniter4/system/HTTP/IPAddressDetector.php:24:0-188:1) class. This refactoring improves code organization, maintainability, and testability without introducing any breaking changes.

**Resolves TODO:** [system/HTTP/RequestTrait.php](cci:7://file:///d:/Ninja_Work/Git_work/CodeIgniter4/system/HTTP/RequestTrait.php:0:0-0:0) line 86
```php
// @TODO Extract all this IP address logic to another class.