### PR TITLE
fix: Add an IDs for toolbar form fields

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -790,7 +790,7 @@ var ciDebugBar = {
                     '">' +
                     row.innerText.replace(
                         patt,
-                        '<input type="text" placeholder="$1">'
+                        '<input id="debugbar-route-id-' + i + '" type="text" placeholder="$1">'
                     ) +
                     '<input type="submit" value="Go" class="debug-bar-mleft4">' +
                     "</form>";


### PR DESCRIPTION
**Description**
Fix browser notification:

> A form field element has neither an **id** nor a **name** attribute. This might prevent the browser from correctly autofilling the form.
> To fix this issue, add a unique **id** or **name** attribute to a form field. This is not strictly needed, but still recommended even if you have an autocomplete attribute on the same element.

A little annoying.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
