### PR TITLE
refactor: Clean up mysqli transactions

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -625,8 +625,6 @@ class Connection extends BaseConnection
      */
     protected function _transBegin(): bool
     {
-        $this->connID->autocommit(false);
-
         return $this->connID->begin_transaction();
     }
 
@@ -635,13 +633,7 @@ class Connection extends BaseConnection
      */
     protected function _transCommit(): bool
     {
-        if ($this->connID->commit()) {
-            $this->connID->autocommit(true);
-
-            return true;
-        }
-
-        return false;
+        return $this->connID->commit();
     }
 
     /**
@@ -649,12 +641,6 @@ class Connection extends BaseConnection
      */
     protected function _transRollback(): bool
     {
-        if ($this->connID->rollback()) {
-            $this->connID->autocommit(true);
-
-            return true;
-        }
-
-        return false;
+        return $this->connID->rollback();
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
Turning off autocommit and starting a transaction makes very little sense. Unless you expect users to issue manual commit statements, the begin transaction is sufficient. Comparing it to the other Connection classes, only the mysqli one does that, which can be considered a bug. If you would like to allow the user to issue manual commit statements then keep only autocommit and remove begin and commit. Additionally, these functions always return true (because of exception mode) and so the if statements and return statements are not meaningful. 

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
