### PR TITLE
chore: pin phpstan to 2.1.34

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "mikey179/vfsstream": "^1.6.12",
         "nexusphp/tachycardia": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "2.1.34",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpcov": "^9.0.2 || ^10.0",
         "phpunit/phpunit": "^10.5.16 || ^11.2",


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**

Latest phpstan 2.1.35 cause various rector errors, this PR pin PHPStan 2.1.34 until we get it working compatible code.

Ref related PRs to show it:

- 2.1.34 (working) : https://github.com/rectorphp/rector-downgrade-php/pull/359
- 2.1.35 (not working): https://github.com/rectorphp/rector-downgrade-php/pull/360
- https://github.com/rectorphp/rector-src/pull/7847

The issue already reported to PHPStan tho:

- https://github.com/phpstan/phpstan/issues/13992

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
