### PR TITLE
fix: preserve Postgre casts when converting named placeholders in prepared queries

### DIFF
--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -83,7 +83,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
         // We only support positional placeholders (?), so convert
         // named placeholders (:name or :name:) while leaving dialect
         // syntax like PostgreSQL casts (::type) untouched.
-        $sql = preg_replace('/(?<!:):([a-zA-Z_][a-zA-Z0-9_]*):?(?!:)/', '?', $sql);
+        $sql = preg_replace('/(?<!:):([a-zA-Z_]\w*):?(?!:)/', '?', $sql);
 
         /** @var Query $query */
         $query = new $queryClass($this->db);

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -80,10 +80,10 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      */
     public function prepare(string $sql, array $options = [], string $queryClass = Query::class)
     {
-        // We only supports positional placeholders (?)
-        // in order to work with the execute method below, so we
-        // need to replace our named placeholders (:name)
-        $sql = preg_replace('/:[^\s,)]+/', '?', $sql);
+        // We only support positional placeholders (?), so convert
+        // named placeholders (:name or :name:) while leaving dialect
+        // syntax like PostgreSQL casts (::type) untouched.
+        $sql = preg_replace('/(?<!:):([a-zA-Z_][a-zA-Z0-9_]*):?(?!:)/', '?', $sql);
 
         /** @var Query $query */
         $query = new $queryClass($this->db);

--- a/tests/_support/Mock/MockPreparedQuery.php
+++ b/tests/_support/Mock/MockPreparedQuery.php
@@ -17,6 +17,8 @@ use CodeIgniter\Database\BasePreparedQuery;
 
 /**
  * @internal
+ *
+ * @extends BasePreparedQuery<object, object, object>
  */
 final class MockPreparedQuery extends BasePreparedQuery
 {

--- a/tests/_support/Mock/MockPreparedQuery.php
+++ b/tests/_support/Mock/MockPreparedQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Mock;
+
+use CodeIgniter\Database\BasePreparedQuery;
+
+/**
+ * @internal
+ */
+final class MockPreparedQuery extends BasePreparedQuery
+{
+    public string $preparedSql = '';
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function _prepare(string $sql, array $options = []): self
+    {
+        $this->preparedSql = $sql;
+
+        return $this;
+    }
+
+    /**
+     * @param array<int, mixed> $data
+     */
+    public function _execute(array $data): bool
+    {
+        return true;
+    }
+
+    public function _getResult()
+    {
+        return null;
+    }
+
+    protected function _close(): bool
+    {
+        return true;
+    }
+}

--- a/tests/system/Database/BasePreparedQueryTest.php
+++ b/tests/system/Database/BasePreparedQueryTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Mock\MockPreparedQuery;
 
 /**
  * @internal
@@ -53,32 +54,8 @@ final class BasePreparedQueryTest extends CIUnitTestCase
         $this->assertSame("SELECT '12:34' AS time_value, ? AS id", $query->preparedSql);
     }
 
-    private function createPreparedQuery(): BasePreparedQuery
+    private function createPreparedQuery(): MockPreparedQuery
     {
-        return new class (new MockConnection([])) extends BasePreparedQuery {
-            public string $preparedSql = '';
-
-            public function _prepare(string $sql, array $options = [])
-            {
-                $this->preparedSql = $sql;
-
-                return $this;
-            }
-
-            public function _execute(array $data): bool
-            {
-                return true;
-            }
-
-            public function _getResult()
-            {
-                return null;
-            }
-
-            protected function _close(): bool
-            {
-                return true;
-            }
-        };
+        return new MockPreparedQuery(new MockConnection([]));
     }
 }

--- a/tests/system/Database/BasePreparedQueryTest.php
+++ b/tests/system/Database/BasePreparedQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class BasePreparedQueryTest extends CIUnitTestCase
+{
+    public function testPrepareConvertsNamedPlaceholdersToPositionalPlaceholders(): void
+    {
+        $query = $this->createPreparedQuery();
+
+        $query->prepare('SELECT * FROM users WHERE id = :id: AND name = :name');
+
+        $this->assertSame('SELECT * FROM users WHERE id = ? AND name = ?', $query->preparedSql);
+    }
+
+    public function testPrepareDoesNotConvertPostgreStyleCastSyntax(): void
+    {
+        $query = $this->createPreparedQuery();
+
+        $query->prepare('SELECT :name: AS name, created_at::timestamp AS created FROM users WHERE id = :id:');
+
+        $this->assertSame(
+            'SELECT ? AS name, created_at::timestamp AS created FROM users WHERE id = ?',
+            $query->preparedSql,
+        );
+    }
+
+    public function testPrepareDoesNotConvertTimeLikeLiterals(): void
+    {
+        $query = $this->createPreparedQuery();
+
+        $query->prepare("SELECT '12:34' AS time_value, :id: AS id");
+
+        $this->assertSame("SELECT '12:34' AS time_value, ? AS id", $query->preparedSql);
+    }
+
+    private function createPreparedQuery(): BasePreparedQuery
+    {
+        return new class (new MockConnection([])) extends BasePreparedQuery {
+            public string $preparedSql = '';
+
+            public function _prepare(string $sql, array $options = [])
+            {
+                $this->preparedSql = $sql;
+
+                return $this;
+            }
+
+            public function _execute(array $data): bool
+            {
+                return true;
+            }
+
+            public function _getResult()
+            {
+                return null;
+            }
+
+            protected function _close(): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -45,6 +45,10 @@ final class PreparedQueryTest extends CIUnitTestCase
     {
         parent::tearDown();
 
+        if ($this->query === null) {
+            return;
+        }
+
         try {
             $this->query->close();
         } catch (BadMethodCallException) {
@@ -107,6 +111,68 @@ final class PreparedQueryTest extends CIUnitTestCase
         $expected = "INSERT INTO {$ec}{$pre}user{$ec} ({$ec}name{$ec}, {$ec}email{$ec}, {$ec}country{$ec}) VALUES ({$placeholders})";
 
         $this->assertSame($expected, $this->query->getQueryString());
+    }
+
+    public function testPrepareAndExecuteManualQueryWithNamedPlaceholdersKeepsTimeLiteral(): void
+    {
+        $this->query = $this->db->prepare(static function ($db): Query {
+            $sql = 'SELECT '
+                . $db->protectIdentifiers('name') . ', '
+                . $db->protectIdentifiers('email')
+                . ", '12:34' AS time_value "
+                . 'FROM ' . $db->protectIdentifiers($db->DBPrefix . 'user')
+                . ' WHERE '
+                . $db->protectIdentifiers('name') . ' = :name:'
+                . ' AND ' . $db->protectIdentifiers('email') . ' = :email';
+
+            return (new Query($db))->setQuery($sql);
+        });
+
+        $preparedSql = $this->query->getQueryString();
+
+        $this->assertStringContainsString("'12:34' AS time_value", $preparedSql);
+
+        if ($this->db->DBDriver === 'Postgre') {
+            $this->assertStringContainsString(' = $1', $preparedSql);
+            $this->assertStringContainsString(' = $2', $preparedSql);
+        } else {
+            $this->assertStringContainsString(' = ?', $preparedSql);
+        }
+
+        $result = $this->query->execute('Derek Jones', 'derek@world.com');
+
+        $this->assertInstanceOf(ResultInterface::class, $result);
+        $this->assertSame('Derek Jones', $result->getRow()->name);
+        $this->assertSame('derek@world.com', $result->getRow()->email);
+        $this->assertSame('12:34', $result->getRow()->time_value);
+    }
+
+    public function testPrepareAndExecuteManualQueryWithPostgreCastKeepsDoubleColonSyntax(): void
+    {
+        if ($this->db->DBDriver !== 'Postgre') {
+            $this->markTestSkipped('PostgreSQL-specific cast syntax test.');
+        }
+
+        $this->query = $this->db->prepare(static function ($db): Query {
+            $sql = 'SELECT '
+                . ':value: AS value, now()::timestamp AS created_at'
+                . ' FROM ' . $db->protectIdentifiers($db->DBPrefix . 'user')
+                . ' WHERE ' . $db->protectIdentifiers('name') . ' = :name:';
+
+            return (new Query($db))->setQuery($sql);
+        });
+
+        $preparedSql = $this->query->getQueryString();
+
+        $this->assertStringContainsString('$1 AS value', $preparedSql);
+        $this->assertStringContainsString('now()::timestamp AS created_at', $preparedSql);
+
+        $result = $this->query->execute('ci4', 'Derek Jones');
+
+        $this->assertInstanceOf(ResultInterface::class, $result);
+        $this->assertSame('ci4', $result->getRow()->value);
+        $this->assertNotEmpty($result->getRow()->created_at);
+        $this->assertNotSame('now()::timestamp', $result->getRow()->created_at);
     }
 
     public function testExecuteRunsQueryAndReturnsTrue(): void

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -45,7 +45,7 @@ final class PreparedQueryTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        if ($this->query === null) {
+        if (! $this->query instanceof BasePreparedQuery) {
             return;
         }
 
@@ -115,11 +115,13 @@ final class PreparedQueryTest extends CIUnitTestCase
 
     public function testPrepareAndExecuteManualQueryWithNamedPlaceholdersKeepsTimeLiteral(): void
     {
-        $this->query = $this->db->prepare(static function ($db): Query {
+        // Quote alias to keep a consistent property name across drivers (OCI8 uppercases unquoted aliases)
+        $timeValue   = $this->db->protectIdentifiers('time_value');
+        $this->query = $this->db->prepare(static function ($db) use ($timeValue): Query {
             $sql = 'SELECT '
                 . $db->protectIdentifiers('name') . ', '
                 . $db->protectIdentifiers('email')
-                . ", '12:34' AS time_value "
+                . ", '12:34' AS " . $timeValue . ' '
                 . 'FROM ' . $db->protectIdentifiers($db->DBPrefix . 'user')
                 . ' WHERE '
                 . $db->protectIdentifiers('name') . ' = :name:'
@@ -130,7 +132,7 @@ final class PreparedQueryTest extends CIUnitTestCase
 
         $preparedSql = $this->query->getQueryString();
 
-        $this->assertStringContainsString("'12:34' AS time_value", $preparedSql);
+        $this->assertStringContainsString("'12:34' AS " . $timeValue, $preparedSql);
 
         if ($this->db->DBDriver === 'Postgre') {
             $this->assertStringContainsString(' = $1', $preparedSql);

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -41,6 +41,7 @@ Bugs Fixed
 - **ContentSecurityPolicy:** Fixed a bug where custom CSP tags were not removed from generated HTML when CSP was disabled. The method now ensures that all custom CSP tags are removed from the generated HTML.
 - **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` produces corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
 - **Database:** Fixed a bug where ``BaseConnection::callFunction()`` could double-prefix already-prefixed function names.
+- **Database:** Fixed a bug where ``BasePreparedQuery::prepare()`` could mis-handle SQL containing colon syntax by over-broad named-placeholder replacement. It now preserves PostgreSQL cast syntax like ``::timestamp``.
 - **Model:** Fixed a bug where ``BaseModel::updateBatch()`` threw an exception when ``updateOnlyChanged`` was ``true`` and the index field value did not change.
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.


### PR DESCRIPTION
**Description**
This PR fixes a bug where named placeholder conversion in `BasePreparedQuery::prepare()` was too broad and could interfere with SQL using colon syntax (i.e., PostgreSQL casts like `::timestamp`).

The conversion now targets only valid named placeholders (`:name` / `:name:`) and leaves dialect syntax like `::type` untouched.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
