### PR TITLE
fix: prevent extra query and invalid size in `Model::chunk()`

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -582,6 +582,7 @@ abstract class BaseModel
      * @return void
      *
      * @throws DataException
+     * @throws InvalidArgumentException if $size is not a positive integer
      */
     abstract public function chunk(int $size, Closure $userFunc);
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -21,6 +21,7 @@ use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\BadMethodCallException;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
@@ -533,10 +534,14 @@ class Model extends BaseModel
      */
     public function chunk(int $size, Closure $userFunc)
     {
+        if ($size <= 0) {
+            throw new InvalidArgumentException('chunk() requires a positive integer for the $size argument.');
+        }
+
         $total  = $this->builder()->countAllResults(false);
         $offset = 0;
 
-        while ($offset <= $total) {
+        while ($offset < $total) {
             $builder = clone $this->builder();
             $rows    = $builder->get($size, $offset);
 

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Models;
 
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\EntityModel;
@@ -37,6 +39,62 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         });
 
         $this->assertSame(4, $rowCount);
+    }
+
+    public function testChunkThrowsOnZeroSize(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('chunk() requires a positive integer for the $size argument.');
+
+        $this->createModel(UserModel::class)->chunk(0, static function ($row): void {});
+    }
+
+    public function testChunkThrowsOnNegativeSize(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('chunk() requires a positive integer for the $size argument.');
+
+        $this->createModel(UserModel::class)->chunk(-1, static function ($row): void {});
+    }
+
+    public function testChunkEarlyExit(): void
+    {
+        $rowCount = 0;
+
+        $this->createModel(UserModel::class)->chunk(2, static function ($row) use (&$rowCount): bool {
+            $rowCount++;
+
+            return false;
+        });
+
+        $this->assertSame(1, $rowCount);
+    }
+
+    public function testChunkDoesNotRunExtraQuery(): void
+    {
+        $queryCount = 0;
+        $listener   = static function () use (&$queryCount): void {
+            $queryCount++;
+        };
+
+        Events::on('DBQuery', $listener);
+        $this->createModel(UserModel::class)->chunk(4, static function ($row): void {});
+        Events::removeListener('DBQuery', $listener);
+
+        $this->assertSame(2, $queryCount);
+    }
+
+    public function testChunkEmptyTable(): void
+    {
+        $this->db->table('user')->truncate();
+
+        $rowCount = 0;
+
+        $this->createModel(UserModel::class)->chunk(2, static function ($row) use (&$rowCount): void {
+            $rowCount++;
+        });
+
+        $this->assertSame(0, $rowCount);
     }
 
     public function testCanCreateAndSaveEntityClasses(): void

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -41,6 +41,7 @@ Bugs Fixed
 - **ContentSecurityPolicy:** Fixed a bug where custom CSP tags were not removed from generated HTML when CSP was disabled. The method now ensures that all custom CSP tags are removed from the generated HTML.
 - **ContentSecurityPolicy:** Fixed a bug where ``generateNonces()`` produces corrupted JSON responses by replacing CSP nonce placeholders with unescaped double quotes. The method now automatically JSON-escapes nonce attributes when the response Content-Type is JSON.
 - **Model:** Fixed a bug where ``BaseModel::updateBatch()`` threw an exception when ``updateOnlyChanged`` was ``true`` and the index field value did not change.
+- **Model:** Fixed a bug where ``Model::chunk()`` ran an unnecessary extra database query at the end of iteration. ``chunk()`` now also throws ``InvalidArgumentException`` when called with a non-positive chunk size.
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.
 


### PR DESCRIPTION
**Description**
This PR fixes a bug where `Model::chunk()` ran an unnecessary extra database query at the end of iteration.

Additionally, `chunk()` now throws `InvalidArgumentException` when called with a chunk size of zero or less. Previously, passing `0` as the size would silently interact with the `Config\Feature::limitZeroAsAll` feature flag, potentially converting `LIMIT 0` into an unlimited query and loading the entire table into memory at once.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
