### PR TITLE
style: implement `CodeIgniterRuleCustomisationPolicy`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,7 +26,6 @@ $finder = Finder::create()
         'ThirdParty',
         'Validation/Views',
     ])
-    ->notName('#Foobar.php$#')
     ->append([
         __FILE__,
         __DIR__ . '/.php-cs-fixer.no-header.php',
@@ -37,9 +36,7 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [
-    'modernize_strpos' => ['modernize_stripos' => true],
-];
+$overrides = [];
 
 $options = [
     'cacheFile' => 'build/.php-cs-fixer.cache',

--- a/.php-cs-fixer.tests.php
+++ b/.php-cs-fixer.tests.php
@@ -11,10 +11,11 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use Utils\PhpCsFixer\CodeIgniterRuleCustomisationPolicy;
 
-/** @var ConfigInterface $config */
+/** @var Config $config */
 $config = require __DIR__ . '/.php-cs-fixer.dist.php';
 
 $finder = Finder::create()
@@ -26,9 +27,7 @@ $finder = Finder::create()
         '_support/View/Cells/multiplier.php',
         '_support/View/Cells/colors.php',
         '_support/View/Cells/addition.php',
-        'system/Database/Live/PreparedQueryTest.php',
-    ])
-    ->notName('#Foobar.php$#');
+    ]);
 
 $overrides = [
     'phpdoc_to_return_type' => true,
@@ -36,6 +35,7 @@ $overrides = [
 ];
 
 return $config
+    ->setRuleCustomisationPolicy(new CodeIgniterRuleCustomisationPolicy())
     ->setFinder($finder)
     ->setCacheFile('build/.php-cs-fixer.tests.cache')
     ->setRules(array_merge($config->getRules(), $overrides));

--- a/tests/_support/Commands/Foobar.php
+++ b/tests/_support/Commands/Foobar.php
@@ -1,11 +1,20 @@
 <?php
 
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
 use Config\App;
 use CodeIgniter\CLI\CLI;
 
 return [
-   'foo' => 'The command will use this as foo.',
-   'bar' => 'The command will use this as bar.',
-   'baz' => 'The baz is here.',
-   'bas' => CLI::color('bas', 'green') . (new App())->baseURL,
+    'foo' => 'The command will use this as foo.',
+    'bar' => 'The command will use this as bar.',
+    'baz' => 'The baz is here.',
+    'bas' => CLI::color('bas', 'green') . (new App())->baseURL,
 ];

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -256,7 +256,7 @@ final class PreparedQueryTest extends CIUnitTestCase
                 'name'    => 'a',
                 'email'   => 'b@example.com',
                 'country' => 'x',
-            ])
+            ]),
         );
 
         $this->query->close();
@@ -264,7 +264,7 @@ final class PreparedQueryTest extends CIUnitTestCase
         // Try to close a non-existing prepared statement
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
-            'Cannot call close on a non-existing prepared statement.'
+            'Cannot call close on a non-existing prepared statement.',
         );
 
         $this->query->close();
@@ -325,7 +325,7 @@ final class PreparedQueryTest extends CIUnitTestCase
 
         $this->seeInDatabase($this->db->DBPrefix . 'without_auto_increment', [
             'key'   => 'test_key',
-            'value' => 'test_value'
+            'value' => 'test_value',
         ]);
 
         $this->assertFalse($this->query->execute('test_key', 'different_value'));
@@ -339,7 +339,7 @@ final class PreparedQueryTest extends CIUnitTestCase
         // Verify the first insert was rolled back
         $this->dontSeeInDatabase($this->db->DBPrefix . 'without_auto_increment', [
             'key'   => 'test_key',
-            'value' => 'test_value'
+            'value' => 'test_value',
         ]);
 
         $this->db->resetTransStatus();

--- a/utils/src/PhpCsFixer/CodeIgniterRuleCustomisationPolicy.php
+++ b/utils/src/PhpCsFixer/CodeIgniterRuleCustomisationPolicy.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Utils\PhpCsFixer;
+
+use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
+use SplFileInfo;
+
+/**
+ * Rule customisation policy for CodeIgniter coding standard.
+ *
+ * @internal
+ */
+final class CodeIgniterRuleCustomisationPolicy implements RuleCustomisationPolicyInterface
+{
+    public function getPolicyVersionForCache(): string
+    {
+        return hash_file('sha256', __FILE__);
+    }
+
+    public function getRuleCustomisers(): array
+    {
+        $normalisedStrEndsWith = static fn (string $haystack, string $needle): bool => str_ends_with(str_replace('\\', '/', $haystack), $needle);
+
+        return [
+            'native_function_casing' => static fn (SplFileInfo $file): bool => ! $normalisedStrEndsWith(
+                $file->getPathname(),
+                '/tests/system/Database/Live/PreparedQueryTest.php',
+            ),
+            'ordered_imports' => static fn (SplFileInfo $file): bool => ! $normalisedStrEndsWith(
+                $file->getPathname(),
+                '/tests/_support/Commands/Foobar.php',
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
Starting in php-cs-fixer v3.92, rules can be applied on a per-file basis using the `RuleCustomisationPolicyInterface`. This implements our own policy so that we can choose which fixers to apply/not apply to a file instead of entirely skipping linting on a file.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
