### PR TITLE
feat: Add `builds next` option

### DIFF
--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -124,6 +124,10 @@ the existing content.
       * Set the date to format `Release Date: January 31, 2021`
     * Update **phpdoc.dist.xml** with the new `<title>CodeIgniter v4.x API</title>`
       and `<version number="4.x.x">`
+    * Update **admin/starter/builds**:
+      * Set `define('LATEST_RELEASE', '^4.x')`
+      * Set `define('NEXT_MINOR', '^4.y-dev')`.
+      * If the major version changes, you need to manually change to `define('NEXT_MINOR', '^5.0-dev')`.
     * Commit the changes with `Prep for 4.x.x release`
 * [ ] Create a new PR from `release-4.x.x` to `develop`:
   * Title: `Prep for 4.x.x release`

--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -126,8 +126,8 @@ the existing content.
       and `<version number="4.x.x">`
     * Update **admin/starter/builds**:
       * Set `define('LATEST_RELEASE', '^4.x')`
-      * Set `define('NEXT_MINOR', '^4.y-dev')`.
-      * If the major version changes, you need to manually change to `define('NEXT_MINOR', '^5.0-dev')`.
+      * Set `define('NEXT_MINOR', '4.y-dev')`.
+      * If the major version changes, you need to manually change to `define('NEXT_MINOR', '5.0-dev')`.
     * Commit the changes with `Prep for 4.x.x release`
 * [ ] Create a new PR from `release-4.x.x` to `develop`:
   * Title: `Prep for 4.x.x release`

--- a/admin/prepare-release.php
+++ b/admin/prepare-release.php
@@ -25,7 +25,7 @@ $versionParts = explode('.', $version);
 $minor        = $versionParts[0] . '.' . $versionParts[1];
 
 // Note: Major version will change someday (4.x..5.x) - update manually.
-$nextVersion = $versionParts[0] . '.' . $versionParts[1] + 1;
+$nextMinor = $versionParts[0] . '.' . $versionParts[1] + 1;
 
 // Creates a branch for release.
 system('git switch develop');
