### PR TITLE
refactor: debugbar time header not dependent on locale

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -397,7 +397,7 @@ class Toolbar
             helper('filesystem');
 
             // Updated to microtime() so we can get history
-            $time = Time::now()->format('U.u');
+            $time = sprintf('%.6F', Time::now()->format('U.u'));
 
             if (! is_dir(WRITEPATH . 'debugbar')) {
                 mkdir(WRITEPATH . 'debugbar', 0777);

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -397,7 +397,7 @@ class Toolbar
             helper('filesystem');
 
             // Updated to microtime() so we can get history
-            $time = sprintf('%.6f', Time::now()->format('U.u'));
+            $time = Time::now()->format('U.u');
 
             if (! is_dir(WRITEPATH . 'debugbar')) {
                 mkdir(WRITEPATH . 'debugbar', 0777);

--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -90,7 +90,7 @@ class History extends BaseCollector
             $contents = @json_decode($contents);
             if (json_last_error() === JSON_ERROR_NONE) {
                 preg_match('/debugbar_(.*)\.json$/s', $filename, $time);
-                $time = sprintf('%.6f', $time[1] ?? 0);
+                $time = sprintf('%.6F', $time[1] ?? 0);
 
                 // Debugbar files shown in History Collector
                 $files[] = [

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -34,7 +34,7 @@ final class HistoryTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->time = (float) sprintf('%.6f', microtime(true));
+        $this->time = (float) sprintf('%.6F', microtime(true));
     }
 
     protected function tearDown(): void
@@ -63,9 +63,9 @@ final class HistoryTest extends CIUnitTestCase
 
         // create 20 dummy debugbar json files
         for ($i = 0; $i < 20; $i++) {
-            $path = str_replace((string) $time, sprintf('%.6f', $time - self::STEP), $path);
+            $path = str_replace((string) $time, sprintf('%.6F', $time - self::STEP), $path);
             file_put_contents($path, json_encode($dummyData));
-            $time = sprintf('%.6f', $time - self::STEP);
+            $time = sprintf('%.6F', $time - self::STEP);
         }
     }
 
@@ -76,7 +76,7 @@ final class HistoryTest extends CIUnitTestCase
         // test dir is now populated with json
         $this->createDummyDebugbarJson();
 
-        $activeRowTime = $time = sprintf('%.6f', $time - self::STEP);
+        $activeRowTime = $time = sprintf('%.6F', $time - self::STEP);
 
         $history = new History();
         $history->setFiles($time, 20);
@@ -85,14 +85,14 @@ final class HistoryTest extends CIUnitTestCase
         $this->assertNotEmpty($history->display()['files'], 'Dummy Debugbar data is empty');
 
         foreach ($history->display()['files'] as $request) {
-            $this->assertSame($request['time'], sprintf('%.6f', $time));
+            $this->assertSame($request['time'], sprintf('%.6F', $time));
             $this->assertSame(
                 $request['datetime'],
                 DateTime::createFromFormat('U.u', $time)->format('Y-m-d H:i:s.u'),
             );
             $this->assertSame($request['active'], ($time === $activeRowTime));
 
-            $time = sprintf('%.6f', $time - self::STEP);
+            $time = sprintf('%.6F', $time - self::STEP);
         }
     }
 }


### PR DESCRIPTION
**Description**
The `U.u` format is already providing us the correct format (6-digits). And with `sprintf`, the comma separator may be transformed either to `.` or `,` depending on locale (`LC_NUMERIC`).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
