### PR TITLE
fix: add necessary comment to the preload file

### DIFF
--- a/preload.php
+++ b/preload.php
@@ -21,7 +21,9 @@ use Config\Paths;
  * How to Use:
  *   0. Copy this file to your project root folder.
  *   1. Set the $paths property of the preload class below.
- *   2. Set opcache.preload in php.ini.
+ *   2. Remove or comment out debug output (the `echo` inside load()),
+ *      preloading script should not produce output.
+ *   3. Set opcache.preload in php.ini.
  *     php.ini:
  *     opcache.preload=/path/to/preload.php
  */


### PR DESCRIPTION
**Description**
This PR updates the sample `preload.php` file to include a short note in the instructions indicating that the debug `echo` statement should be removed before using the file in a real preloading setup. Preloading scripts are expected not to produce output, so this clarification helps prevent accidental usage of the sample with debug output left enabled.

Fixes #9821

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
