### PR TITLE
docs: remove internal tag from `Throttler::check()` description

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -90,8 +90,6 @@ class Throttler implements ThrottlerInterface
      * @param int    $capacity The number of requests the "bucket" can hold
      * @param int    $seconds  The time it takes the "bucket" to completely refill
      * @param int    $cost     The number of tokens this action uses.
-     *
-     * @internal param int $maxRequests
      */
     public function check(string $key, int $capacity, int $seconds, int $cost = 1): bool
     {


### PR DESCRIPTION
**Description**
This PR removes the @internal tag from the `Throttler::check()` method description.

It seems like a mistake and can be removed, as it doesn't provide meaningful information and might be confusing.

Fixes #9813

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
