### PR TITLE
refactor: remove `$config` in `Response` constructor

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -198,6 +198,8 @@ class Services extends BaseService
      * The CURL Request class acts as a simple HTTP client for interacting
      * with other servers, typically through APIs.
      *
+     * @todo v4.8.0 Remove $config parameter since unused
+     *
      * @return CURLRequest
      */
     public static function curlrequest(array $options = [], ?ResponseInterface $response = null, ?App $config = null, bool $getShared = true)
@@ -207,7 +209,7 @@ class Services extends BaseService
         }
 
         $config ??= config(App::class);
-        $response ??= new Response($config);
+        $response ??= new Response();
 
         return new CURLRequest(
             $config,
@@ -576,6 +578,8 @@ class Services extends BaseService
     /**
      * The Response class models an HTTP response.
      *
+     * @todo v4.8.0 Remove $config parameter since unused
+     *
      * @return ResponseInterface
      */
     public static function response(?App $config = null, bool $getShared = true)
@@ -584,13 +588,13 @@ class Services extends BaseService
             return static::getSharedInstance('response', $config);
         }
 
-        $config ??= config(App::class);
-
-        return new Response($config);
+        return new Response();
     }
 
     /**
      * The Redirect class provides nice way of working with redirects.
+     *
+     * @todo v4.8.0 Remove $config parameter since unused
      *
      * @return RedirectResponse
      */
@@ -600,8 +604,7 @@ class Services extends BaseService
             return static::getSharedInstance('redirectresponse', $config);
         }
 
-        $config ??= config(App::class);
-        $response = new RedirectResponse($config);
+        $response = new RedirectResponse();
         $response->setProtocolVersion(AppServices::get('request')->getProtocolVersion());
 
         return $response;

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -115,7 +115,11 @@ class CURLRequest extends OutgoingRequest
      *  - timeout
      *  - any other request options to use as defaults.
      *
+     * @todo v4.8.0 Remove $config parameter since unused
+     *
      * @param array<string, mixed> $options
