### PR TITLE
fix: make seeder to respect database group

### DIFF
--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -27,7 +27,7 @@ class Seeder
     /**
      * The name of the database group to use.
      *
-     * @var non-empty-string
+     * @var non-empty-string|null
      */
     protected $DBGroup;
 

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -92,10 +92,16 @@ class Seeder
 
         $this->config = &$config;
 
-        $db ??= Database::connect($this->DBGroup);
-
-        $this->db    = $db;
-        $this->forge = Database::forge($this->DBGroup);
+        if (isset($this->DBGroup)) {
+            $this->db    = Database::connect($this->DBGroup);
+            $this->forge = Database::forge($this->DBGroup);
+        } elseif ($db instanceof BaseConnection) {
+            $this->db    = $db;
+            $this->forge = Database::forge($db);
+        } else {
+            $this->db    = Database::connect($config->defaultGroup);
+            $this->forge = Database::forge($config->defaultGroup);
+        }
     }
 
     /**
@@ -145,7 +151,7 @@ class Seeder
         }
 
         /** @var Seeder $seeder */
-        $seeder = new $class($this->config);
+        $seeder = new $class($this->config, $this->db);
         $seeder->setSilent($this->silent)->run();
 
         unset($seeder);

--- a/tests/_support/Database/Seeds/SeederWithDBGroup.php
+++ b/tests/_support/Database/Seeds/SeederWithDBGroup.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Database\Seeds;
+
+use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Seeder;
+
+/**
+ * Test seeder with explicit DBGroup set.
+ */
+class SeederWithDBGroup extends Seeder
+{
+    protected $DBGroup = 'tests';
+
+    /**
+     * Store the connection used during run() for testing.
+     */
+    public static ?BaseConnection $lastConnection = null;
+
+    public function run(): void
+    {
+        self::$lastConnection = $this->db;
+    }
+
+    /**
+     * Expose the db connection for testing.
+     */
+    public function getDatabase(): BaseConnection
+    {
+        return $this->db;
+    }
+
+    /**
+     * Reset static state for testing.
+     */
+    public static function reset(): void
+    {
+        self::$lastConnection = null;
+    }
+}

--- a/tests/_support/Database/Seeds/SeederWithoutDBGroup.php
+++ b/tests/_support/Database/Seeds/SeederWithoutDBGroup.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Database\Seeds;
+
+use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Seeder;
+
+/**
+ * Test seeder without DBGroup set (should inherit connection).
+ */
+class SeederWithoutDBGroup extends Seeder
+{
+    /**
+     * Store the connection used during run() for testing.
+     */
+    public static ?BaseConnection $lastConnection = null;
+
+    public function run(): void
+    {
+        self::$lastConnection = $this->db;
+    }
+
+    /**
+     * Expose the db connection for testing.
+     */
+    public function getDatabase(): BaseConnection
+    {
+        return $this->db;
+    }
+
+    /**
+     * Reset static state for testing.
+     */
+    public static function reset(): void
+    {
+        self::$lastConnection = null;
+    }
+}

--- a/tests/system/Database/DatabaseSeederTest.php
+++ b/tests/system/Database/DatabaseSeederTest.php
@@ -30,10 +30,6 @@ final class DatabaseSeederTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        $instances = Database::getConnections();
-        unset($instances['default']);
-        $this->setPrivateProperty(Database::class, 'instances', $instances);
-
         SeederWithDBGroup::reset();
         SeederWithoutDBGroup::reset();
     }