@@ -80,7 +80,7 @@ replace_file_content(
 replace_file_content(
     './admin/starter/builds',
     '/define\(\'NEXT_MINOR\', \'.*?\'\);/mu',
-    "define('NEXT_MINOR', '^{$nextVersion}-dev');",
+    "define('NEXT_MINOR', '{$nextMinor}-dev');",
 );
 
 // Commits

--- a/admin/prepare-release.php
+++ b/admin/prepare-release.php
@@ -24,6 +24,9 @@ $version      = $argv[1]; // e.g., '4.4.3'
 $versionParts = explode('.', $version);
 $minor        = $versionParts[0] . '.' . $versionParts[1];
 
+// Note: Major version will change someday (4.x..5.x) - update manually.
+$nextVersion = $versionParts[0] . '.' . $versionParts[1] + 1;
+
 // Creates a branch for release.
 system('git switch develop');
 system('git branch -D release-' . $version);
@@ -66,6 +69,18 @@ replace_file_content(
     "./user_guide_src/source/changelogs/v{$version}.rst",
     '/^Release Date: .*/mu',
     "Release Date: {$date}",
+);
+
+// Update appstarter/builds script
+replace_file_content(
+    './admin/starter/builds',
+    '/define\(\'LATEST_RELEASE\', \'.*?\'\);/mu',
+    "define('LATEST_RELEASE', '^{$minor}');",
+);
+replace_file_content(
+    './admin/starter/builds',
+    '/define\(\'NEXT_MINOR\', \'.*?\'\);/mu',
+    "define('NEXT_MINOR', '^{$nextVersion}-dev');",
 );
 
 // Commits

--- a/admin/prepare-release.php
+++ b/admin/prepare-release.php
@@ -80,7 +80,7 @@ replace_file_content(
 replace_file_content(
     './admin/starter/builds',
     '/define\(\'NEXT_MINOR\', \'.*?\'\);/mu',
-    "define('NEXT_MINOR', '{$nextMinor}-dev');",
+    "define('NEXT_MINOR', '^{$nextMinor}-dev');",
 );
 
 // Commits

--- a/admin/starter/builds
+++ b/admin/starter/builds
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 
-define('LATEST_RELEASE', '^4.0');
+define('LATEST_RELEASE', '^4.7');
+define('DEVELOP_BRANCH', 'dev-develop');
+define('NEXT_MINOR', '^4.8-dev');
 define('GITHUB_URL', 'https://github.com/codeigniter4/codeigniter4');
 
 /*
@@ -11,17 +13,17 @@ define('GITHUB_URL', 'https://github.com/codeigniter4/codeigniter4');
  * Use this script to toggle the CodeIgniter dependency between the
  * latest stable release and the most recent development update.
  *
- * Usage: php builds [release|development]
+ * Usage: php builds [release|development|next]
  */
 
+$branch = $argv[1] ?? '';
+
 // Determine the requested stability
-if (empty($argv[1]) || ! in_array($argv[1], ['release', 'development'], true)) {
-    echo 'Usage: php builds [release|development]' . PHP_EOL;
+if ($branch === '' || ! in_array($branch, ['release', 'development', 'next'], true)) {
+    echo 'Usage: php builds [release|development|next]' . PHP_EOL;
 
     exit;
 }
-
-$dev = $argv[1] === 'development';
 
 $modified = [];
 
@@ -36,7 +38,7 @@ if (is_file($file)) {
         $array = json_decode($contents, true);
 
         if (is_array($array)) {
-            if ($dev) {
+            if ($branch !== 'release') {
                 $array['minimum-stability'] = 'dev';
                 $array['prefer-stable']     = true;
                 $array['repositories'] ??= [];
@@ -57,7 +59,7 @@ if (is_file($file)) {
                     ];
                 }
 
-                $array['require']['codeigniter4/codeigniter4'] = 'dev-develop';
+                $array['require']['codeigniter4/codeigniter4'] = $branch === 'next' ? NEXT_MINOR : DEVELOP_BRANCH;
                 unset($array['require']['codeigniter4/framework']);
             } else {
                 unset($array['minimum-stability']);
@@ -70,7 +72,7 @@ if (is_file($file)) {
                         }
                     }
 
-                    if (empty($array['repositories'])) {
+                    if ($array['repositories'] === []) {
                         unset($array['repositories']);
                     }
                 }
@@ -100,7 +102,7 @@ foreach ($files as $file) {
     if (is_file($file)) {
         $contents = file_get_contents($file);
 
-        if ($dev) {
+        if ($branch !== 'release') {
             $contents = str_replace('vendor/codeigniter4/framework', 'vendor/codeigniter4/codeigniter4', $contents);
         } else {
             $contents = str_replace('vendor/codeigniter4/codeigniter4', 'vendor/codeigniter4/framework', $contents);
@@ -120,6 +122,7 @@ if ($modified === []) {
     foreach ($modified as $file) {
         echo " * {$file}" . PHP_EOL;
     }
-
-    echo 'Run `composer update` to sync changes with your vendor folder.' . PHP_EOL;
 }
+
+echo 'Run `composer update` to sync changes with your vendor folder.' . PHP_EOL;
+echo 'Don\'t forget to update the project files in app folder from "vendor/codeigniter4/*/app/".' . PHP_EOL;

--- a/admin/starter/builds
+++ b/admin/starter/builds
@@ -3,7 +3,7 @@
 
 define('LATEST_RELEASE', '^4.7');
 define('DEVELOP_BRANCH', 'dev-develop');
-define('NEXT_MINOR', '^4.8-dev');
+define('NEXT_MINOR', '4.8-dev');
 define('GITHUB_URL', 'https://github.com/codeigniter4/codeigniter4');
 
 /*

--- a/admin/starter/builds
+++ b/admin/starter/builds
@@ -3,7 +3,7 @@
 
 define('LATEST_RELEASE', '^4.7');
 define('DEVELOP_BRANCH', 'dev-develop');
-define('NEXT_MINOR', '4.8-dev');
+define('NEXT_MINOR', '^4.8-dev');
 define('GITHUB_URL', 'https://github.com/codeigniter4/codeigniter4');
 
 /*

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -27,8 +27,8 @@ Changes
 Others
 ======
 
-- **builds:** In the ``builds`` script (for ``codeigniter4/appstarter``), the ``next`` option has been added
-  to switch ``4.7.x`` to the next minor version ``4.8-dev``. See :ref:`Latest Dev<switch-to-dev-version>`.
+- **builds:** In the ``builds`` script (for ``codeigniter4/appstarter``), the ``next`` argument has been added
+  to switch ``4.7.x`` to the next minor version ``4.8.x-dev``. See :ref:`Latest Dev<switch-to-dev-version>`.
 
 ************
 Deprecations

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -24,6 +24,12 @@ Message Changes
 Changes
 *******
 
+Others
+======
+
+- **builds:** In the ``builds`` script (for ``codeigniter4/appstarter``), the ``next`` option has been added
+  to switch ``4.7.x`` to the next minor version ``4.8-dev``. See :ref:`Latest Dev<switch-to-dev-version>`.
+
 ************
 Deprecations
 ************

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -158,6 +158,8 @@ Folders in your project after set up:
 - app, public, tests, writable
 - vendor/codeigniter4/framework/system
 
+.. _switch-to-dev-version:
+
 Latest Dev
 ----------
 
@@ -168,6 +170,9 @@ for a developer who is willing to live with the latest unreleased changes, which
 The `development user guide <https://codeigniter4.github.io/CodeIgniter4/>`_ is accessible online.
 Note that this differs from the released user guide, and will pertain to the
 develop branch explicitly.
+
+.. note:: You should not rely on the version of the framework in your project
+    - the development code may contain an incorrect number.
 
 Update for Latest Dev
 ^^^^^^^^^^^^^^^^^^^^^
@@ -188,15 +193,11 @@ files if necessary.
 Next Minor Version
 ^^^^^^^^^^^^^^^^^^
 
-If you want to use the next minor version branch, after using the ``builds`` command
-edit **composer.json** manually.
+If you want to use the next minor version branch:
 
-If you try the ``4.8`` branch, change the version to ``4.8.x-dev``::
+.. code-block:: console
 
-    "require": {
-        "php": "^8.2",
-        "codeigniter4/codeigniter4": "4.8.x-dev"
-    },
+    php builds next
 
 And run ``composer update`` to sync your vendor
 folder with the latest target build. Then, check the Upgrading Guide


### PR DESCRIPTION
**Description**
- A small improvement to upgrade to the dev branch: **4.7 | dev-develop |  4.8-dev**

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
