### PR TITLE
fix: ensure CSP nonces are Base64 encoded

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -303,7 +303,7 @@ class ContentSecurityPolicy
     public function getStyleNonce(): string
     {
         if ($this->styleNonce === null) {
-            $this->styleNonce = bin2hex(random_bytes(12));
+            $this->styleNonce = base64_encode(random_bytes(12));
             $this->styleSrc[] = 'nonce-' . $this->styleNonce;
         }
 
@@ -316,7 +316,7 @@ class ContentSecurityPolicy
     public function getScriptNonce(): string
     {
         if ($this->scriptNonce === null) {
-            $this->scriptNonce = bin2hex(random_bytes(12));
+            $this->scriptNonce = base64_encode(random_bytes(12));
             $this->scriptSrc[] = 'nonce-' . $this->scriptNonce;
         }
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -731,7 +731,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $cliDetection        = Kint::$cli_detection;
         Kint::$cli_detection = false;
 
-        $this->expectOutputRegex('/<script class="kint-rich-script" nonce="[0-9a-z]{24}">/u');
+        $this->expectOutputRegex('/<script class="kint-rich-script" nonce="[a-zA-Z0-9+\/-_]+[=]{0,2}">/u');
         d('string');
 
         // Restore settings
@@ -754,7 +754,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         Kint::$cli_detection = false;
 
-        $this->expectOutputRegex('/<style class="kint-rich-style" nonce="[0-9a-z]{24}">/u');
+        $this->expectOutputRegex('/<style class="kint-rich-style" nonce="[a-zA-Z0-9+\/-_]+[=]{0,2}">/u');
         trace();
     }
 

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -578,18 +578,20 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
     {
         $this->prepare();
 
-        $nonce = $this->csp->getScriptNonce();
-
-        $this->assertMatchesRegularExpression('/\A[0-9a-z]{24}\z/', $nonce);
+        $this->assertMatchesRegularExpression(
+            '/\A[a-zA-Z0-9+\/-_]+[=]{0,2}\z/',
+            $this->csp->getScriptNonce(),
+        );
     }
 
     public function testGetStyleNonce(): void
     {
         $this->prepare();
 
-        $nonce = $this->csp->getStyleNonce();
-
-        $this->assertMatchesRegularExpression('/\A[0-9a-z]{24}\z/', $nonce);
+        $this->assertMatchesRegularExpression(
+            '/\A[a-zA-Z0-9+\/-_]+[=]{0,2}\z/',
+            $this->csp->getStyleNonce(),
+        );
     }
 
     #[PreserveGlobalState(false)]

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -337,7 +337,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $html   = script_tag($target);
 
         $this->assertMatchesRegularExpression(
-            '!<script nonce="\w+?" src="http://site.com/js/mystyles.js".*?>!u',
+            '!<script nonce="[a-zA-Z0-9+\/-_]+[=]{0,2}" src="http://site.com/js/mystyles.js".*?>!u',
             $html,
         );
 

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -493,7 +493,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         $html = safe_mailto('foo@example.jp', 'Foo');
 
-        $this->assertMatchesRegularExpression('/<script .*?nonce="\w+?".*?>/u', $html);
+        $this->assertMatchesRegularExpression('/<script .*?nonce="[a-zA-Z0-9+\/]+[=]{0,2}".*?>/u', $html);
     }
 
     /**

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -107,7 +107,7 @@ final class HoneypotTest extends CIUnitTestCase
         $this->response->setBody('<head></head><body><form></form></body>');
         $this->honeypot->attachHoneypot($this->response);
 
-        $regex = '!<head><style nonce="[0-9a-f]+">#hpc { display:none }</style></head><body><form><div style="display:none" id="hpc"><label>Fill This Field</label><input type="text" name="honeypot" value=""></div></form></body>!u';
+        $regex = '!<head><style nonce="[a-zA-Z0-9+\/-_]+[=]{0,2}">#hpc { display:none }</style></head><body><form><div style="display:none" id="hpc"><label>Fill This Field</label><input type="text" name="honeypot" value=""></div></form></body>!u';
         $this->assertMatchesRegularExpression($regex, $this->response->getBody());
     }
 

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -151,7 +151,7 @@ final class ParserPluginTest extends CIUnitTestCase
         $template = 'aaa {+ csp_script_nonce +} bbb';
 
         $this->assertMatchesRegularExpression(
-            '/aaa nonce="[0-9a-z]{24}" bbb/',
+            '/aaa nonce="[a-zA-Z0-9+\/-_]+[=]{0,2}" bbb/',
             $this->parser->renderString($template),
         );
     }

--- a/user_guide_src/source/changelogs/v4.6.5.rst
+++ b/user_guide_src/source/changelogs/v4.6.5.rst
@@ -31,6 +31,7 @@ Bugs Fixed
 **********
 
 - **Database:** Fixed a bug where ``Seeder::call()`` did not pass the database connection to child seeders, causing them to use the default connection instead of the one specified via ``Database::seeder('group')``.
+- **HTTP:** Updated the Content Security Policy nonce generation to use base64 encoding instead of hexadecimal, ensuring compatibility with CSP specifications.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
Per [CSP specification](https://www.w3.org/TR/CSP3/#grammardef-hash-source), CSP nonces are base64 encoded values appended to `nonce-`. In the framework's implementation, we're using `bin2hex` which results in hexadecimal encoded values instead.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
