### PR TITLE
fix: quote reserved keyword `timestamp` used as a field name for session table

### DIFF
--- a/system/Commands/Generators/Views/migration.tpl.php
+++ b/system/Commands/Generators/Views/migration.tpl.php
@@ -15,7 +15,7 @@ class {class} extends Migration
             'id' => ['type' => 'VARCHAR', 'constraint' => 128, 'null' => false],
 <?php if ($DBDriver === 'MySQLi'): ?>
             'ip_address' => ['type' => 'VARCHAR', 'constraint' => 45, 'null' => false],
-            'timestamp timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL',
+            '`timestamp` timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL',
             'data' => ['type' => 'BLOB', 'null' => false],
  <?php elseif ($DBDriver === 'Postgre'): ?>
             'ip_address inet NOT NULL',

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -43,6 +43,7 @@ Bugs Fixed
 - **Database:** Fixed a bug in ``SQLite3`` where the password parameter was ignored unless it was an empty string.
 - **Debug:** Fixed a bug in ``ExceptionHandler`` where JSON encoding would fail when exception traces contained resources (e.g., database connections), closures, or circular references.
 - **Forge:** Fixed a bug in ``Postgre`` and ``SQLSRV`` where changing a column's default value using ``Forge::modifyColumn()`` method produced incorrect SQL syntax.
+- **Migrations:** Fixed a bug in the session table migration template where the ``timestamp`` field name conflicted with reserved keywords in MySQL/MariaDB.
 - **Model:** Fixed a bug in ``Model::replace()`` where ``created_at`` field (when available) wasn't set correctly.
 - **Model:** Fixed a bug in ``Model::insertBatch()`` and ``Model::updateBatch()`` where casts were not applied to inserted or updated values.
 - **Toolbar:** Fixed bugs in ``Collectors\Logs`` that were preventing the "Logs" tab from appearing on the Debug Toolbar.


### PR DESCRIPTION
**Description**
This PR fixes a bug in the session table schema for `mysqli` driver.

The `timestamp` field name in the session table is a reserved keyword in MySQL and MariaDB. Quoting it ensures proper creation and operation of the table when creating the table via `mysqli`.

Fixes #9796

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
