### PR TITLE
feat: add database session timezone configuration

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -49,6 +49,7 @@ class Database extends Config
             'datetime' => 'Y-m-d H:i:s',
             'time'     => 'H:i:s',
         ],
+        'timezone' => false,
     ];
 
     //    /**
@@ -98,6 +99,7 @@ class Database extends Config
     //            'datetime' => 'Y-m-d H:i:s',
     //            'time'     => 'H:i:s',
     //        ],
+    //        'timezone'   => false,
     //    ];
 
     //    /**
@@ -155,6 +157,7 @@ class Database extends Config
     //            'datetime' => 'Y-m-d H:i:s',
     //            'time'     => 'H:i:s',
     //        ],
+    //        'timezone'   => false,
     //    ];
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\Database;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
+use CodeIgniter\I18n\Time;
+use Exception;
 use stdClass;
 use Stringable;
 use Throwable;
@@ -155,6 +157,20 @@ abstract class BaseConnection implements ConnectionInterface
      * @var string
      */
     protected $DBCollat = '';
+
+    /**
+     * Database session timezone
+     *
+     * false    = Don't set timezone (default, backward compatible)
+     * true     = Automatically sync with app timezone
+     * string   = Specific timezone (offset or named timezone)
+     *
+     * Named timezones (e.g., 'America/New_York') will be automatically
+     * converted to offsets (e.g., '-05:00') for database compatibility.
+     *
+     * @var bool|string
+     */
+    protected $timezone = false;
 
     /**
      * Swap Prefix
@@ -1913,6 +1929,68 @@ abstract class BaseConnection implements ConnectionInterface
     protected function _enableForeignKeyChecks()
     {
         return '';
+    }
+
+    /**
+     * Converts a named timezone to an offset string.
+     *
+     * Converts timezone identifiers (e.g., 'America/New_York') to offset strings
+     * (e.g., '-05:00' or '-04:00' depending on DST). This is useful because not all
+     * databases have timezone tables loaded, but all support offset notation.
+     *
+     * @param string $timezone Named timezone (e.g., 'America/New_York', 'UTC', 'Europe/Paris')
+     *
+     * @return string Offset string (e.g., '+00:00', '-05:00', '+01:00')
+     */
+    protected function convertTimezoneToOffset(string $timezone): string
+    {
+        // If it's already an offset, return as-is
+        if (preg_match('/^[+-]\d{2}:\d{2}$/', $timezone)) {
+            return $timezone;
+        }
+
+        try {
+            $offset = Time::now($timezone)->getOffset();
+
+            // Convert offset seconds to +-HH:MM format
+            $hours   = (int) ($offset / 3600);
+            $minutes = abs((int) (($offset % 3600) / 60));
+
+            return sprintf('%+03d:%02d', $hours, $minutes);
+        } catch (Exception $e) {
+            // If timezone conversion fails, log and return UTC
+            log_message('error', "Invalid timezone '{$timezone}': {$e->getMessage()}. Falling back to UTC.");
+
+            return '+00:00';
+        }
+    }
+
+    /**
+     * Gets the timezone string to use for database session.
+     *
+     * Handles the timezone configuration logic:
+     * - false: Don't set timezone (returns null)
+     * - true: Auto-sync with app timezone from config
+     * - string: Use specific timezone (converts named timezones to offsets)
+     *
+     * @return string|null The timezone offset string, or null if timezone should not be set
+     */
+    protected function getSessionTimezone(): ?string
+    {
+        if ($this->timezone === false) {
+            return null;
+        }
+
+        // Auto-sync with app timezone
+        if ($this->timezone === true) {
+            $appConfig = config('App');
+            $timezone  = $appConfig->appTimezone ?? 'UTC';
+        } else {
+            // Use specific timezone from config
+            $timezone = $this->timezone;
+        }
+
+        return $this->convertTimezoneToOffset($timezone);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1959,7 +1959,7 @@ abstract class BaseConnection implements ConnectionInterface
             return sprintf('%+03d:%02d', $hours, $minutes);
         } catch (Exception $e) {
             // If timezone conversion fails, log and return UTC
-            log_message('error', "Invalid timezone '{$timezone}': {$e->getMessage()}. Falling back to UTC.");
+            log_message('error', "Invalid timezone '{$timezone}'. Falling back to UTC. {$e->getMessage()}.");
 
             return '+00:00';
         }

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -145,9 +145,19 @@ class Connection extends BaseConnection
 
         $func = $persistent ? 'oci_pconnect' : 'oci_connect';
 
