### PR TITLE
fix: disable echo in the preload file

### DIFF
--- a/preload.php
+++ b/preload.php
@@ -101,7 +101,9 @@ class preload
                 }
 
                 require_once $file[0];
-                echo 'Loaded: ' . $file[0] . "\n";
+                // Uncomment only for debugging (to inspect which files are included).
+                // Never use this in production - preload scripts must not generate output.
+                // echo 'Loaded: ' . $file[0] . "\n";
             }
         }
     }


### PR DESCRIPTION
**Description**
This PR updates the sample `preload.php` by commenting out the debug `echo` line and adding a note that preload scripts must not produce output in real use.

Closes #9822

Fixes #9821

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide