### PR TITLE
fix: Upgrade from 4.6

### DIFF
--- a/admin/starter/app/Config/Paths.php
+++ b/admin/starter/app/Config/Paths.php
@@ -75,4 +75,16 @@ class Paths
      * is used when no value is provided to `Services::renderer()`.
      */
     public string $viewDirectory = __DIR__ . '/../Views';
+
+    /**
+     * ---------------------------------------------------------------
+     * ENVIRONMENT DIRECTORY NAME
+     * ---------------------------------------------------------------
+     *
+     * This variable must contain the name of the directory where
+     * the .env file is located.
+     * Please consider security implications when changing this
+     * value - the directory should not be publicly accessible.
+     */
+    public string $envDirectory = __DIR__ . '/../../';
 }

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -191,11 +191,11 @@ Next Minor Version
 If you want to use the next minor version branch, after using the ``builds`` command
 edit **composer.json** manually.
 
-If you try the ``4.7`` branch, change the version to ``4.7.x-dev``::
+If you try the ``4.8`` branch, change the version to ``4.8.x-dev``::
 
     "require": {
         "php": "^8.2",
-        "codeigniter4/codeigniter4": "4.7.x-dev"
+        "codeigniter4/codeigniter4": "4.8.x-dev"
     },
 
 And run ``composer update`` to sync your vendor

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -7,6 +7,12 @@ upgrading from.
 
 See also :doc:`./backward_compatibility_notes`.
 
+The manual mentions changes to **project space**. To perform the update,
+you need to compare the original files from **vendor/codeigniter4/framework** or from the ZIP archive and make changes.
+
+Example, the original **app/Config/App.php** will be located in **vendor/codeigniter4/framework/app/Config/App.php**.
+Alternatively, replace it with a new file and add your previous lines.
+
 .. note:: If you don't know what version of CodeIgniter you are currently running,
     you can get it from :ref:`the Debug Toolbar <the-debug-toolbar>`,
     or simply echo the constant ``\CodeIgniter\CodeIgniter::CI_VERSION``.


### PR DESCRIPTION
**Description**
Fixes #9933 

- Updated **Paths.php** for appstarteer
- Added a note for a better understanding of how to update the configuration when updating

Question: We stopped paying attention to the updates section. We rely on the changelog. Thus, the section has lost its relevance. 
We need to specify all the changes in the code (excluding PHPDoc) in **update_*.rst**? Now it contains partial notes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