-        return ($this->charset === '')
+        $this->connID = ($this->charset === '')
             ? $func($this->username, $this->password, $this->DSN)
             : $func($this->username, $this->password, $this->DSN, $this->charset);
+
+        // Set session timezone if configured and connection is successful
+        if ($this->connID !== false) {
+            $timezoneOffset = $this->getSessionTimezone();
+            if ($timezoneOffset !== null) {
+                $this->simpleQuery("ALTER SESSION SET TIME_ZONE = '{$timezoneOffset}'");
+            }
+        }
+
+        return $this->connID;
     }
 
     /**

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -97,6 +97,12 @@ class Connection extends BaseConnection
 
                 throw new DatabaseException($error);
             }
+
+            // Set session timezone if configured
+            $timezoneOffset = $this->getSessionTimezone();
+            if ($timezoneOffset !== null) {
+                $this->simpleQuery("SET TIME ZONE '{$timezoneOffset}'");
+            }
         }
 
         return $this->connID;

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -385,6 +385,7 @@ final class BaseConnectionTest extends CIUnitTestCase
 
         $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('Invalid/Timezone');
         $this->assertSame('+00:00', $result);
+        $this->assertLogged('error', "Invalid timezone 'Invalid/Timezone'. Falling back to UTC. DateTimeZone::__construct(): Unknown or bad timezone (Invalid/Timezone).");
     }
 
     public function testGetSessionTimezoneWithFalse(): void

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -345,4 +345,93 @@ final class BaseConnectionTest extends CIUnitTestCase
             'with dots' => ['com.sitedb.web', '"com.sitedb.web"'],
         ];
     }
+
+    public function testConvertTimezoneToOffsetWithOffset(): void
+    {
+        $db = new MockConnection($this->options);
+
+        // Offset strings should be returned as-is
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('+05:30');
+        $this->assertSame('+05:30', $result);
+
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('-08:00');
+        $this->assertSame('-08:00', $result);
+
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('+00:00');
+        $this->assertSame('+00:00', $result);
+    }
+
+    public function testConvertTimezoneToOffsetWithNamedTimezone(): void
+    {
+        $db = new MockConnection($this->options);
+
+        // UTC should always be +00:00
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('UTC');
+        $this->assertSame('+00:00', $result);
+
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('America/New_York');
+        $this->assertContains($result, ['-05:00', '-04:00']); // EST/EDT
+
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('Europe/Paris');
+        $this->assertContains($result, ['+01:00', '+02:00']); // CET/CEST
+
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('Asia/Tokyo');
+        $this->assertSame('+09:00', $result); // JST (no DST)
+    }
+
+    public function testConvertTimezoneToOffsetWithInvalidTimezone(): void
+    {
+        $db = new MockConnection($this->options);
+
+        $result = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')('Invalid/Timezone');
+        $this->assertSame('+00:00', $result);
+    }
+
+    public function testGetSessionTimezoneWithFalse(): void
+    {
+        $options             = $this->options;
+        $options['timezone'] = false;
+        $db                  = new MockConnection($options);
+
+        $result = $this->getPrivateMethodInvoker($db, 'getSessionTimezone')();
+        $this->assertNull($result);
+    }
+
+    public function testGetSessionTimezoneWithTrue(): void
+    {
+        $options             = $this->options;
+        $options['timezone'] = true;
+        $db                  = new MockConnection($options);
+
+        $result = $this->getPrivateMethodInvoker($db, 'getSessionTimezone')();
+        $this->assertSame('+00:00', $result); // UTC = +00:00
+    }
+
+    public function testGetSessionTimezoneWithSpecificOffset(): void
+    {
+        $options             = $this->options;
+        $options['timezone'] = '+05:30';
+        $db                  = new MockConnection($options);
+
+        $result = $this->getPrivateMethodInvoker($db, 'getSessionTimezone')();
+        $this->assertSame('+05:30', $result);
+    }
+
+    public function testGetSessionTimezoneWithSpecificNamedTimezone(): void
+    {
+        $options             = $this->options;
+        $options['timezone'] = 'America/Chicago';
+        $db                  = new MockConnection($options);
+
+        $result = $this->getPrivateMethodInvoker($db, 'getSessionTimezone')();
+        $this->assertContains($result, ['-06:00', '-05:00']);
+    }
+
+    public function testGetSessionTimezoneWithoutTimezoneKey(): void
+    {
+        $db = new MockConnection($this->options);
+
+        $result = $this->getPrivateMethodInvoker($db, 'getSessionTimezone')();
+        $this->assertNull($result);
+    }
 }

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Database\Live;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Exceptions\RuntimeException;
-use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
@@ -188,7 +187,7 @@ final class ConnectTest extends CIUnitTestCase
 
         $appConfig      = config('App');
         $appTimezone    = $appConfig->appTimezone ?? 'UTC';
-        $expectedOffset = $this->convertTimezoneToOffset($appTimezone);
+        $expectedOffset = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')($appTimezone);
 
         $this->assertSame($expectedOffset, $timezone);
     }
@@ -220,23 +219,5 @@ final class ConnectTest extends CIUnitTestCase
             default:
                 throw new RuntimeException("Unsupported driver: {$driver}");
         }
-    }
-
-    /**
-     * Helper method to convert timezone to offset (mirrors BaseConnection logic)
-     */
-    private function convertTimezoneToOffset(string $timezone): string
-    {
-        if (preg_match('/^[+-]\d{2}:\d{2}$/', $timezone)) {
-            return $timezone;
-        }
-
-        $time   = Time::now($timezone);
-        $offset = $time->getOffset();
-
-        $hours   = (int) ($offset / 3600);
-        $minutes = abs((int) (($offset % 3600) / 60));
-
-        return sprintf('%+03d:%02d', $hours, $minutes);
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -51,6 +51,8 @@ Forge
 Others
 ------
 
+- Added new ``timezone`` option to connection array in ``Config\Database`` config. This ensures consistent timestamps between model operations and database functions like ``NOW()``. Supported drivers: **MySQLi**, **Postgre**, and **OCI8**. See :ref:`database-config-timezone` for details.
+
 Model
 =====
 

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -191,6 +191,12 @@ Description of Values
                  This can be used since v4.5.0, and you can get the value, e.g., ``$db->dateFormat['datetime']``.
                  Currently, the database drivers do not use these values directly,
                  but :ref:`Model <model-saving-dates>` uses them.
+**timezone**     (``MySQLi``, ``Postgre``, and ``OCI8`` only) The database session timezone.
+                 * ``false``       - Don't set session timezone (default, backward compatible)
+                 * ``true``        - Automatically sync with ``App::$appTimezone``
+                 * ``string``      - Specific timezone offset (e.g., ``'+05:30'``) or named timezone (e.g., ``'America/New_York'``)
+                 Named timezones are automatically converted to offsets for database compatibility.
+                 See :ref:`database-config-timezone` for details.
 ================ ===========================================================================================================
 
 .. _DateTime format: https://www.php.net/manual/en/datetime.format.php
@@ -229,3 +235,21 @@ MySQLi driver accepts an array with the following options:
 * ``ssl_capath`` - Path to a directory containing trusted CA certificates in PEM format
 * ``ssl_cipher`` - List of *allowed* ciphers to be used for the encryption, separated by colons (``:``)
 * ``ssl_verify`` - true/false (boolean) - Whether to verify the server certificate or not
+
+.. _database-config-timezone:
+
+timezone
+--------
+
+.. versionadded:: 4.8.0
+
+Synchronizes the database session timezone with your application timezone to ensure consistent
+timestamps between model operations and database functions like ``NOW()``.
+
+.. note:: Modern database environments usually have UTC set by default, so this option may not be needed
+    in most cases.
+
+Accepts ``false`` (default, don't set), ``true`` (auto-sync with ``App::$appTimezone``),
+or a timezone string (e.g., ``'+05:30'`` or ``'America/New_York'``).
+
+Named timezones are automatically converted to offsets for compatibility.


### PR DESCRIPTION
**Description**
This PR adds a new timezone configuration option to synchronize database session timezone with application timezone, ensuring consistent timestamps between model operations and database functions like `NOW()`.                                
                                                                                                                                                                                                                                         
Modern database environments usually have UTC set by default, so this option may not be needed in most cases. This feature is primarily useful when working with legacy systems, shared hosting environments, etc., where the database timezone cannot be controlled at the server level.

Not supported drivers:

- SQLite3 - has no concept of session-level timezone configuration. All datetime functions operate in UTC by default.
- SQLSRV - does not support session-level timezone changes. It derives datetime from the operating system and cannot be changed at the session or instance level.

Closes #9903

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
