### PR TITLE
fix: Update pip packages

### DIFF
--- a/user_guide_src/requirements.txt
+++ b/user_guide_src/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=5.3.0,<6.0.0
+sphinx>=8.0.0,<9.0.0
 sphinxcontrib-phpdomain>=0.11.0
 docutils>=0.19
-sphinx-rtd-theme>=2.0.0,<3.0.0
+sphinx-rtd-theme>=3.0.0
 jinja2>=3.1.3,<4.0.0

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -79,7 +79,6 @@ html_theme_options = {
 	'navigation_depth': 2,
 	'includehidden': False,
 	'logo_only': True,
-	'display_version': False,
 }
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,


### PR DESCRIPTION
**Description**
- For Python 3.13, there are deleted packages for sphinx (imghdr). Upgrading the version should fix the errors

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
