### PR TITLE
refactor: add strict types to tests

### DIFF
--- a/.php-cs-fixer.tests.php
+++ b/.php-cs-fixer.tests.php
@@ -30,6 +30,7 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
+    'declare_strict_types'  => true,
     'phpdoc_to_return_type' => true,
     'void_return'           => true,
 ];

--- a/tests/_support/Commands/Foobar.php
+++ b/tests/_support/Commands/Foobar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/utils/src/PhpCsFixer/CodeIgniterRuleCustomisationPolicy.php
+++ b/utils/src/PhpCsFixer/CodeIgniterRuleCustomisationPolicy.php
@@ -33,6 +33,10 @@ final class CodeIgniterRuleCustomisationPolicy implements RuleCustomisationPolic
         $normalisedStrEndsWith = static fn (string $haystack, string $needle): bool => str_ends_with(str_replace('\\', '/', $haystack), $needle);
 
         return [
+            'declare_strict_types' => static fn (SplFileInfo $file): bool => ! $normalisedStrEndsWith(
+                $file->getPathname(),
+                '/tests/system/Debug/ExceptionsTest.php',
+            ),
             'native_function_casing' => static fn (SplFileInfo $file): bool => ! $normalisedStrEndsWith(
                 $file->getPathname(),
                 '/tests/system/Database/Live/PreparedQueryTest.php',


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
Looks like rector is adding strict types to tests. This sets up php-cs-fixer to do the same.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
