### PR TITLE
chore: fix misleading Imagick error message

### DIFF
--- a/system/Language/en/Images.php
+++ b/system/Language/en/Images.php
@@ -21,7 +21,7 @@ return [
     'pngNotSupported'        => 'PNG images are not supported.',
     'webpNotSupported'       => 'WEBP images are not supported.',
     'fileNotSupported'       => 'The supplied file is not a supported image type.',
-    'unsupportedImageCreate' => 'Your server does not support the GD function required to process this type of image.',
+    'unsupportedImageCreate' => 'Your server does not support the required functionality to process this type of image.',
     'jpgOrPngRequired'       => 'The image resize protocol specified in your preferences only works with JPEG or PNG image types.',
     'rotateUnsupported'      => 'Image rotation does not appear to be supported by your server.',
     'imageProcessFailed'     => 'Image processing failed. Please verify that your server supports the chosen protocol and that the path to your image library is correct.',

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -18,6 +18,8 @@ BREAKING
 Message Changes
 ***************
 
+- Updated ``Images.unsupportedImageCreate``.
+
 *******
 Changes
 *******

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -38,6 +38,10 @@ The available Handlers are as follows:
 
 .. note:: The ImageMagick handler requires the imagick extension.
 
+.. note::
+   On Windows, the ImageMagick handler requires **absolute file paths** when
+   loading images (for example, using ``WRITEPATH`` or ``FCPATH``).
+
 *******************
 Processing an Image
 *******************


### PR DESCRIPTION
**Description**
This PR fixes the exception message that is shared between image handlers.

Closes #9927

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
