### PR TITLE
fix: resolve inconsistent PHPStan errors between local and CI environment

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,6 +19,7 @@ parameters:
             - system/Commands/Generators/Views/*
             - system/Debug/Toolbar/Views/toolbar.tpl.php
             - system/Images/Handlers/GDHandler.php
+            - system/Test/Mock/MockCommon.php
             - system/ThirdParty/*
             - system/Validation/Views/single.php
             - tests/system/View/Views/*

--- a/utils/phpstan-baseline/arguments.count.neon
+++ b/utils/phpstan-baseline/arguments.count.neon
@@ -1,0 +1,8 @@
+# total 2 errors
+
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Function is_cli invoked with 1 parameter, 0 required\.$#'
+            count: 2
+            path: ../../tests/system/Debug/ToolbarTest.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,7 +1,8 @@
-# total 2635 errors
+# total 2637 errors
 
 includes:
     - argument.type.neon
+    - arguments.count.neon
     - assign.propertyType.neon
     - booleanNot.exprNotBoolean.neon
     - codeigniter.getReassignArray.neon


### PR DESCRIPTION
**Description**
This PR excludes `MockCommon.php` from PHPStan scan for consistent results.

From my understanding, PHPStan scanned both function definitions, and depending on which it loaded first (or cached), it could detect different signatures.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
