### PR TITLE
chore: clean up deprecated NodeTraverser:: constant usage, use Nodevisitor:: instead on RemoveErrorSuppressInTryCatchStmtsRector

### DIFF
--- a/utils/src/Rector/RemoveErrorSuppressInTryCatchStmtsRector.php
+++ b/utils/src/Rector/RemoveErrorSuppressInTryCatchStmtsRector.php
@@ -19,7 +19,7 @@ use PhpParser\Node\Expr\ErrorSuppress;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\TryCatch;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -63,7 +63,7 @@ final class RemoveErrorSuppressInTryCatchStmtsRector extends AbstractRector
             $node->stmts,
             static function (Node $subNode) use (&$hasChanged): int|Expr|null {
                 if ($subNode instanceof Class_ || $subNode instanceof Function_) {
-                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
                 if ($subNode instanceof ErrorSuppress) {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**

Using `NodeTraverser::` constants is deprecated, see 

https://github.com/nikic/PHP-Parser/blob/c97b23dce761ab3c913ee8ac5879af7a358f88de/lib/PhpParser/NodeTraverser.php#L21-L24

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