+     *
+     * @phpstan-ignore-next-line constructor.unusedParameter
      */
     public function __construct(App $config, URI $uri, ?ResponseInterface $response = null, array $options = [])
     {
@@ -125,7 +129,7 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct(Method::GET, $uri);
 
-        $this->responseOrig = $response ?? new Response($config);
+        $this->responseOrig = $response ?? new Response();
         // Remove the default Content-Type header.
         $this->responseOrig->removeHeader('Content-Type');
 

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Exceptions\DownloadException;
 use CodeIgniter\Files\File;
-use Config\App;
 use Config\Mimes;
 
 /**
@@ -64,12 +63,9 @@ class DownloadResponse extends Response implements NonBufferedResponseInterface
      */
     protected $statusCode = 200;
 
-    /**
-     * Constructor.
-     */
     public function __construct(string $filename, bool $setMime)
     {
-        parent::__construct(config(App::class));
+        parent::__construct();
 
         $this->filename = $filename;
         $this->setMime  = $setMime;

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
-use Config\App;
 use Config\Cookie as CookieConfig;
 
 /**
@@ -141,16 +140,7 @@ class Response extends Message implements ResponseInterface
      */
     protected $pretend = false;
 
-    /**
-     * Constructor
-     *
-     * @param App $config
-     *
-     * @todo Recommend removing reliance on config injection
-     *
-     * @deprecated 4.5.0 The param $config is no longer used.
-     */
-    public function __construct($config) // @phpstan-ignore-line
+    public function __construct()
     {
         // Default to a non-caching page.
         // Also ensures that a Cache-control header exists.

--- a/system/HTTP/SSEResponse.php
+++ b/system/HTTP/SSEResponse.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\HTTP;
 
 use Closure;
-use Config\App;
 use JsonException;
 
 /**
@@ -31,7 +30,7 @@ class SSEResponse extends Response implements NonBufferedResponseInterface
      */
     public function __construct(private readonly Closure $callback)
     {
-        parent::__construct(config(App::class));
+        parent::__construct();
     }
 
     /**

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -112,7 +112,7 @@ final class ResponseTraitTest extends CIUnitTestCase
                 null,
                 new UserAgent(),
             );
-            $this->response = new MockResponse($config);
+            $this->response = new MockResponse();
         }
 
         $headers = array_merge(['Accept' => 'text/html'], $userHeaders);
@@ -625,7 +625,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->createCookieConfig();
 
         $request  = new MockIncomingRequest($config, new SiteURI($config), null, new UserAgent());
-        $response = new MockResponse($config);
+        $response = new MockResponse();
 
         $controller = new class ($request, $response) {
             use ResponseTrait;

--- a/tests/system/Cache/ResponseCacheTest.php
+++ b/tests/system/Cache/ResponseCacheTest.php
@@ -87,7 +87,7 @@ final class ResponseCacheTest extends CIUnitTestCase
     {
         $pageCache = $this->createResponseCache();
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setHeader('ETag', 'abcd1234');
         $response->setBody('The response body.');
 
@@ -97,7 +97,7 @@ final class ResponseCacheTest extends CIUnitTestCase
         ));
 
         // Check cache with a request with the same URI path.
-        $cachedResponse = $pageCache->get($this->createIncomingRequest('foo/bar'), new Response(new App()));
+        $cachedResponse = $pageCache->get($this->createIncomingRequest('foo/bar'), new Response());
         $this->assertInstanceOf(ResponseInterface::class, $cachedResponse);
         $this->assertSame('The response body.', $cachedResponse->getBody());
         $this->assertSame('abcd1234', $cachedResponse->getHeaderLine('ETag'));
@@ -105,14 +105,14 @@ final class ResponseCacheTest extends CIUnitTestCase
         // Check cache with a request with the same URI path and different query string.
         $cachedResponse = $pageCache->get(
             $this->createIncomingRequest('foo/bar', ['foo' => 'bar', 'bar' => 'baz']),
-            new Response(new App()),
+            new Response(),
         );
         $this->assertInstanceOf(ResponseInterface::class, $cachedResponse);
         $this->assertSame('The response body.', $cachedResponse->getBody());
         $this->assertSame('abcd1234', $cachedResponse->getHeaderLine('ETag'));
 
         // Check cache with another request with the different URI path.
-        $cachedResponse = $pageCache->get($this->createIncomingRequest('another'), new Response(new App()));
+        $cachedResponse = $pageCache->get($this->createIncomingRequest('another'), new Response());
         $this->assertNotInstanceOf(ResponseInterface::class, $cachedResponse);
     }
 
@@ -120,14 +120,14 @@ final class ResponseCacheTest extends CIUnitTestCase
     {
         $pageCache = $this->createResponseCache();
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setStatusCode(432, 'Foo Bar');
         $response->setBody('The response body.');
 
         $this->assertTrue($pageCache->make($this->createIncomingRequest('foo/bar'), $response));
 
         // Check cached response status
-        $cachedResponse = $pageCache->get($this->createIncomingRequest('foo/bar'), new Response(new App()));
+        $cachedResponse = $pageCache->get($this->createIncomingRequest('foo/bar'), new Response());
         $this->assertInstanceOf(ResponseInterface::class, $cachedResponse);
         $this->assertSame(432, $cachedResponse->getStatusCode());
         $this->assertSame('Foo Bar', $cachedResponse->getReasonPhrase());
@@ -143,7 +143,7 @@ final class ResponseCacheTest extends CIUnitTestCase
 
         $request = $this->createIncomingRequest('foo/bar', ['foo' => 'bar', 'bar' => 'baz']);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setHeader('ETag', 'abcd1234');
         $response->setBody('The response body.');
 
@@ -152,7 +152,7 @@ final class ResponseCacheTest extends CIUnitTestCase
         // Check cache with a request with the same URI path and same query string.
         $cachedResponse = $pageCache->get(
             $this->createIncomingRequest('foo/bar', ['foo' => 'bar', 'bar' => 'baz']),
-            new Response(new App()),
+            new Response(),
         );
         $this->assertInstanceOf(ResponseInterface::class, $cachedResponse);
         $this->assertSame('The response body.', $cachedResponse->getBody());
@@ -161,12 +161,12 @@ final class ResponseCacheTest extends CIUnitTestCase
         // Check cache with a request with the same URI path and different query string.
         $cachedResponse = $pageCache->get(
             $this->createIncomingRequest('foo/bar', ['xfoo' => 'bar', 'bar' => 'baz']),
-            new Response(new App()),
+            new Response(),
         );
         $this->assertNotInstanceOf(ResponseInterface::class, $cachedResponse);
 
         // Check cache with another request with the different URI path.
-        $cachedResponse = $pageCache->get($this->createIncomingRequest('another'), new Response(new App()));
+        $cachedResponse = $pageCache->get($this->createIncomingRequest('another'), new Response());
         $this->assertNotInstanceOf(ResponseInterface::class, $cachedResponse);
     }
 
@@ -174,7 +174,7 @@ final class ResponseCacheTest extends CIUnitTestCase
     {
         $pageCache = $this->createResponseCache();
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setBody('The response body.');
 
         $this->assertTrue($pageCache->make($this->createIncomingRequest('foo/bar'), $response));
@@ -182,7 +182,7 @@ final class ResponseCacheTest extends CIUnitTestCase
         // Check cache with a request with the same URI path and different HTTP method
         $cachedResponse = $pageCache->get(
             $this->createIncomingRequest('foo/bar')->withMethod('POST'),
-            new Response(new App()),
+            new Response(),
         );
         $this->assertNotInstanceOf(ResponseInterface::class, $cachedResponse);
     }
@@ -191,18 +191,18 @@ final class ResponseCacheTest extends CIUnitTestCase
     {
         $pageCache = $this->createResponseCache();
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setBody('The response body.');
 
         $this->assertTrue($pageCache->make($this->createCLIRequest(['foo', 'bar']), $response));
 
         // Check cache with a request with the same params.
-        $cachedResponse = $pageCache->get($this->createCLIRequest(['foo', 'bar']), new Response(new App()));
+        $cachedResponse = $pageCache->get($this->createCLIRequest(['foo', 'bar']), new Response());
         $this->assertInstanceOf(ResponseInterface::class, $cachedResponse);
         $this->assertSame('The response body.', $cachedResponse->getBody());
 
         // Check cache with another request with the different params.
-        $cachedResponse = $pageCache->get($this->createCLIRequest(['baz']), new Response(new App()));
+        $cachedResponse = $pageCache->get($this->createCLIRequest(['baz']), new Response());
         $this->assertNotInstanceOf(ResponseInterface::class, $cachedResponse);
     }
 
@@ -217,7 +217,7 @@ final class ResponseCacheTest extends CIUnitTestCase
 
         $request = $this->createIncomingRequest('foo/bar');
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setHeader('ETag', 'abcd1234');
         $response->setBody('The response body.');
 
@@ -229,7 +229,7 @@ final class ResponseCacheTest extends CIUnitTestCase
         $mockCache->save($cacheKey, 'Invalid data');
 
         // Check cache with a request with the same URI path.
-        $pageCache->get($request, new Response(new App()));
+        $pageCache->get($request, new Response());
     }
 
     public function testInvalidCacheError(): void
@@ -243,7 +243,7 @@ final class ResponseCacheTest extends CIUnitTestCase
 
         $request = $this->createIncomingRequest('foo/bar');
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setHeader('ETag', 'abcd1234');
         $response->setBody('The response body.');
 
@@ -255,6 +255,6 @@ final class ResponseCacheTest extends CIUnitTestCase
         $mockCache->save($cacheKey, serialize(['a' => '1']));
 
         // Check cache with a request with the same URI path.
-        $pageCache->get($request, new Response(new App()));
+        $pageCache->get($request, new Response());
     }
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -448,7 +448,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
             'zibble' => 'fritz',
         ]);
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $response->withInput();
 
         $this->assertSame('bar', old('foo')); // regular parameter
@@ -482,7 +482,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
             'zibble' => serialize('fritz'),
         ]);
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $response->withInput();
 
         // serialized parameters are only HTML-escaped.
@@ -522,7 +522,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $superglobals->setGetArray([]);
         $superglobals->setPostArray(['location' => $locations]);
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $response->withInput();
 
         $this->assertSame($locations, old('location'));

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -46,7 +46,6 @@ use CodeIgniter\Typography\Typography;
 use CodeIgniter\Validation\Validation;
 use CodeIgniter\View\Cell;
 use CodeIgniter\View\Parser;
-use Config\App;
 use Config\Database as DatabaseConfig;
 use Config\Exceptions;
 use Config\Security as SecurityConfig;
@@ -334,11 +333,11 @@ final class ServicesTest extends CIUnitTestCase
     #[RunInSeparateProcess]
     public function testMockInjection(): void
     {
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $response = service('response');
         $this->assertInstanceOf(MockResponse::class, $response);
 
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $response2 = service('response');
         $this->assertInstanceOf(MockResponse::class, $response2);
 
@@ -354,13 +353,13 @@ final class ServicesTest extends CIUnitTestCase
     #[RunInSeparateProcess]
     public function testReset(): void
     {
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $response = service('response');
         $this->assertInstanceOf(MockResponse::class, $response);
 
         Services::reset(true); // reset mocks & shared instances
 
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $response2 = service('response');
         $this->assertInstanceOf(MockResponse::class, $response2);
 
@@ -371,7 +370,7 @@ final class ServicesTest extends CIUnitTestCase
     #[RunInSeparateProcess]
     public function testResetSingle(): void
     {
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         Services::injectMock('security', new MockSecurity(new SecurityConfig()));
         $response = service('response');
         $security = service('security');
@@ -391,7 +390,7 @@ final class ServicesTest extends CIUnitTestCase
 
     public function testResetSingleCaseInsensitive(): void
     {
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $someService = service('response');
         $this->assertInstanceOf(MockResponse::class, $someService);
 
@@ -404,7 +403,7 @@ final class ServicesTest extends CIUnitTestCase
     #[RunInSeparateProcess]
     public function testResetServiceCache(): void
     {
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $response = service('response');
         $this->assertInstanceOf(MockResponse::class, $response);
         service('response')->setStatusCode(200);

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -59,7 +59,7 @@ final class ControllerTest extends CIUnitTestCase
 
         $config         = new App();
         $this->request  = new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
-        $this->response = new Response($config);
+        $this->response = new Response();
         $this->logger   = service('logger');
     }
 

--- a/tests/system/Filters/PageCacheTest.php
+++ b/tests/system/Filters/PageCacheTest.php
@@ -48,21 +48,21 @@ final class PageCacheTest extends CIUnitTestCase
 
         $request = $this->createRequest();
 
-        $response200 = new Response(new App());
+        $response200 = new Response();
         $response200->setStatusCode(200);
         $response200->setBody('Success');
 
         $result = $filter->after($request, $response200);
         $this->assertInstanceOf(Response::class, $result);
 
-        $response404 = new Response(new App());
+        $response404 = new Response();
         $response404->setStatusCode(404);
         $response404->setBody('Not Found');
 
         $result = $filter->after($request, $response404);
         $this->assertInstanceOf(Response::class, $result);
 
-        $response500 = new Response(new App());
+        $response500 = new Response();
         $response500->setStatusCode(500);
         $response500->setBody('Server Error');
 
@@ -79,7 +79,7 @@ final class PageCacheTest extends CIUnitTestCase
         $request = $this->createRequest();
 
         // Test 200 response - should be cached
-        $response200 = new Response(new App());
+        $response200 = new Response();
         $response200->setStatusCode(200);
         $response200->setBody('Success');
 
@@ -87,7 +87,7 @@ final class PageCacheTest extends CIUnitTestCase
         $this->assertInstanceOf(Response::class, $result);
 
         // Test 404 response - should NOT be cached
-        $response404 = new Response(new App());
+        $response404 = new Response();
         $response404->setStatusCode(404);
         $response404->setBody('Not Found');
 
@@ -95,7 +95,7 @@ final class PageCacheTest extends CIUnitTestCase
         $this->assertNotInstanceOf(ResponseInterface::class, $result);
 
         // Test 500 response - should NOT be cached
-        $response500 = new Response(new App());
+        $response500 = new Response();
         $response500->setStatusCode(500);
         $response500->setBody('Server Error');
 
@@ -111,21 +111,21 @@ final class PageCacheTest extends CIUnitTestCase
 
         $request = $this->createRequest();
 
-        $response200 = new Response(new App());
+        $response200 = new Response();
         $response200->setStatusCode(200);
         $response200->setBody('Success');
 
         $result = $filter->after($request, $response200);
         $this->assertInstanceOf(Response::class, $result);
 
-        $response404 = new Response(new App());
+        $response404 = new Response();
         $response404->setStatusCode(404);
         $response404->setBody('Not Found');
 
         $result = $filter->after($request, $response404);
         $this->assertInstanceOf(Response::class, $result);
 
-        $response410 = new Response(new App());
+        $response410 = new Response();
         $response410->setStatusCode(410);
         $response410->setBody('Gone');
 
@@ -133,7 +133,7 @@ final class PageCacheTest extends CIUnitTestCase
         $this->assertInstanceOf(Response::class, $result);
 
         // Test 500 response - should NOT be cached (not in whitelist)
-        $response500 = new Response(new App());
+        $response500 = new Response();
         $response500->setStatusCode(500);
         $response500->setBody('Server Error');
 
@@ -163,7 +163,7 @@ final class PageCacheTest extends CIUnitTestCase
 
         $request = $this->createRequest();
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $response->redirect('/new-url');
 
         $result = $filter->after($request, $response);

--- a/tests/system/HTTP/CURLRequestShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestShareOptionsTest.php
@@ -34,8 +34,7 @@ final class CURLRequestShareOptionsTest extends CURLRequestTest
      */
     protected function getRequest(array $options = [], ?array $shareConnectionOptions = null): MockCURLRequest
     {
-        $uri = isset($options['baseURI']) ? new URI($options['baseURI']) : new URI();
-        $app = new App();
+        $uri = new URI($options['baseURI'] ?? null);
 
         $config               = new ConfigCURLRequest();
         $config->shareOptions = true;
@@ -46,7 +45,7 @@ final class CURLRequestShareOptionsTest extends CURLRequestTest
 
         Factories::injectMock('config', 'CURLRequest', $config);
 
-        return new MockCURLRequest(($app), $uri, new Response($app), $options);
+        return new MockCURLRequest(new App(), $uri, new Response(), $options);
     }
 
     public function testHeaderContentLengthNotSharedBetweenRequests(): void

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -52,8 +52,7 @@ class CURLRequestTest extends CIUnitTestCase
      */
     protected function getRequest(array $options = [], ?array $shareConnectionOptions = null): MockCURLRequest
     {
-        $uri = isset($options['baseURI']) ? new URI($options['baseURI']) : new URI();
-        $app = new App();
+        $uri = new URI($options['baseURI'] ?? null);
 
         $config               = new ConfigCURLRequest();
         $config->shareOptions = false;
@@ -64,7 +63,7 @@ class CURLRequestTest extends CIUnitTestCase
 
         Factories::injectMock('config', 'CURLRequest', $config);
 
-        return new MockCURLRequest(($app), $uri, new Response($app), $options);
+        return new MockCURLRequest(new App(), $uri, new Response(), $options);
     }
 
     /**

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -49,11 +49,10 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
     {
         $this->resetServices();
 
-        $config = config(App::class);
+        // Needed by CSP
+        config(App::class)->CSPEnabled = $CSPEnabled;
 
-        $config->CSPEnabled = $CSPEnabled;
-
-        $this->response = new Response($config);
+        $this->response = new Response();
         $this->response->pretend(false);
 
         $this->csp = $this->response->getCSP();
@@ -181,7 +180,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
 
         $csp = new ContentSecurityPolicy($config);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(true);
 
         $response->setBody('Blah blah blah blah');
@@ -738,7 +737,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $config->scriptNonceTag = '{custom-script-nonce-tag}';
         $csp                    = new ContentSecurityPolicy($config);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(true);
         $body = 'Blah blah {custom-script-nonce-tag} blah blah';
         $response->setBody($body);
@@ -754,7 +753,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $config->autoNonce = false;
         $csp               = new ContentSecurityPolicy($config);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(true);
         $body = 'Blah blah {csp-script-nonce} blah blah';
         $response->setBody($body);
@@ -773,7 +772,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $config->autoNonce = false;
         $csp               = new ContentSecurityPolicy($config);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(true);
         $body = 'Blah blah {csp-style-nonce} blah blah';
         $response->setBody($body);
@@ -817,7 +816,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $config->styleNonceTag = '{custom-style-nonce-tag}';
         $csp                   = new ContentSecurityPolicy($config);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(true);
         $body = 'Blah blah {custom-style-nonce-tag} blah blah';
         $response->setBody($body);

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -70,7 +70,7 @@ final class RedirectResponseTest extends CIUnitTestCase
 
     public function testRedirectToFullURI(): void
     {
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $response = $response->to('http://example.com/foo');
 
@@ -80,7 +80,7 @@ final class RedirectResponseTest extends CIUnitTestCase
 
     public function testRedirectRoute(): void
     {
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $this->routes->add('exampleRoute', 'Home::index');
 
@@ -102,7 +102,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->expectException(HTTPException::class);
         $this->expectExceptionMessage('The route for "differentRoute" cannot be found.');
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $this->routes->add('exampleRoute', 'Home::index');
 
@@ -114,7 +114,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->expectException(HTTPException::class);
         $this->expectExceptionMessage('The route for "Bad::badMethod" cannot be found.');
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $this->routes->add('exampleRoute', 'Home::index');
 
@@ -123,8 +123,7 @@ final class RedirectResponseTest extends CIUnitTestCase
 
     public function testRedirectRelativeConvertsToFullURI(): void
     {
-        $response = new RedirectResponse($this->config);
-
+        $response = new RedirectResponse();
         $response = $response->to('/foo');
 
         $this->assertTrue($response->hasHeader('Location'));
@@ -139,7 +138,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         service('superglobals')->setGet('foo', 'bar');
         service('superglobals')->setPost('bar', 'baz');
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $returned = $response->withInput();
 
@@ -155,7 +154,7 @@ final class RedirectResponseTest extends CIUnitTestCase
     {
         $_SESSION = [];
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $validation = $this->createMock(Validation::class);
         $validation->method('getErrors')->willReturn(['foo' => 'bar']);
@@ -173,7 +172,7 @@ final class RedirectResponseTest extends CIUnitTestCase
     {
         $_SESSION = [];
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $returned = $response->with('foo', 'bar');
 
@@ -190,7 +189,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->request = new MockIncomingRequest($this->config, new SiteURI($this->config), null, new UserAgent());
         Services::injectMock('request', $this->request);
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $returned = $response->back();
         $this->assertSame('http://somewhere.com', $returned->header('location')->getValue());
@@ -202,7 +201,7 @@ final class RedirectResponseTest extends CIUnitTestCase
     {
         $_SESSION = [];
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $returned = $response->back();
 
@@ -223,7 +222,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $request = new MockIncomingRequest($config, new SiteURI($config), null, new UserAgent());
         Services::injectMock('request', $request);
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
 
         $this->routes->add('exampleRoute', 'Home::index');
 
@@ -242,7 +241,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $baseResponse = service('response');
         $baseResponse->setCookie('foo', 'bar');
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $this->assertFalse($response->hasCookie('foo', 'bar'));
 
         $response = $response->withCookies();
@@ -255,7 +254,7 @@ final class RedirectResponseTest extends CIUnitTestCase
     {
         $_SESSION = [];
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $response = $response->withCookies();
 
         $this->assertEmpty($response->getCookies());
@@ -268,7 +267,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $baseResponse = service('response');
         $baseResponse->setHeader('foo', 'bar');
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $this->assertFalse($response->hasHeader('foo'));
 
         $response = $response->withHeaders();
@@ -289,7 +288,7 @@ final class RedirectResponseTest extends CIUnitTestCase
             $baseResponse->removeHeader($key);
         }
 
-        $response = new RedirectResponse(new App());
+        $response = new RedirectResponse();
         $response->withHeaders();
 
         $this->assertEmpty($baseResponse->headers());

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -18,7 +18,6 @@ use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\App;
 use Config\Cookie as CookieConfig;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -45,7 +44,7 @@ final class ResponseCookieTest extends CIUnitTestCase
     {
         $config         = config('Cookie');
         $config->prefix = 'mine';
-        $response       = new Response(new App());
+        $response       = new Response();
         $response->setCookie('foo', 'bar');
 
         $this->assertInstanceOf(Cookie::class, $response->getCookie('foo'));
@@ -58,7 +57,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookiesAll(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie('foo', 'bar');
         $response->setCookie('bee', 'bop');
 
@@ -70,7 +69,7 @@ final class ResponseCookieTest extends CIUnitTestCase
     public function testSetCookieObject(): void
     {
         $cookie   = new Cookie('foo', 'bar');
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setCookie($cookie);
 
@@ -80,7 +79,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieGet(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie('foo', 'bar');
         $response->setCookie('bee', 'bop');
 
@@ -90,7 +89,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieDomain(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setCookie('foo', 'bar');
         $cookie = $response->getCookie('foo');
@@ -102,7 +101,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
         $config         = config('Cookie');
         $config->domain = 'mine.com';
-        $response       = new Response(new App());
+        $response       = new Response();
         $response->setCookie('alu', 'la');
         $cookie = $response->getCookie('alu');
         $this->assertSame('mine.com', $cookie->getDomain());
@@ -110,7 +109,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookiePath(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setCookie('foo', 'bar');
         $cookie = $response->getCookie('foo');
@@ -123,7 +122,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieSecure(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setCookie('foo', 'bar');
         $cookie = $response->getCookie('foo');
@@ -136,7 +135,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieHTTPOnly(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setCookie('foo', 'bar');
         $cookie = $response->getCookie('foo');
@@ -149,18 +148,18 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieExpiry(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setCookie('foo', 'bar');
         $cookie = $response->getCookie('foo');
         $this->assertTrue($cookie->isExpired());
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
         $cookie = $response->getCookie('bee');
         $this->assertFalse($cookie->isExpired());
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => -1000]);
         $cookie = $response->getCookie('bee');
         $this->assertSame(0, $cookie->getExpiresTimestamp());
@@ -168,7 +167,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieDelete(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         // foo is already expired, bee will stick around
         $response->setCookie('foo', 'bar');
@@ -177,20 +176,20 @@ final class ResponseCookieTest extends CIUnitTestCase
         $this->assertFalse($cookie->isExpired());
 
         // delete cookie manually
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => '']);
         $cookie = $response->getCookie('bee');
         $this->assertTrue($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
 
         // delete with no effect
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
         $response->deleteCookie();
         $cookie = $response->getCookie('bee');
         $this->assertFalse($cookie->isExpired());
 
         // delete cookie for real
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
         $response->deleteCookie('bee');
         $cookie = $response->getCookie('bee');
@@ -199,7 +198,7 @@ final class ResponseCookieTest extends CIUnitTestCase
         $config = config('Cookie');
         // delete cookie for real, with prefix
         $config->prefix = 'mine';
-        $response       = new Response(new App());
+        $response       = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
         $response->deleteCookie('bee');
         $cookie = $response->getCookie('bee');
@@ -207,7 +206,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
         // delete cookie with wrong prefix?
         $config->prefix = 'mine';
-        $response       = new Response(new App());
+        $response       = new Response();
         $response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
         $response->deleteCookie('bee', '', '', 'wrong');
         $cookie = $response->getCookie('bee');
@@ -218,7 +217,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
         // delete cookie with wrong domain?
         $config->domain = '.mine.com';
-        $response       = new Response(new App());
+        $response       = new Response();
         $response->setCookie(['name' => 'bees', 'value' => 'bop', 'expire' => 1000]);
         $response->deleteCookie('bees', 'wrong', '', '');
         $cookie = $response->getCookie('bees');
@@ -230,7 +229,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieDefaultSetSameSite(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie([
             'name'  => 'bar',
             'value' => 'foo',
@@ -246,7 +245,7 @@ final class ResponseCookieTest extends CIUnitTestCase
     {
         $config           = config('Cookie');
         $config->samesite = 'Strict';
-        $response         = new Response(new App());
+        $response         = new Response();
         $response->setCookie([
             'name'  => 'bar',
             'value' => 'foo',
@@ -263,7 +262,7 @@ final class ResponseCookieTest extends CIUnitTestCase
         /** @var CookieConfig $config */
         $config           = config('Cookie');
         $config->samesite = '';
-        $response         = new Response(new App());
+        $response         = new Response();
         $response->setCookie([
             'name'  => 'bar',
             'value' => 'foo',
@@ -279,7 +278,7 @@ final class ResponseCookieTest extends CIUnitTestCase
     {
         $config = new CookieConfig();
         unset($config->samesite);
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie([
             'name'  => 'bar',
             'value' => 'foo',
@@ -293,7 +292,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieStrictSameSite(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie([
             'name'     => 'bar',
             'value'    => 'foo',
@@ -308,7 +307,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testCookieInvalidSameSite(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->expectException(CookieException::class);
         $this->expectExceptionMessage(lang('Cookie.invalidSameSite', ['Invalid']));
@@ -334,7 +333,7 @@ final class ResponseCookieTest extends CIUnitTestCase
             'value'  => 'foo',
             'expire' => 9999,
         ];
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie($cookieAttr);
 
         $cookie  = $response->getCookie('bar');
@@ -346,7 +345,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
     public function testGetCookieStore(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $this->assertInstanceOf(CookieStore::class, $response->getCookieStore());
     }
 }

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -51,7 +51,7 @@ final class ResponseSendTest extends CIUnitTestCase
     #[WithoutErrorHandler]
     public function testHeadersMissingDate(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(false);
 
         $body = 'Hello';
@@ -87,9 +87,9 @@ final class ResponseSendTest extends CIUnitTestCase
         $this->resetFactories();
         $this->resetServices();
 
-        $config             = config('App');
-        $config->CSPEnabled = true;
-        $response           = new Response($config);
+        config(App::class)->CSPEnabled = true;
+
+        $response = new Response();
         $response->pretend(false);
 
         $body = 'Hello';
@@ -122,7 +122,7 @@ final class ResponseSendTest extends CIUnitTestCase
     {
         $loginTime = time();
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(false);
 
         $routes = service('routes');
@@ -161,7 +161,7 @@ final class ResponseSendTest extends CIUnitTestCase
         $request->method('isSecure')->willReturn(false);
         Services::injectMock('request', $request);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(false);
         $body = 'Hello';
         $response->setBody($body);
@@ -189,7 +189,7 @@ final class ResponseSendTest extends CIUnitTestCase
     #[WithoutErrorHandler]
     public function testHeaderOverride(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(false);
 
         $body = 'Hello';

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -52,8 +52,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testCanSetStatusCode(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->setStatusCode(200);
 
         $this->assertSame(200, $response->getStatusCode());
@@ -61,25 +60,15 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetStatusCodeThrowsExceptionForBadCodes(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->expectException(HTTPException::class);
         $response->setStatusCode(54322);
     }
 
-    public function testConstructWithCSPEnabled(): void
-    {
-        $config             = new App();
-        $config->CSPEnabled = true;
-        $response           = new Response($config);
-
-        $this->assertInstanceOf(Response::class, $response);
-    }
-
     public function testSetStatusCodeSetsReason(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->setStatusCode(200);
 
         $this->assertSame('OK', $response->getReasonPhrase());
@@ -87,8 +76,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testCanSetCustomReasonCode(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->setStatusCode(200, 'Not the mama');
 
         $this->assertSame('Not the mama', $response->getReasonPhrase());
@@ -96,7 +84,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testRequiresMessageWithUnknownStatusCode(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->expectException(HTTPException::class);
         $this->expectExceptionMessage(lang('HTTP.unknownStatusCode', [115]));
@@ -105,7 +93,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testRequiresMessageWithSmallStatusCode(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->expectException(HTTPException::class);
         $this->expectExceptionMessage(lang('HTTP.invalidStatusCode', [95]));
@@ -114,7 +102,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testRequiresMessageWithLargeStatusCode(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->expectException(HTTPException::class);
         $this->expectExceptionMessage(lang('HTTP.invalidStatusCode', [695]));
@@ -123,8 +111,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetStatusCodeInterpretsReason(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->setStatusCode(300);
 
         $this->assertSame('Multiple Choices', $response->getReasonPhrase());
@@ -132,8 +119,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetStatusCodeSavesCustomReason(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->setStatusCode(300, 'My Little Pony');
 
         $this->assertSame('My Little Pony', $response->getReasonPhrase());
@@ -141,14 +127,14 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testGetReasonDefaultsToOK(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->assertSame('OK', $response->getReasonPhrase());
     }
 
     public function testSetDateRemembersDateInUTC(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $datetime = DateTime::createFromFormat('!Y-m-d', '2000-03-10');
         $response->setDate($datetime);
@@ -170,7 +156,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $this->resetServices();
 
-        $response = new Response($config);
+        $response = new Response();
         $pager    = service('pager');
 
         $pager->store('default', 3, 10, 200);
@@ -200,8 +186,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetContentType(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->setContentType('text/json');
 
         $this->assertSame('text/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
@@ -209,8 +194,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testNoCache(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->noCache();
 
         $this->assertSame('no-store, max-age=0, no-cache', $response->getHeaderLine('Cache-control'));
@@ -218,7 +202,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetCache(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $date = date('r');
 
@@ -238,18 +222,15 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetCacheNoOptions(): void
     {
-        $response = new Response(new App());
-
-        $options = [];
-
-        $response->setCache($options);
+        $response = new Response();
+        $response->setCache([]);
 
         $this->assertSame('no-store, max-age=0, no-cache', $response->getHeaderLine('Cache-Control'));
     }
 
     public function testSetLastModifiedWithDateTimeObject(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $datetime = DateTime::createFromFormat('Y-m-d', '2000-03-10');
         $response->setLastModified($datetime);
@@ -264,8 +245,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testRedirectSetsDefaultCodeAndLocationHeader(): void
     {
-        $response = new Response(new App());
-
+        $response = new Response();
         $response->redirect('example.com');
 
         $this->assertTrue($response->hasHeader('location'));
@@ -286,7 +266,7 @@ final class ResponseTest extends CIUnitTestCase
             ->setServer('SERVER_PROTOCOL', $protocol)
             ->setServer('REQUEST_METHOD', $method);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->redirect('example.com', 'auto', $code);
 
         $this->assertTrue($response->hasHeader('location'));
@@ -330,7 +310,7 @@ final class ResponseTest extends CIUnitTestCase
             ->setServer('SERVER_PROTOCOL', 'HTTP/1.1')
             ->setServer('REQUEST_METHOD', 'POST');
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->redirect('example.com', 'auto', $code);
 
         $this->assertSame('0;url=example.com', $response->getHeaderLine('Refresh'));
@@ -353,14 +333,14 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetCookieFails(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $this->assertFalse($response->hasCookie('foo'));
     }
 
     public function testSetCookieMatch(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie('foo', 'bar');
 
         $this->assertTrue($response->hasCookie('foo'));
@@ -369,7 +349,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetCookieFailDifferentPrefix(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie('foo', 'bar', '', '', '', 'ack');
 
         $this->assertFalse($response->hasCookie('foo'));
@@ -377,7 +357,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSetCookieSuccessOnPrefix(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->setCookie('foo', 'bar', '', '', '', 'ack');
 
         $this->assertTrue($response->hasCookie('foo', null, 'ack'));
@@ -396,7 +376,7 @@ final class ResponseTest extends CIUnitTestCase
         ];
         $expected = service('format')->getFormatter('application/json')->format($body);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setJSON($body);
 
         $this->assertSame($expected, $response->getJSON());
@@ -415,7 +395,7 @@ final class ResponseTest extends CIUnitTestCase
         ];
         $expected = service('format')->getFormatter('application/json')->format($body);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setBody($body);
 
         $this->assertSame($expected, $response->getJSON());
@@ -433,7 +413,7 @@ final class ResponseTest extends CIUnitTestCase
         ];
         $expected = service('format')->getFormatter('application/xml')->format($body);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setXML($body);
 
         $this->assertSame($expected, $response->getXML());
@@ -452,7 +432,7 @@ final class ResponseTest extends CIUnitTestCase
         ];
         $expected = service('format')->getFormatter('application/xml')->format($body);
 
-        $response = new Response(new App());
+        $response = new Response();
         $response->setBody($body);
 
         $this->assertSame($expected, $response->getXML());
@@ -460,7 +440,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testGetDownloadResponseByData(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $actual = $response->download('unit-test.txt', 'data');
 
@@ -478,7 +458,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testGetDownloadResponseByFilePath(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $actual = $response->download(__FILE__, null);
 
@@ -496,7 +476,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testVagueDownload(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
 
         $actual = $response->download();
 
@@ -505,7 +485,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testPretendMode(): void
     {
-        $response = new MockResponse(new App());
+        $response = new MockResponse();
         $response->pretend(true);
         $this->assertTrue($response->getPretend());
         $response->pretend(false);
@@ -514,7 +494,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testMisbehaving(): void
     {
-        $response = new MockResponse(new App());
+        $response = new MockResponse();
         $response->misbehave();
 
         $this->expectException(HTTPException::class);
@@ -526,7 +506,7 @@ final class ResponseTest extends CIUnitTestCase
         service('superglobals')
             ->setServer('SERVER_PROTOCOL', 'HTTP/1.1')
             ->setServer('REQUEST_METHOD', 'POST');
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setProtocolVersion('HTTP/1.1');
         $response->redirect('/foo');
@@ -539,7 +519,7 @@ final class ResponseTest extends CIUnitTestCase
         service('superglobals')
             ->setServer('SERVER_PROTOCOL', 'HTTP/1.1')
             ->setServer('REQUEST_METHOD', 'GET');
-        $response = new Response(new App());
+        $response = new Response();
 
         $response->setProtocolVersion('HTTP/1.1');
         $response->redirect('/foo');
@@ -553,7 +533,7 @@ final class ResponseTest extends CIUnitTestCase
     {
         $loginTime = time();
 
-        $response = new Response(new App());
+        $response = new Response();
         $answer1  = $response->redirect('/login')
             ->setCookie('foo', 'bar', YEAR)
             ->setCookie('login_time', (string) $loginTime, YEAR);
@@ -565,7 +545,7 @@ final class ResponseTest extends CIUnitTestCase
     // Make sure we don't blow up if pretending to send headers
     public function testPretendOutput(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(true);
 
         $response->setBody('Happy days');
@@ -580,10 +560,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSendRemovesDefaultNoncePlaceholdersWhenCSPDisabled(): void
     {
-        $config             = new App();
-        $config->CSPEnabled = false;
-
-        $response = new Response($config);
+        $response = new Response();
         $response->pretend(true);
 
         $body = '<html><script {csp-script-nonce}>console.log("test")</script><style {csp-style-nonce}>.test{}</style></html>';
@@ -603,9 +580,6 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSendRemovesCustomNoncePlaceholdersWhenCSPDisabled(): void
     {
-        $appConfig             = new App();
-        $appConfig->CSPEnabled = false;
-
         // Create custom CSP config with custom nonce tags
         $cspConfig                 = new \Config\ContentSecurityPolicy();
         $cspConfig->scriptNonceTag = '{custom-script-tag}';
@@ -613,7 +587,7 @@ final class ResponseTest extends CIUnitTestCase
 
         Services::injectMock('csp', new ContentSecurityPolicy($cspConfig));
 
-        $response = new Response($appConfig);
+        $response = new Response();
         $response->pretend(true);
 
         $body = '<html><script {custom-script-tag}>test()</script><style {custom-style-tag}>.x{}</style></html>';
@@ -633,10 +607,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSendNoEffectWhenBodyEmptyAndCSPDisabled(): void
     {
-        $config             = new App();
-        $config->CSPEnabled = false;
-
-        $response = new Response($config);
+        $response = new Response();
         $response->pretend(true);
 
         $body = '';
@@ -652,10 +623,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSendNoEffectWithNoPlaceholdersAndCSPDisabled(): void
     {
-        $config             = new App();
-        $config->CSPEnabled = false;
-
-        $response = new Response($config);
+        $response = new Response();
         $response->pretend(true);
 
         $body = '<html><head><title>Test</title></head><body><p>No placeholders here</p></body></html>';
@@ -672,10 +640,7 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSendRemovesMultiplePlaceholdersWhenCSPDisabled(): void
     {
-        $config             = new App();
-        $config->CSPEnabled = false;
-
-        $response = new Response($config);
+        $response = new Response();
         $response->pretend(true);
 
         $body = '<html><script {csp-script-nonce}>console.log("test")</script><script {csp-script-nonce}>console.log("test2")</script><style {csp-style-nonce}>.test{}</style><style {csp-style-nonce}>.test2{}</style></html>';
@@ -697,16 +662,13 @@ final class ResponseTest extends CIUnitTestCase
 
     public function testSendRemovesPlaceholdersWhenBothCSPAndAutoNonceAreDisabled(): void
     {
-        $appConfig             = new App();
-        $appConfig->CSPEnabled = false;
-
         // Create custom CSP config with custom nonce tags
         $cspConfig            = new \Config\ContentSecurityPolicy();
         $cspConfig->autoNonce = false;
 
         Services::injectMock('csp', new ContentSecurityPolicy($cspConfig));
 
-        $response = new Response($appConfig);
+        $response = new Response();
         $response->pretend(true);
 
         $body = '<html><script {csp-script-nonce}>test()</script><style {csp-style-nonce}>.x{}</style></html>';

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -51,7 +51,7 @@ final class CookieHelperTest extends CIUnitTestCase
         $this->value  = 'hello world';
         $this->expire = 9999;
 
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $this->response = service('response');
         $request        = new IncomingRequest(new App(), new SiteURI(new App()), null, new UserAgent());
         Services::injectMock('request', $request);

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Log\Handlers;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use CodeIgniter\Test\Mock\MockResponse;
-use Config\App;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
@@ -77,7 +76,7 @@ final class ChromeLoggerHandlerTest extends CIUnitTestCase
 
     public function testChromeLoggerHeaderSent(): void
     {
-        Services::injectMock('response', new MockResponse(new App()));
+        Services::injectMock('response', new MockResponse());
         $response = service('response');
 
         $config = new LoggerConfig();

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -323,7 +323,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $agent  = new UserAgent();
 
         $request  = new IncomingRequest($config, $uri, '', $agent);
-        $response = new Response($config);
+        $response = new Response();
         $logger   = new NullLogger();
 
         $resource->initController($request, $response, $logger);
@@ -351,7 +351,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $agent  = new UserAgent();
 
         $request  = new IncomingRequest($config, $uri, '', $agent);
-        $response = new Response($config);
+        $response = new Response();
         $logger   = new NullLogger();
 
         $resource->initController($request, $response, $logger);

--- a/tests/system/Test/TestCaseEmissionsTest.php
+++ b/tests/system/Test/TestCaseEmissionsTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Test;
 
 use CodeIgniter\HTTP\Response;
-use Config\App;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -49,7 +48,7 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
     #[WithoutErrorHandler]
     public function testHeadersEmitted(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(false);
 
         $body = 'Hello';
@@ -76,7 +75,7 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
     #[WithoutErrorHandler]
     public function testHeadersNotEmitted(): void
     {
-        $response = new Response(new App());
+        $response = new Response();
         $response->pretend(false);
 
         $body = 'Hello';

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Test;
 
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
-use Config\App;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -154,7 +153,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testAssertRedirectSuccess(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->testResponse->setResponse(new RedirectResponse(new App()));
+        $this->testResponse->setResponse(new RedirectResponse());
 
         $this->assertInstanceOf(RedirectResponse::class, $this->testResponse->response());
         $this->assertTrue($this->testResponse->isRedirect());
@@ -175,7 +174,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testGetRedirectUrlReturnsUrl(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->testResponse->setResponse(new RedirectResponse(new App()));
+        $this->testResponse->setResponse(new RedirectResponse());
         $this->testResponse->response()->redirect('foo/bar');
 
         $this->assertSame('foo/bar', $this->testResponse->getRedirectUrl());
@@ -191,7 +190,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testRedirectToSuccess(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->testResponse->setResponse(new RedirectResponse(new App()));
+        $this->testResponse->setResponse(new RedirectResponse());
         $this->testResponse->response()->redirect('foo/bar');
 
         $this->testResponse->assertRedirectTo('foo/bar');
@@ -200,7 +199,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testRedirectToSuccessFullURL(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->testResponse->setResponse(new RedirectResponse(new App()));
+        $this->testResponse->setResponse(new RedirectResponse());
         $this->testResponse->response()->redirect('http://foo.com/bar');
 
         $this->testResponse->assertRedirectTo('http://foo.com/bar');
@@ -209,7 +208,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testRedirectToSuccessMixedURL(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->testResponse->setResponse(new RedirectResponse(new App()));
+        $this->testResponse->setResponse(new RedirectResponse());
         $this->testResponse->response()->redirect('bar');
 
         $this->testResponse->assertRedirectTo('http://example.com/index.php/bar');
@@ -434,7 +433,7 @@ final class TestResponseTest extends CIUnitTestCase
 
     protected function getTestResponse(?string $body = null, array $responseOptions = [], array $headers = []): void
     {
-        $this->response = new Response(new App());
+        $this->response = new Response();
         $this->response->setBody($body);
 
         foreach ($responseOptions as $key => $value) {

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -62,10 +62,15 @@ Libraries
 Helpers and Functions
 =====================
 
-Others
-======
+HTTP
+====
 
 - Added ``SSEResponse`` class for streaming Server-Sent Events (SSE) over HTTP. See :ref:`server-sent-events`.
+- ``Response`` and its child classes no longer require ``Config\App`` passed to their constructors.
+    Consequently, ``CURLRequest``'s ``$config`` parameter is unused and will be removed in a future release.
+
+Others
+======
 
 ***************
 Message Changes


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
Remove unused `$config` in `Response`

**Checklist:**
- [x] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
