### PR TITLE
fix: tests with migrations_lock

### DIFF
--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -189,6 +189,7 @@ class Migration_Create_test_tables extends Migration
         $this->forge->dropTable('stringifypkey', true);
         $this->forge->dropTable('without_auto_increment', true);
         $this->forge->dropTable('ip_table', true);
+        $this->forge->dropTable('migrations_lock', true);
 
         if (in_array($this->db->DBDriver, ['MySQLi', 'Postgre'], true)) {
             $this->forge->dropTable('ci_sessions', true);


### PR DESCRIPTION
**Description**
This PR fixes tests migrations by ensuring the `migrations_lock` table is always removed.

No changelog entry, as this change is relevant only for tests.

Fixes #9832

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
