### PR TITLE
fix: signal trait

### DIFF
--- a/system/CLI/SignalTrait.php
+++ b/system/CLI/SignalTrait.php
@@ -95,11 +95,15 @@ trait SignalTrait
      * @param array<int, string> $methodMap Optional signal-to-method mapping
      */
     protected function registerSignals(
-        array $signals = [SIGTERM, SIGINT, SIGHUP, SIGQUIT],
+        array $signals = [],
         array $methodMap = [],
     ): void {
         if (! $this->isPcntlAvailable()) {
             return;
+        }
+
+        if ($signals === []) {
+            $signals = [SIGTERM, SIGINT, SIGHUP, SIGQUIT];
         }
 
         if (! $this->isPosixAvailable() && (in_array(SIGTSTP, $signals, true) || in_array(SIGCONT, $signals, true))) {


### PR DESCRIPTION
**Description**
This PR fixes `SignalTrait` for Windows. When `pcntl` extension is not available, signal constants will be unrecognized, causing errors. See: https://github.com/codeigniter4/queue/issues/71

No changelog entry is included, as `SignalTrait` is a new feature in `4.7`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