@@ -75,11 +71,10 @@ final class DatabaseSeederTest extends CIUnitTestCase
     public function testSeederWithDBGroupUsesOwnConnection(): void
     {
         $config = new Database();
-        $db     = Database::connect('default');
+        $db     = Database::connect('tests', false);
 
         $seeder = new SeederWithDBGroup($config, $db);
 
-        // Should use 'tests' connection (from DBGroup), not the passed 'default' connection
         $testsDb = Database::connect('tests');
         $this->assertSame($testsDb, $seeder->getDatabase());
         $this->assertNotSame($db, $seeder->getDatabase());
@@ -119,7 +114,7 @@ final class DatabaseSeederTest extends CIUnitTestCase
     public function testCallChildWithDBGroupUsesOwnConnection(): void
     {
         $config = new Database();
-        $db     = Database::connect('default');
+        $db     = Database::connect('tests', false);
 
         $seeder = new Seeder($config, $db);
         $seeder->setSilent(true)->call(SeederWithDBGroup::class);

--- a/tests/system/Database/DatabaseSeederTest.php
+++ b/tests/system/Database/DatabaseSeederTest.php
@@ -17,13 +17,27 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
 use Faker\Generator;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Database\Seeds\SeederWithDBGroup;
+use Tests\Support\Database\Seeds\SeederWithoutDBGroup;
 
 /**
  * @internal
  */
-#[Group('Others')]
+#[Group('DatabaseLive')]
 final class DatabaseSeederTest extends CIUnitTestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $instances = Database::getConnections();
+        unset($instances['default']);
+        $this->setPrivateProperty(Database::class, 'instances', $instances);
+
+        SeederWithDBGroup::reset();
+        SeederWithoutDBGroup::reset();
+    }
+
     public function testInstantiateNoSeedPath(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -56,5 +70,62 @@ final class DatabaseSeederTest extends CIUnitTestCase
 
         $seeder = new Seeder(new Database());
         $seeder->call('');
+    }
+
+    public function testSeederWithDBGroupUsesOwnConnection(): void
+    {
+        $config = new Database();
+        $db     = Database::connect('default');
+
+        $seeder = new SeederWithDBGroup($config, $db);
+
+        // Should use 'tests' connection (from DBGroup), not the passed 'default' connection
+        $testsDb = Database::connect('tests');
+        $this->assertSame($testsDb, $seeder->getDatabase());
+        $this->assertNotSame($db, $seeder->getDatabase());
+    }
+
+    public function testSeederWithoutDBGroupUsesPassedConnection(): void
+    {
+        $config = new Database();
+        $db     = Database::connect('tests');
+
+        $seeder = new SeederWithoutDBGroup($config, $db);
+
+        $this->assertSame($db, $seeder->getDatabase());
+    }
+
+    public function testSeederWithoutDBGroupAndNoConnectionUsesDefault(): void
+    {
+        $config = new Database();
+
+        $seeder = new SeederWithoutDBGroup($config);
+
+        $defaultDb = Database::connect($config->defaultGroup);
+        $this->assertSame($defaultDb, $seeder->getDatabase());
+    }
+
+    public function testCallPassesConnectionToChildSeeder(): void
+    {
+        $config = new Database();
+        $db     = Database::connect('tests');
+
+        $seeder = new Seeder($config, $db);
+        $seeder->setSilent(true)->call(SeederWithoutDBGroup::class);
+
+        $this->assertSame($db, SeederWithoutDBGroup::$lastConnection);
+    }
+
+    public function testCallChildWithDBGroupUsesOwnConnection(): void
+    {
+        $config = new Database();
+        $db     = Database::connect('default');
+
+        $seeder = new Seeder($config, $db);
+        $seeder->setSilent(true)->call(SeederWithDBGroup::class);
+
+        $testsDb = Database::connect('tests');
+        $this->assertSame($testsDb, SeederWithDBGroup::$lastConnection);
+        $this->assertNotSame($db, SeederWithDBGroup::$lastConnection);
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.5.rst
+++ b/user_guide_src/source/changelogs/v4.6.5.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Database:** Fixed a bug where ``Seeder::call()`` did not pass the database connection to child seeders, causing them to use the default connection instead of the one specified via ``Database::seeder('group')``.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/dbmgmt/seeds.rst
+++ b/user_guide_src/source/dbmgmt/seeds.rst
@@ -44,6 +44,29 @@ You can grab a copy of the main seeder through the database config class:
 
 .. literalinclude:: seeds/004.php
 
+Using a Different Database Group
+================================
+
+You can specify a different database group when obtaining a seeder instance by passing the group name
+as the first parameter:
+
+.. literalinclude:: seeds/005.php
+
+When using ``call()`` to run child seeders, the database connection is automatically passed to them.
+This means child seeders will use the same connection as the parent seeder, unless they explicitly
+specify their own ``$DBGroup`` property.
+
+If a seeder needs to always use a specific database group regardless of the parent seeder's connection,
+you can set the ``$DBGroup`` property in the seeder class:
+
+.. literalinclude:: seeds/006.php
+
+The connection priority is:
+
+1. If ``$DBGroup`` is set in the seeder class, that connection group is always used
+2. Otherwise, if a connection was passed (from parent seeder via ``call()`` or from ``Database::seeder()``), it is used
+3. Otherwise, the default connection group is used
+
 Command Line Seeding
 ====================
 

--- a/user_guide_src/source/dbmgmt/seeds/005.php
+++ b/user_guide_src/source/dbmgmt/seeds/005.php
@@ -1,0 +1,4 @@
+<?php
+
+$seeder = \Config\Database::seeder('group_name');
+$seeder->call('TestSeeder');

--- a/user_guide_src/source/dbmgmt/seeds/006.php
+++ b/user_guide_src/source/dbmgmt/seeds/006.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    protected $DBGroup = 'group_name';
+
+    public function run()
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
**Description**
This PR fixes the `Seeder` behavior where calling `Database::seeder('tests')` did not respect the selected database group and always used the default one.

With this change, seeders are now handled in the same way as migrations, ensuring the correct database group is used.

Fixes #9885

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
