### PR TITLE
fix: make router cache attributes time independent

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -226,6 +226,7 @@ deptrac:
       - +Controller
     Router:
       - HTTP
+      - I18n
     Security:
       - Cookie
       - I18n

--- a/system/Router/Attributes/Cache.php
+++ b/system/Router/Attributes/Cache.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Router\Attributes;
 use Attribute;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\I18n\Time;
 
 /**
  * Cache Attribute
@@ -74,7 +75,8 @@ class Cache implements RouteAttributeInterface
             foreach ($cached['headers'] as $name => $value) {
                 $response->setHeader($name, $value);
             }
-            $response->setHeader('Age', (string) (time() - ($cached['timestamp'] ?? time())));
+            $time = Time::now()->getTimestamp();
+            $response->setHeader('Age', (string) ($time - ($cached['timestamp'] ?? $time)));
 
             return $response;
         }
@@ -122,7 +124,7 @@ class Cache implements RouteAttributeInterface
             'body'      => $response->getBody(),
             'headers'   => $headers,
             'status'    => $response->getStatusCode(),
-            'timestamp' => time(),
+            'timestamp' => Time::now()->getTimestamp(),
         ];
 
         cache()->save($cacheKey, $data, $this->for);

--- a/tests/system/Router/Attributes/CacheTest.php
+++ b/tests/system/Router/Attributes/CacheTest.php
@@ -39,6 +39,13 @@ final class CacheTest extends CIUnitTestCase
         Time::setTestNow('2026-01-10 12:00:00');
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Time::setTestNow();
+    }
+
     public function testConstructorDefaults(): void
     {
         $cache = new Cache();

--- a/tests/system/Router/Attributes/CacheTest.php
+++ b/tests/system/Router/Attributes/CacheTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use Config\Services;
@@ -34,6 +35,8 @@ final class CacheTest extends CIUnitTestCase
 
         // Clear cache before each test
         cache()->clean();
+
+        Time::setTestNow('2026-01-10 12:00:00');
     }
 
     public function testConstructorDefaults(): void
@@ -73,7 +76,7 @@ final class CacheTest extends CIUnitTestCase
             'body'      => 'Cached content',
             'status'    => 200,
             'headers'   => ['Content-Type' => 'text/html'],
-            'timestamp' => time() - 10,
+            'timestamp' => Time::now()->getTimestamp() - 10,
         ];
         cache()->save($cacheKey, $cachedData, 3600);
 
@@ -124,7 +127,7 @@ final class CacheTest extends CIUnitTestCase
             'body'      => 'Custom cached content',
             'status'    => 200,
             'headers'   => [],
-            'timestamp' => time(),
+            'timestamp' => Time::now()->getTimestamp(),
         ];
         cache()->save('my_custom_key', $cachedData, 3600);
 


### PR DESCRIPTION
**Description**
This PR replaces `time()` calls with the mockable `Time` class to decouple router cache from the current time.

See: https://github.com/codeigniter4/CodeIgniter4/pull/9874#issuecomment-3726196493

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
