### PR TITLE
fix: escape CSP nonce attributes in JSON responses

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -898,13 +898,17 @@ class ContentSecurityPolicy
             return;
         }
 
+        // Escape quotes for JSON responses to prevent corrupting the JSON body
+        $jsonEscape = str_contains($response->getHeaderLine('Content-Type'), 'json');
+
         // Replace style and script placeholders with nonces
         $pattern = sprintf('/(%s|%s)/', preg_quote($this->styleNonceTag, '/'), preg_quote($this->scriptNonceTag, '/'));
 
-        $body = preg_replace_callback($pattern, function ($match): string {
+        $body = preg_replace_callback($pattern, function ($match) use ($jsonEscape): string {
             $nonce = $match[0] === $this->styleNonceTag ? $this->getStyleNonce() : $this->getScriptNonce();
+            $attr  = 'nonce="' . $nonce . '"';
 
-            return "nonce=\"{$nonce}\"";
+            return $jsonEscape ? str_replace('"', '\\"', $attr) : $attr;
         }, $body);
 
         $response->setBody($body);

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -16,9 +16,12 @@ namespace CodeIgniter\Debug;
 use App\Controllers\Home;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Exceptions\RuntimeException;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\IniTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
+use Config\App;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
@@ -40,6 +43,8 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         parent::setUp();
 
         $this->handler = new ExceptionHandler(new ExceptionsConfig());
+
+        $this->resetServices();
     }
 
     public function testDetermineViewsPageNotFoundException(): void
@@ -385,5 +390,33 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         $this->assertTrue($sanitizeData(true));
         $this->assertFalse($sanitizeData(false));
         $this->assertNull($sanitizeData(null));
+    }
+
+    public function testHandleJsonResponseWithCSPEnabledProducesValidJson(): void
+    {
+        $config             = config(App::class);
+        $config->CSPEnabled = true;
+
+        /** @var IncomingRequest $request */
+        $request = service('incomingrequest', $config, false);
+        $request->setHeader('accept', 'application/json');
+        $response = new Response($config);
+        $response->pretend();
+
+        $exception = new RuntimeException('Test exception');
+
+        ob_start();
+        $this->handler->handle($exception, $request, $response, 500, EXIT_ERROR);
+        $output = ob_get_clean();
+
+        $json = json_decode($output);
+        $this->assertNotNull($json);
+
+        // Nonce placeholders must not appear in the output
+        $this->assertStringNotContainsString('{csp-style-nonce}', (string) $output);
+        $this->assertStringNotContainsString('{csp-script-nonce}', (string) $output);
+
+        // The nonce attribute values should be properly JSON-escaped
+        $this->assertMatchesRegularExpression('/nonce=\\\\"[A-Za-z0-9+\/=]+\\\\"/', $output);
     }
 }

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -16,12 +16,9 @@ namespace CodeIgniter\Debug;
 use App\Controllers\Home;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Exceptions\RuntimeException;
-use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\IniTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
-use Config\App;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
@@ -390,33 +387,5 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         $this->assertTrue($sanitizeData(true));
         $this->assertFalse($sanitizeData(false));
         $this->assertNull($sanitizeData(null));
-    }
-
-    public function testHandleJsonResponseWithCSPEnabledProducesValidJson(): void
-    {
-        $config             = config(App::class);
-        $config->CSPEnabled = true;
-
-        /** @var IncomingRequest $request */
-        $request = service('incomingrequest', $config, false);
-        $request->setHeader('accept', 'application/json');
-        $response = new Response($config);
-        $response->pretend();
-
-        $exception = new RuntimeException('Test exception');
-
-        ob_start();
-        $this->handler->handle($exception, $request, $response, 500, EXIT_ERROR);
-        $output = ob_get_clean();
-
-        $json = json_decode($output);
-        $this->assertNotNull($json);
-
-        // Nonce placeholders must not appear in the output
-        $this->assertStringNotContainsString('{csp-style-nonce}', (string) $output);
-        $this->assertStringNotContainsString('{csp-script-nonce}', (string) $output);
-
-        // The nonce attribute values should be properly JSON-escaped
-        $this->assertMatchesRegularExpression('/nonce=\\\\"[A-Za-z0-9+\/=]+\\\\"/', $output);
     }
 }

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -951,8 +951,9 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
 
         $this->assertMatchesRegularExpression('/<style nonce="[A-Za-z0-9+\/=]+">/', $result);
         $this->assertMatchesRegularExpression('/<script nonce="[A-Za-z0-9+\/=]+">/', $result);
-        $this->assertStringNotContainsString('{csp-style-nonce}', (string) $result);
-        $this->assertStringNotContainsString('{csp-script-nonce}', (string) $result);
+        $this->assertIsString($result);
+        $this->assertStringNotContainsString('{csp-style-nonce}', $result);
+        $this->assertStringNotContainsString('{csp-script-nonce}', $result);
     }
 
     #[PreserveGlobalState(false)]
@@ -968,6 +969,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $result = $this->response->getBody();
         $parsed = json_decode($result, true);
 
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertNotNull($parsed);
         $this->assertMatchesRegularExpression('/nonce="[A-Za-z0-9+\/=]+"/', $parsed['html']);
     }

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -937,4 +937,38 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $this->assertNotContains('report-uri http://example.com/csp/reports', $directives);
         $this->assertNotContains('report-to default', $directives);
     }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testGenerateNoncesReplacesPlaceholdersInHtml(): void
+    {
+        $body = '<style {csp-style-nonce}>body{}</style><script {csp-script-nonce}>alert(1)</script>';
+
+        $this->response->setBody($body);
+        $this->csp->finalize($this->response);
+
+        $result = $this->response->getBody();
+
+        $this->assertMatchesRegularExpression('/<style nonce="[A-Za-z0-9+\/=]+">/', $result);
+        $this->assertMatchesRegularExpression('/<script nonce="[A-Za-z0-9+\/=]+">/', $result);
+        $this->assertStringNotContainsString('{csp-style-nonce}', (string) $result);
+        $this->assertStringNotContainsString('{csp-script-nonce}', (string) $result);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testGenerateNoncesEscapesQuotesInJsonResponse(): void
+    {
+        $data = json_encode(['html' => '<script {csp-script-nonce}>alert(1)</script>']);
+
+        $this->response->setContentType('application/json');
+        $this->response->setBody($data);
+        $this->csp->finalize($this->response);
+
+        $result = $this->response->getBody();
+        $parsed = json_decode($result, true);
+
+        $this->assertNotNull($parsed);
+        $this->assertMatchesRegularExpression('/nonce="[A-Za-z0-9+\/=]+"/', $parsed['html']);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -30,7 +30,7 @@ Deprecations
 Bugs Fixed
 **********
 
-- **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
+- **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` produces corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
This PR fixes a bug where `ContentSecurityPolicy::generateNonces()` could corrupt the JSON response body.

The method now detects `application/json` Content-Type responses and properly escapes double quotes in nonce attribute replacements, preventing malformed JSON.

Fixes #9934

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
