### PR TITLE
fix: avoid double-prefixing in `BaseConnection::callFunction()`

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1508,7 +1508,7 @@ abstract class BaseConnection implements ConnectionInterface
     {
         $driver = $this->getDriverFunctionPrefix();
 
-        if (! str_contains($driver, $functionName)) {
+        if (! str_starts_with($functionName, $driver)) {
             $functionName = $driver . $functionName;
         }
 

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -345,4 +345,28 @@ final class BaseConnectionTest extends CIUnitTestCase
             'with dots' => ['com.sitedb.web', '"com.sitedb.web"'],
         ];
     }
+
+    public function testCallFunctionDoesNotDoublePrefixAlreadyPrefixedName(): void
+    {
+        $db = new class ($this->options) extends MockConnection {
+            protected function getDriverFunctionPrefix(): string
+            {
+                return 'str_';
+            }
+        };
+
+        $this->assertTrue($db->callFunction('str_contains', 'CodeIgniter', 'Ignite'));
+    }
+
+    public function testCallFunctionPrefixesUnprefixedName(): void
+    {
+        $db = new class ($this->options) extends MockConnection {
+            protected function getDriverFunctionPrefix(): string
+            {
+                return 'str_';
+            }
+        };
+
+        $this->assertTrue($db->callFunction('contains', 'CodeIgniter', 'Ignite'));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -40,6 +40,7 @@ Bugs Fixed
 
 - **ContentSecurityPolicy:** Fixed a bug where custom CSP tags were not removed from generated HTML when CSP was disabled. The method now ensures that all custom CSP tags are removed from the generated HTML.
 - **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` produces corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
+- **Database:** Fixed a bug where ``BaseConnection::callFunction()`` could double-prefix already-prefixed function names.
 - **Model:** Fixed a bug where ``BaseModel::updateBatch()`` threw an exception when ``updateOnlyChanged`` was ``true`` and the index field value did not change.
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.


### PR DESCRIPTION
**Description**
This PR fixes a bug where `BaseConnection::callFunction()` could incorrectly prepend the driver function prefix even when the passed function name was already prefixed.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
