### PR TITLE
fix(cache): prevent Redis error when `deleteMatching()` finds no keys

### DIFF
--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -162,6 +162,10 @@ class PredisHandler extends BaseHandler
             $matchedKeys[] = $key;
         }
 
+        if ($matchedKeys === []) {
+            return 0;
+        }
+
         return $this->redis->del($matchedKeys);
     }
 

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -195,7 +195,7 @@ class RedisHandler extends BaseHandler
             }
         } while ($iterator > 0);
 
-        return $this->redis->del($matchedKeys);
+        return (int) $this->redis->del($matchedKeys);
     }
 
     /**

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -160,6 +160,11 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
         $this->assertSame('90', $this->handler->getCacheInfo()['Keyspace']['db0']['keys']);
     }
 
+    public function testDeleteMatchingNothing(): void
+    {
+        $this->assertSame(0, $this->handler->deleteMatching('user_1_info*'));
+    }
+
     public function testClean(): void
     {
         $this->handler->save(self::$key1, 1);

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -184,6 +184,11 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         yield 'cache-prefix' => ['key_1*', 13, 'foo_'];
     }
 
+    public function testDeleteMatchingNothing(): void
+    {
+        $this->assertSame(0, $this->handler->deleteMatching('user_1_info*'));
+    }
+
     public function testIncrementAndDecrement(): void
     {
         $this->handler->save('counter', 100);

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -37,6 +37,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Cache:** Fixed a bug in ``PredisHandler::deleteMatching()`` causing Redis error when no keys match the pattern.
+- **Cache:** Fixed a bug in ``RedisHandler::deleteMatching()`` returning ``false`` instead of ``int`` when no keys match the pattern.
 - **Database:** Fixed a bug in ``Database::connect()`` which was causing to store non-shared connection instances in shared cache.
 - **Database:** Fixed a bug in ``Connection::getFieldData()`` for ``SQLSRV`` and ``OCI8`` where extra characters were returned in column default values (specific to those handlers), instead of following the convention used by other drivers.
 - **Database:** Fixed a bug in ``BaseBuilder::compileOrderBy()`` where the method could overwrite ``QBOrderBy`` with a string instead of keeping it as an array, causing type errors and preventing additional ``ORDER BY`` clauses from being appended.


### PR DESCRIPTION
**Description**
This PR fixes bugs in `RedisHandler` and `PredisHandler` when `deleteMatching()` is called with a pattern that matches no keys.

Fixes #9828

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
