### PR TITLE
refactor: Superglobals - remove property promotion and fix PHPDocs

### DIFF
--- a/system/Superglobals.php
+++ b/system/Superglobals.php
@@ -43,6 +43,36 @@ use CodeIgniter\Exceptions\InvalidArgumentException;
 final class Superglobals
 {
     /**
+     * @var array<string, server_items>
+     */
+    private array $server = [];
+
+    /**
+     * @var array<string, get_items>
+     */
+    private array $get = [];
+
+    /**
+     * @var array<string, post_items>
+     */
+    private array $post = [];
+
+    /**
+     * @var array<string, cookie_items>
+     */
+    private array $cookie = [];
+
+    /**
+     * @var array<string, files_items>
+     */
+    private array $files = [];
+
+    /**
+     * @var array<string, request_items>
+     */
+    private array $request = [];
+
+    /**
      * @param array<string, server_items>|null  $server
      * @param array<string, get_items>|null     $get
      * @param array<string, post_items>|null    $post
@@ -51,12 +81,12 @@ final class Superglobals
      * @param array<string, request_items>|null $request
      */
     public function __construct(
-        private ?array $server = null,
-        private ?array $get = null,
-        private ?array $post = null,
-        private ?array $cookie = null,
-        private ?array $files = null,
-        private ?array $request = null,
+        ?array $server = null,
+        ?array $get = null,
+        ?array $post = null,
+        ?array $cookie = null,
+        ?array $files = null,
+        ?array $request = null,
     ) {
         $this
             ->setServerArray($server ?? $_SERVER)
@@ -360,7 +390,7 @@ final class Superglobals
     /**
      * Get all $_FILES values.
      *
-     * @return files_items
+     * @return array<string, files_items>
      */
     public function getFilesArray(): array
     {
@@ -370,7 +400,7 @@ final class Superglobals
     /**
      * Set the entire $_FILES array.
      *
-     * @param files_items $array
+     * @param array<string, files_items> $array
      */
     public function setFilesArray(array $array): self
     {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
After #9858, I am updating the phpstan extension and noted some improvements.
- CPP is now redundant given we use the `set` methods in the constructor.
- Fix PHPDocs in `(get|set)FilesArray` returning previously a single file array

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
