### PR TITLE
chore: set ini-values from extra-ini-options input

### DIFF
--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -43,6 +43,10 @@ on:
         description: Additional PHP extensions that are needed to be enabled
         type: string
         required: false
+      extra-ini-options:
+        description: Additional PHP configuration directives that should be appended to the php.ini
+        type: string
+        required: false
       extra-composer-options:
         description: Additional Composer options that should be appended to the `composer update` call
         type: string
@@ -163,6 +167,7 @@ jobs:
           php-version: ${{ inputs.php-version }}
           tools: composer
           extensions: gd, ${{ inputs.extra-extensions }}
+          ini-values: ${{ inputs.extra-ini-options }}
           coverage: ${{ env.COVERAGE_DRIVER }}
         env:
           COVERAGE_DRIVER: ${{ inputs.enable-coverage && 'xdebug' || 'none' }}

--- a/.github/workflows/reusable-serviceless-phpunit-test.yml
+++ b/.github/workflows/reusable-serviceless-phpunit-test.yml
@@ -37,6 +37,10 @@ on:
         description: Additional PHP extensions that are needed to be enabled
         type: string
         required: false
+      extra-ini-options:
+        description: Additional PHP configuration directives that should be appended to the php.ini
+        type: string
+        required: false
       extra-composer-options:
         description: Additional Composer options that should be appended to the `composer update` call
         type: string
@@ -75,6 +79,7 @@ jobs:
           php-version: ${{ inputs.php-version }}
           tools: composer
           extensions: gd, ${{ inputs.extra-extensions }}
+          ini-values: ${{ inputs.extra-ini-options }}
           coverage: ${{ env.COVERAGE_DRIVER }}
         env:
           COVERAGE_DRIVER: ${{ inputs.enable-coverage && 'xdebug' || 'none' }}


### PR DESCRIPTION
**Description**
Added the ability to pass additional configuration directives to PHP, which is useful for configuring extensions.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
