### PR TITLE
fix: Not allowed empty PK value for update() and delete()

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1104,7 +1104,7 @@ abstract class BaseModel
             throw new InvalidArgumentException('delete(): argument #1 ($id) should not be boolean.');
         }
 
-        if (! in_array($id, [null, 0, '0'], true) && (is_numeric($id) || is_string($id))) {
+        if (is_numeric($id) || is_string($id)) {
             $id = [$id];
         }
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -443,7 +443,7 @@ class Model extends BaseModel
 
         $builder = $this->builder();
 
-        if (! in_array($id, [null, '', 0, '0', []], true)) {
+        if ($this->isValidID($id)) {
             $builder = $builder->whereIn($this->table . '.' . $this->primaryKey, $id);
         }
 
@@ -459,6 +459,25 @@ class Model extends BaseModel
         }
 
         return $builder->update();
+    }
+
+    /**
+     * Make sure that the primary keys are set and non-empty
+     * for $this->delete() and $this->update().
+     *
+     * @param int|list<mixed>|string|null $id
+     */
+    protected function isValidID($id): bool
+    {
+        if (is_array($id) && $id !== []) {
+            foreach ($id as $valueId) {
+                if (is_array($valueId) || ! $this->isValidID($valueId)) {
+                    return false;
+                }
+            }
+        }
+
+        return ! in_array($id, [null, '', 0, '0', []], true);
     }
 
     /**
@@ -496,7 +515,7 @@ class Model extends BaseModel
         $set     = [];
         $builder = $this->builder();
 
-        if (! in_array($id, [null, '', 0, '0', []], true)) {
+        if ($this->isValidID($id)) {
             $builder = $builder->whereIn($this->primaryKey, $id);
         }
 

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -273,6 +273,10 @@ final class DeleteModelTest extends LiveModelTestCase
             [0],
             [null],
             ['0'],
+            // @todo Fail only testDontThrowExceptionWhenSoftDeleteConditionIsSetWithEmptyValue()
+            // [''],
+            // [[]],
+            // [[15 => 150, '_id_' => '200', 20 => '0']],
         ];
     }
 }

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -553,10 +553,14 @@ final class UpdateModelTest extends LiveModelTestCase
      * @param false|null $id
      */
     #[DataProvider('provideUpdateThrowDatabaseExceptionWithoutWhereClause')]
-    public function testUpdateThrowDatabaseExceptionWithoutWhereClause($id, string $exception, string $exceptionMessage): void
+    public function testUpdateThrowDatabaseExceptionWithoutWhereClause($id, string $exception): void
     {
         $this->expectException($exception);
-        $this->expectExceptionMessage($exceptionMessage);
+        $this->expectExceptionMessage(
+            $exception === DatabaseException::class
+            ? 'Updates are not allowed unless they contain a "where" or "like" clause.'
+            : 'update(): argument #1 ($id) should not be boolean.',
+        );
 
         // $useSoftDeletes = false
         $this->createModel(JobModel::class);
@@ -570,12 +574,34 @@ final class UpdateModelTest extends LiveModelTestCase
             [
                 null,
                 DatabaseException::class,
-                'Updates are not allowed unless they contain a "where" or "like" clause.',
             ],
             [
                 false,
                 InvalidArgumentException::class,
-                'update(): argument #1 ($id) should not be boolean.',
+            ],
+            [
+                '',
+                DatabaseException::class,
+            ],
+            [
+                0,
+                DatabaseException::class,
+            ],
+            [
+                '0',
+                DatabaseException::class,
+            ],
+            [
+                [],
+                DatabaseException::class,
+            ],
+            [
+                [15 => 150, '_id_' => '200', 20 => '0'],
+                DatabaseException::class,
+            ],
+            [
+                [0 => '150', [1 => 200]],
+                DatabaseException::class,
             ],
         ];
     }


### PR DESCRIPTION
**Description**
Comment https://github.com/codeigniter4/CodeIgniter4/pull/9830#discussion_r2613135237

For the event, I returned the transfer of an array IDs or `null`.

An attempt to return the check for incorrect PK update()/delete(). Values of `'' 0 '0' null` and the same values in the array `[1 => null, 2 => '', 3 => '0',...]`  are invalid, they can cause SQL exception. We intercept this before executing the query and throw our DatabaseException.

In this state, it only solves for the `$id` passed to `delete()`, `update()`. But we can pass the value via `where('id', [1, 2, 3])-> update()` or `whereIn('id', [1, 2, 3])-> update()` and other. Therefore, I need to know whether to handle these cases or return an SQL exception to the user?

Example bad SQL:
```sql
# where('id', [])
#  SQLite3Exception: near ")": syntax error
UPDATE `db_user` SET `deleted_at` = '2025-12-12 09:57:36'
WHERE `id` = ()
AND `deleted_at` IS NULL

# where('id', [15 => 150, '_id_' => '200', 20 => '0'])
# DatabaseException: row value misused
UPDATE `db_user` SET `deleted_at` = '2025-12-12 09:57:36'
WHERE `id` = (150,'200','0')
AND `deleted_at` IS NULL
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
