### PR TITLE
fix: initialize standalone toolbar

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -8,8 +8,7 @@ var ciDebugBar = {
     icon: null,
 
     init: function () {
-        // Standalone debugbar pages do not have #toolbarContainer, use body as fallback.
-        this.toolbarContainer = document.getElementById("toolbarContainer") || document.body;
+        this.toolbarContainer = document.getElementById("toolbarContainer");
         this.toolbar = document.getElementById("debug-bar");
         this.icon = document.getElementById("debug-icon");
 

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -8,7 +8,8 @@ var ciDebugBar = {
     icon: null,
 
     init: function () {
-        this.toolbarContainer = document.getElementById("toolbarContainer");
+        // Standalone debugbar pages do not have #toolbarContainer, use body as fallback.
+        this.toolbarContainer = document.getElementById("toolbarContainer") || document.body;
         this.toolbar = document.getElementById("debug-bar");
         this.icon = document.getElementById("debug-icon");
 

--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -28,6 +28,7 @@ use CodeIgniter\View\Parser;
 <script id="toolbar_js">
     var ciSiteURL = "<?= rtrim(site_url(), '/') ?>"
     <?= file_get_contents(__DIR__ . '/toolbar.js') ?>
+    <?= file_get_contents(__DIR__ . '/toolbarstandalone.js') ?>
 </script>
 <div id="debug-icon" class="debug-bar-ndisplay">
     <a id="debug-icon-link">

--- a/system/Debug/Toolbar/Views/toolbarstandalone.js
+++ b/system/Debug/Toolbar/Views/toolbarstandalone.js
@@ -9,22 +9,54 @@ if (! document.getElementById('debugbar_loader')) {
                 return;
             }
 
-            localStorage.setItem('debugbar-time', time);
-            localStorage.setItem('debugbar-time-new', time);
             window.location.href = ciSiteURL + '?debugbar_time=' + time;
         };
     }
 
     (function () {
+        function ensureToolbarContainer(icon, toolbar) {
+            let toolbarContainer = document.getElementById('toolbarContainer');
+
+            if (toolbarContainer) {
+                return;
+            }
+
+            toolbarContainer = document.createElement('div');
+            toolbarContainer.setAttribute('id', 'toolbarContainer');
+
+            if (icon) {
+                toolbarContainer.appendChild(icon);
+            }
+
+            if (toolbar) {
+                toolbarContainer.appendChild(toolbar);
+            }
+
+            document.body.appendChild(toolbarContainer);
+        }
+
         function initStandaloneToolbar() {
             if (typeof ciDebugBar !== 'object') {
                 return;
             }
 
-            if (! document.getElementById('debug-bar') || ! document.getElementById('debug-icon')) {
+            const icon = document.getElementById('debug-icon');
+            const toolbar = document.getElementById('debug-bar');
+
+            if (! toolbar || ! icon) {
                 return;
             }
 
+            const currentTime = new URLSearchParams(window.location.search).get('debugbar_time');
+
+            if (currentTime && ! isNaN(currentTime)) {
+                if (! localStorage.getItem('debugbar-time')) {
+                    localStorage.setItem('debugbar-time', currentTime);
+                }
+                localStorage.setItem('debugbar-time-new', currentTime);
+            }
+
+            ensureToolbarContainer(icon, toolbar);
             ciDebugBar.init();
         }
 

--- a/system/Debug/Toolbar/Views/toolbarstandalone.js
+++ b/system/Debug/Toolbar/Views/toolbarstandalone.js
@@ -1,0 +1,37 @@
+/*
+ * Bootstrap for standalone Debug Toolbar pages (?debugbar_time=...).
+ */
+
+if (! document.getElementById('debugbar_loader')) {
+    if (typeof loadDoc !== 'function') {
+        window.loadDoc = function (time) {
+            if (isNaN(time)) {
+                return;
+            }
+
+            localStorage.setItem('debugbar-time', time);
+            localStorage.setItem('debugbar-time-new', time);
+            window.location.href = ciSiteURL + '?debugbar_time=' + time;
+        };
+    }
+
+    (function () {
+        function initStandaloneToolbar() {
+            if (typeof ciDebugBar !== 'object') {
+                return;
+            }
+
+            if (! document.getElementById('debug-bar') || ! document.getElementById('debug-icon')) {
+                return;
+            }
+
+            ciDebugBar.init();
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initStandaloneToolbar, false);
+        } else {
+            initStandaloneToolbar();
+        }
+    })();
+}

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -34,6 +34,7 @@ Bugs Fixed
 
 - **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` produces corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
+- **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug where the Debug Toolbar loaded from `?debugbar_time=...` (via `Debugbar-Link` headers for AJAX/non-HTML responses) appeared but was not interactive.

The fix adds a dedicated standalone bootstrap script for this mode, while keeping `toolbar.js` focused on core toolbar behavior. It also provides a `loadDoc()` fallback only when the main loader flow is absent, so the History section keeps working on standalone toolbar pages.

Fixes #9949

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
