### PR TITLE
fix: Fixed relative paths in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,45 +44,45 @@ $RECYCLE.BIN/
 .env
 .vagrant
 Vagrantfile
-user_guide_src/venv/
+/user_guide_src/venv/
 .python-version
-user_guide_src/.python-version
+/user_guide_src/.python-version
 
 #-------------------------
 # Temporary Files
 #-------------------------
-writable/cache/*
-!writable/cache/index.html
+/writable/cache/*
+!/writable/cache/index.html
 
-writable/logs/*
-!writable/logs/index.html
+/writable/logs/*
+!/writable/logs/index.html
 
-writable/session/*
-!writable/session/index.html
+/writable/session/*
+!/writable/session/index.html
 
-writable/uploads/*
-!writable/uploads/index.html
+/writable/uploads/*
+!/writable/uploads/index.html
 
-writable/debugbar/*
-!writable/debugbar/index.html
+/writable/debugbar/*
+!/writable/debugbar/index.html
 
-writable/**/*.db
-writable/**/*.sqlite
+/writable/**/*.db
+/writable/**/*.sqlite
 
 php_errors.log
 
 #-------------------------
 # User Guide Temp Files
 #-------------------------
-user_guide_src/build/*
+/user_guide_src/build/*
 
 #-------------------------
 # Test Files
 #-------------------------
-tests/coverage*
+/tests/coverage*
 
 # Don't save phpunit under version control.
-phpunit
+/phpunit
 
 #-------------------------
 # Composer

--- a/.gitignore
+++ b/.gitignore
@@ -105,14 +105,14 @@ _modules/*
 *.iml
 
 # Netbeans
-nbproject/
-build/
-nbbuild/
-dist/
-nbdist/
-nbactions.xml
-nb-configuration.xml
-.nb-gradle/
+/nbproject/
+/build/
+/nbbuild/
+/dist/
+/nbdist/
+/nbactions.xml
+/nb-configuration.xml
+/.nb-gradle/
 
 # Sublime Text
 *.tmlanguage.cache

--- a/admin/framework/.gitignore
+++ b/admin/framework/.gitignore
@@ -48,38 +48,38 @@ Vagrantfile
 #-------------------------
 # Temporary Files
 #-------------------------
-writable/cache/*
-!writable/cache/index.html
+/writable/cache/*
+!/writable/cache/index.html
 
-writable/logs/*
-!writable/logs/index.html
+/writable/logs/*
+!/writable/logs/index.html
 
-writable/session/*
-!writable/session/index.html
+/writable/session/*
+!/writable/session/index.html
 
-writable/uploads/*
-!writable/uploads/index.html
+/writable/uploads/*
+!/writable/uploads/index.html
 
-writable/debugbar/*
-!writable/debugbar/index.html
+/writable/debugbar/*
+!/writable/debugbar/index.html
 
 php_errors.log
 
 #-------------------------
 # User Guide Temp Files
 #-------------------------
-user_guide_src/build/*
-user_guide_src/cilexer/build/*
-user_guide_src/cilexer/dist/*
-user_guide_src/cilexer/pycilexer.egg-info/*
+/user_guide_src/build/*
+/user_guide_src/cilexer/build/*
+/user_guide_src/cilexer/dist/*
+/user_guide_src/cilexer/pycilexer.egg-info/*
 
 #-------------------------
 # Test Files
 #-------------------------
-tests/coverage*
+/tests/coverage*
 
 # Don't save phpunit under version control.
-phpunit
+/phpunit
 
 #-------------------------
 # Composer

--- a/admin/starter/.gitignore
+++ b/admin/starter/.gitignore
@@ -48,38 +48,38 @@ Vagrantfile
 #-------------------------
 # Temporary Files
 #-------------------------
-writable/cache/*
-!writable/cache/index.html
+/writable/cache/*
+!/writable/cache/index.html
 
-writable/logs/*
-!writable/logs/index.html
+/writable/logs/*
+!/writable/logs/index.html
 
-writable/session/*
-!writable/session/index.html
+/writable/session/*
+!/writable/session/index.html
 
-writable/uploads/*
-!writable/uploads/index.html
+/writable/uploads/*
+!/writable/uploads/index.html
 
-writable/debugbar/*
-!writable/debugbar/index.html
+/writable/debugbar/*
+!/writable/debugbar/index.html
 
 php_errors.log
 
 #-------------------------
 # User Guide Temp Files
 #-------------------------
-user_guide_src/build/*
-user_guide_src/cilexer/build/*
-user_guide_src/cilexer/dist/*
-user_guide_src/cilexer/pycilexer.egg-info/*
+/user_guide_src/build/*
+/user_guide_src/cilexer/build/*
+/user_guide_src/cilexer/dist/*
+/user_guide_src/cilexer/pycilexer.egg-info/*
 
 #-------------------------
 # Test Files
 #-------------------------
-tests/coverage*
+/tests/coverage*
 
 # Don't save phpunit under version control.
-phpunit
+/phpunit
 
 #-------------------------
 # Composer


### PR DESCRIPTION
**Description**
Fixes #9873 

- It is rare case when **phpunit** is located at the root. The previous rule ignored everything - (sub)directories and files - this is incorrect.

- Additionally updated paths that are always located at the root (**writable**, **user_guide_src**)

- **vendor/** can be in internal subfolders - left as it is

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
