### PR TITLE
docs: further specify alpha-rules and the permit_empty rule

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -976,7 +976,7 @@ not_in_list             Yes        Fails if field is within a predetermined     
 numeric                 No         Fails if field contains anything other than
                                    numeric characters.
 permit_empty            No         Allows the field to receive an empty array,
-                                   empty string, null or false. When true, 
+                                   empty string, null or false. On success, it
                                    skips all other validation rules except for
                                    required_with and required_without.
 regex_match             Yes        Fails if field does not match the regular     ``regex_match[/regex/]``


### PR DESCRIPTION
**Description**
Specified that the alpha-rules fail on empty strings and that permit_empty will skip all other rules except for required_with and required_without.

