### PR TITLE
fix: `SUPPORTPATH` may be undefined in some contexts

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -124,7 +124,7 @@ abstract class CIUnitTestCase extends TestCase
      *
      * @var string
      */
-    protected $basePath = 'tests/_support/Database';
+    protected $basePath = TESTPATH . '_support/Database';
 
     /**
      * The namespace(s) to help us find the migration classes.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
I'm updating `phpstan-codeigniter` to cater `4.7` and I'm hitting the following test error:
```
An error occurred inside PHPUnit.

Message:  Undefined constant "CodeIgniter\Test\SUPPORTPATH"
Location: /Users/paul/Workspace/phpstan-codeigniter/vendor/codeigniter4/codeigniter4/system/Test/CIUnitTestCase.php:127
```

Upon investigation, I learned that `util_bootstrap.php` defines `SUPPORTPATH` if `tests/_support/` is an existing directory. Since I'm not using that, consequentially, that constant is not defined. This forces anyone to define a `tests/_support/` directory which I find rather unconventional. However, my point is the class should not have a constant expression that relies on a conditionally defined constant.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
