### PR TITLE
docs(readme): revamp overview, quick start, and contribution links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,98 @@
-# CodeIgniter 4 Development
+# CodeIgniter 4
 
+[![Latest Release](https://img.shields.io/github/v/release/codeigniter4/CodeIgniter4)](https://packagist.org/packages/codeigniter4/framework)
 [![PHPUnit](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-phpunit.yml/badge.svg)](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-phpunit.yml)
-[![PHPStan](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-phpstan.yml/badge.svg)](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-phpstan.yml)
-[![Psalm](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-psalm.yml/badge.svg)](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-psalm.yml)
-[![Coverage Status](https://coveralls.io/repos/github/codeigniter4/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/github/codeigniter4/CodeIgniter4?branch=develop)
-[![Downloads](https://poser.pugx.org/codeigniter4/framework/downloads)](https://packagist.org/packages/codeigniter4/framework)
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/codeigniter4/CodeIgniter4)](https://packagist.org/packages/codeigniter4/framework)
-[![GitHub stars](https://img.shields.io/github/stars/codeigniter4/CodeIgniter4)](https://packagist.org/packages/codeigniter4/framework)
-[![GitHub license](https://img.shields.io/github/license/codeigniter4/CodeIgniter4)](https://github.com/codeigniter4/CodeIgniter4/blob/develop/LICENSE)
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/codeigniter4/CodeIgniter4/pulls)
-<br>
+[![Static Analysis](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-phpstan.yml/badge.svg)](https://github.com/codeigniter4/CodeIgniter4/actions/workflows/test-phpstan.yml)
+[![License](https://img.shields.io/github/license/codeigniter4/CodeIgniter4)](LICENSE)
 
-## What is CodeIgniter?
+CodeIgniter 4 is a modern, lightweight PHP full-stack framework focused on developer productivity, speed, and security. It provides a collection of expressive libraries, a powerful CLI, and an intuitive MVC structure that helps you ship production-ready applications quickly.
 
-CodeIgniter is a PHP full-stack web framework that is light, fast, flexible and secure.
-More information can be found at the [official site](https://codeigniter.com).
+---
 
-This repository holds the source code for CodeIgniter 4 only.
-Version 4 is a complete rewrite to bring the quality and the code into a more modern version,
-while still keeping as many of the things intact that has made people love the framework over the years.
+## Overview
 
-More information about the plans for version 4 can be found in [CodeIgniter 4](https://forum.codeigniter.com/forumdisplay.php?fid=28) on the forums.
+- **Lightweight core** with optional packages so you only ship what you need.
+- **Secure by design** thanks to CSRF protection, content security features, and built-in validation.
+- **Developer friendly** CLI (`php spark`) for scaffolding, migrations, tasks, and testing.
+- **Flexible architecture** that embraces PSR standards, Composer autoloading, and namespacing.
 
-### Documentation
+## Requirements
 
-The [User Guide](https://codeigniter.com/user_guide/) is the primary documentation for CodeIgniter 4.
+- PHP 8.1 or newer
+- `ext-intl` and `ext-mbstring` enabled
+- Recommended: `ext-curl`, `ext-json`, and database-specific extensions (`ext-mysqli`, `ext-pgsql`, etc.)
 
-You will also find the [current **in-progress** User Guide](https://codeigniter4.github.io/CodeIgniter4/).
-As with the rest of the framework, it is a work in progress, and will see changes over time to structure, explanations, etc.
+> PHP 8.1 reaches end of life on December 31, 2025. Upgrade sooner to stay supported.
 
-You might also be interested in the [API documentation](https://codeigniter4.github.io/api/) for the framework components.
+## Quick Start
 
-## Important Change with index.php
+1. **Clone and install dependencies**
+   ```bash
+   git clone https://github.com/codeigniter4/CodeIgniter4.git
+   cd CodeIgniter4
+   composer install
+   ```
+2. **Bootstrap your environment**
+   ```bash
+   cp env .env
+   php spark key:generate
+   ```
+   On Windows use `copy env .env` instead of `cp`.
+   Update `.env` with your app name, base URL, and database credentials.
+3. **Serve the application**
+   ```bash
+   php spark serve
+   ```
+   Visit `http://localhost:8080` to confirm the welcome page loads.
 
-`index.php` is no longer in the root of the project! It has been moved inside the *public* folder,
-for better security and separation of components.
+## Common Tasks
 
-This means that you should configure your web server to "point" to your project's *public* folder, and
-not to the project root. A better practice would be to configure a virtual host to point there. A poor practice would be to point your web server to the project root and expect to enter *public/...*, as the rest of your logic and the
-framework are exposed.
+- `php spark make:controller Home` – scaffold a controller.
+- `php spark make:migration CreateUsers` – generate a database migration.
+- `php spark migrate` – run pending migrations.
+- `php spark routes` – inspect the current routing table.
+- `php spark help` – list available CLI commands.
 
-**Please** read the user guide for a better explanation of how CI4 works!
+Composer scripts streamline maintenance tasks:
 
-## Repository Management
+- `composer test` – run the PHPUnit suite.
+- `composer analyze` – run static analysis (PHPStan + Rector dry run).
+- `composer cs` – check coding standards.
+- `composer cs-fix` – automatically fix coding standards.
+- `composer metrics` – generate PhpMetrics reports.
 
-CodeIgniter is developed completely on a volunteer basis. As such, please give up to 7 days
-for your issues to be reviewed. If you haven't heard from one of the team in that time period,
-feel free to leave a comment on the issue so that it gets brought back to our attention.
+## Project Structure
 
-> [!IMPORTANT]
-> We use GitHub issues to track **BUGS** and to track approved **DEVELOPMENT** work packages.
-> We use our [forum](http://forum.codeigniter.com) to provide SUPPORT and to discuss
-> FEATURE REQUESTS.
+- `app/` – application code (controllers, models, views, configuration).
+- `public/` – web server document root containing `index.php`.
+- `system/` – framework core (avoid editing directly).
+- `tests/` – PHPUnit test suite.
+- `writable/` – runtime storage (cache, logs, sessions, uploads).
 
-If you raise an issue here that pertains to support or a feature request, it will
-be closed! If you are not sure if you have found a bug, raise a thread on the forum first -
-someone else may have encountered the same thing.
+Configure your web server (Apache/Nginx) to serve the `public/` directory to keep application files outside the public web root.
 
-Before raising a new GitHub issue, please check that your bug hasn't already
-been reported or fixed.
+## Documentation & Guides
 
-We use pull requests (PRs) for CONTRIBUTIONS to the repository.
-We are looking for contributions that address one of the reported bugs or
-approved work packages.
-
-Do not use a PR as a form of feature request.
-Unsolicited contributions will only be considered if they fit nicely
-into the framework roadmap.
-Remember that some components that were part of CodeIgniter 3 are being moved
-to optional packages, with their own repository.
+- Official User Guide: https://codeigniter.com/user_guide/
+- In-progress Docs (latest develop): https://codeigniter4.github.io/CodeIgniter4/
+- API Reference: https://codeigniter4.github.io/api/
+- Community Forum: https://forum.codeigniter.com/
+- Slack Community: https://codeigniterchat.slack.com/
 
 ## Contributing
 
-We **are** accepting contributions from the community! It doesn't matter whether you can code, write documentation, or help find bugs,
-all contributions are welcome.
+We welcome bug reports, documentation updates, and pull requests from the community. Before contributing:
 
-Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/CodeIgniter4/blob/develop/contributing/README.md).
+1. Review the [contributing guide](contributing/README.md).
+2. Search existing issues to avoid duplicates.
+3. Use GitHub Issues for confirmed bugs and approved enhancements; use the forum for support or feature ideas.
 
-CodeIgniter has had thousands on contributions from people since its creation. This project would not be what it is without them.
+PRs should include tests when applicable and follow the project's coding standards (`composer cs` / `composer cs-fix`).
 
-<a href="https://github.com/codeigniter4/CodeIgniter4/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=codeigniter4/CodeIgniter4" />
-</a>
+## Security
 
-Made with [contrib.rocks](https://contrib.rocks).
+Report security issues via the [responsible disclosure process](SECURITY.md). Please do not open public GitHub issues for vulnerabilities.
 
-## Server Requirements
+## License
 
-PHP version 8.1 or higher is required, with the following extensions installed:
-
-- [intl](http://php.net/manual/en/intl.requirements.php)
-- [mbstring](http://php.net/manual/en/mbstring.installation.php)
-
-> [!WARNING]
-> - The end of life date for PHP 7.4 was November 28, 2022.
-> - The end of life date for PHP 8.0 was November 26, 2023.
-> - If you are still using PHP 7.4 or 8.0, you should upgrade immediately.
-> - The end of life date for PHP 8.1 will be December 31, 2025.
-
-Additionally, make sure that the following extensions are enabled in your PHP:
-
-- json (enabled by default - don't turn it off)
-- [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
-- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
-
-## Running CodeIgniter Tests
-
-Information on running the CodeIgniter test suite can be found in the [README.md](tests/README.md) file in the tests directory.
+CodeIgniter 4 is open-source software released under the [MIT License](LICENSE).


### PR DESCRIPTION
Rewrite README.md to provide a clearer overview of CodeIgniter 4, including key framework features, requirements, and community resources.
Add a pragmatic quick-start section with Windows-specific notes, highlight common spark/Composer workflows, and outline the project structure so newcomers can get productive quickly.
Clarify contribution and security guidance by linking to the relevant docs.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide 
