### PR TITLE
fix: add fallback for `appOverridesFolder` config in View

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -202,8 +202,10 @@ class View implements RendererInterface
         $this->renderVars['file'] = $this->viewPath . $this->renderVars['view'];
 
         if (str_contains($this->renderVars['view'], '\\')) {
-            $overrideFolder = $this->config->appOverridesFolder !== ''
-                 ? trim($this->config->appOverridesFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+            $appOverridesFolder = $this->config->appOverridesFolder ?? 'overrides';
+
+            $overrideFolder = $appOverridesFolder !== ''
+                 ? trim($appOverridesFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
                  : '';
 
             $this->renderVars['file'] = $this->viewPath

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -43,6 +43,7 @@ Bugs Fixed
 - **Model:** Fixed a bug where ``BaseModel::updateBatch()`` threw an exception when ``updateOnlyChanged`` was ``true`` and the index field value did not change.
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.
+- **View:** Fixed a bug where ``View`` would throw an error if the ``appOverridesFolder`` config property was not defined.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes an error when `appOverridesFolder` is not defined in the `View` config. This ensures backward compatibility for users who haven't added the new config property yet.

Closes #9955

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
