### PR TITLE
feat: add `chunkRows()` method in models

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -586,6 +586,21 @@ abstract class BaseModel
     abstract public function chunk(int $size, Closure $userFunc);
 
     /**
+     * Loops over records in batches, allowing you to operate on each chunk at a time.
+     * This method works only with DB calls.
+     *
+     * This method calls the `$userFunc` with the chunk, instead of a single record as in `chunk()`.
+     * This allows you to operate on multiple records at once, which can be more efficient for certain operations.
+     *
+     * @param Closure(array<array<string, string>>|array<object>): mixed $userFunc
+     *
+     * @return void
+     *
+     * @throws DataException
+     */
+    abstract public function chunkArray(int $size, Closure $userFunc);
+
+    /**
      * Fetches the row of database.
      *
      * @param int|list<int|string>|string|null $id One primary key or an array of primary keys.

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -595,12 +595,12 @@ abstract class BaseModel
      *
      * @param Closure(list<array<string, string>>|list<object>): mixed $userFunc
      *
-     * @returns void
+     * @return void
      *
      * @throws DataException
      * @throws InvalidArgumentException if $size is not a positive integer
      */
-    abstract public function chunkRows(int $size, Closure $userFunc): void;
+    abstract public function chunkRows(int $size, Closure $userFunc);
 
     /**
      * Fetches the row of database.

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -598,8 +598,9 @@ abstract class BaseModel
      * @return void
      *
      * @throws DataException
+     * @throws InvalidArgumentException if $size is not a positive integer
      */
-    abstract public function chunkArray(int $size, Closure $userFunc);
+    abstract public function chunkRows(int $size, Closure $userFunc);
 
     /**
      * Fetches the row of database.

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -595,12 +595,12 @@ abstract class BaseModel
      *
      * @param Closure(list<array<string, string>>|list<object>): mixed $userFunc
      *
-     * @return void
+     * @returns void
      *
      * @throws DataException
      * @throws InvalidArgumentException if $size is not a positive integer
      */
-    abstract public function chunkRows(int $size, Closure $userFunc);
+    abstract public function chunkRows(int $size, Closure $userFunc): void;
 
     /**
      * Fetches the row of database.

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -592,7 +592,7 @@ abstract class BaseModel
      * This method calls the `$userFunc` with the chunk, instead of a single record as in `chunk()`.
      * This allows you to operate on multiple records at once, which can be more efficient for certain operations.
      *
-     * @param Closure(array<array<string, string>>|array<object>): mixed $userFunc
+     * @param Closure(list<array<string, string>>|list<object>): mixed $userFunc
      *
      * @return void
      *

--- a/system/Model.php
+++ b/system/Model.php
@@ -26,6 +26,7 @@ use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
 use Config\Feature;
+use Generator;
 use stdClass;
 
 /**
@@ -525,7 +526,14 @@ class Model extends BaseModel
         return $this->builder()->testMode($test)->countAllResults($reset);
     }
 
-    private function iterateChunks(int $size): \Generator
+    /**
+     * Iterates over the result set in chunks of the specified size.
+     *
+     * @param int $size The number of records to retrieve in each chunk.
+     *
+     * @returns Generator<array<int, array|object>>
+     */
+    private function iterateChunks(int $size): Generator
     {
         if ($size <= 0) {
             throw new InvalidArgumentException('$size must be a positive integer.');

--- a/system/Model.php
+++ b/system/Model.php
@@ -26,7 +26,6 @@ use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
 use Config\Feature;
-use Generator;
 use stdClass;
 
 /**
@@ -526,7 +525,7 @@ class Model extends BaseModel
         return $this->builder()->testMode($test)->countAllResults($reset);
     }
 
-    private function iterateChunks(int $size): Generator
+    private function iterateChunks(int $size): \Generator
     {
         if ($size <= 0) {
             throw new InvalidArgumentException('$size must be a positive integer.');
@@ -580,7 +579,7 @@ class Model extends BaseModel
      * determine the rows to operate on.
      * This method works only with dbCalls.
      */
-    public function chunkRows(int $size, Closure $userFunc)
+    public function chunkRows(int $size, Closure $userFunc): void
     {
         foreach ($this->iterateChunks($size) as $rows) {
             if ($userFunc($rows) === false) {

--- a/system/Model.php
+++ b/system/Model.php
@@ -531,7 +531,7 @@ class Model extends BaseModel
      *
      * @param int $size The number of records to retrieve in each chunk.
      *
-     * @returns Generator<array<int, array|object>>
+     * @return Generator<list<array<string, string>>|list<object>>
      */
     private function iterateChunks(int $size): Generator
     {
@@ -564,10 +564,6 @@ class Model extends BaseModel
 
     /**
      * {@inheritDoc}
-     *
-     * Works with `$this->builder` to get the Compiled select to
-     * determine the rows to operate on.
-     * This method works only with dbCalls.
      */
     public function chunk(int $size, Closure $userFunc)
     {
@@ -582,10 +578,6 @@ class Model extends BaseModel
 
     /**
      * {@inheritDoc}
-     *
-     * Works with `$this->builder` to get the Compiled select to
-     * determine the rows to operate on.
-     * This method works only with dbCalls.
      */
     public function chunkRows(int $size, Closure $userFunc): void
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -26,6 +26,7 @@ use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
 use Config\Feature;
+use Generator;
 use stdClass;
 
 /**
@@ -525,17 +526,10 @@ class Model extends BaseModel
         return $this->builder()->testMode($test)->countAllResults($reset);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * Works with `$this->builder` to get the Compiled select to
-     * determine the rows to operate on.
-     * This method works only with dbCalls.
-     */
-    public function chunk(int $size, Closure $userFunc)
+    private function iterateChunks(int $size): Generator
     {
         if ($size <= 0) {
-            throw new InvalidArgumentException('chunk() requires a positive integer for the $size argument.');
+            throw new InvalidArgumentException('$size must be a positive integer.');
         }
 
         $total  = $this->builder()->countAllResults(false);
@@ -557,6 +551,20 @@ class Model extends BaseModel
                 continue;
             }
 
+            yield $rows;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Works with `$this->builder` to get the Compiled select to
+     * determine the rows to operate on.
+     * This method works only with dbCalls.
+     */
+    public function chunk(int $size, Closure $userFunc)
+    {
+        foreach ($this->iterateChunks($size) as $rows) {
             foreach ($rows as $row) {
                 if ($userFunc($row) === false) {
                     return;
@@ -572,31 +580,9 @@ class Model extends BaseModel
      * determine the rows to operate on.
      * This method works only with dbCalls.
      */
-    public function chunkArray(int $size, Closure $userFunc)
+    public function chunkRows(int $size, Closure $userFunc)
     {
-        if ($size <= 0) {
-            throw new InvalidArgumentException('chunkArray() requires a positive integer for the $size argument.');
-        }
-
-        $total  = $this->builder()->countAllResults(false);
-        $offset = 0;
-
-        while ($offset < $total) {
-            $builder = clone $this->builder();
-            $rows    = $builder->get($size, $offset);
-
-            if (! $rows) {
-                throw DataException::forEmptyDataset('chunk');
-            }
-
-            $rows = $rows->getResult($this->tempReturnType);
-
-            $offset += $size;
-
-            if ($rows === []) {
-                continue;
-            }
-
+        foreach ($this->iterateChunks($size) as $rows) {
             if ($userFunc($rows) === false) {
                 return;
             }

--- a/system/Model.php
+++ b/system/Model.php
@@ -561,6 +561,40 @@ class Model extends BaseModel
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * Works with `$this->builder` to get the Compiled select to
+     * determine the rows to operate on.
+     * This method works only with dbCalls.
+     */
+    public function chunkArray(int $size, Closure $userFunc)
+    {
+        $total  = $this->builder()->countAllResults(false);
+        $offset = 0;
+
+        while ($offset <= $total) {
+            $builder = clone $this->builder();
+            $rows    = $builder->get($size, $offset);
+
+            if (! $rows) {
+                throw DataException::forEmptyDataset('chunk');
+            }
+
+            $rows = $rows->getResult($this->tempReturnType);
+
+            $offset += $size;
+
+            if ($rows === []) {
+                continue;
+            }
+
+            if ($userFunc($rows) === false) {
+                return;
+            }
+        }
+    }
+
+    /**
      * Provides a shared instance of the Query Builder.
      *
      * @param non-empty-string|null $table

--- a/system/Model.php
+++ b/system/Model.php
@@ -21,6 +21,7 @@ use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\BadMethodCallException;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
@@ -569,10 +570,14 @@ class Model extends BaseModel
      */
     public function chunkArray(int $size, Closure $userFunc)
     {
+        if ($size <= 0) {
+            throw new InvalidArgumentException('chunkArray() requires a positive integer for the $size argument.');
+        }
+
         $total  = $this->builder()->countAllResults(false);
         $offset = 0;
 
-        while ($offset <= $total) {
+        while ($offset < $total) {
             $builder = clone $this->builder();
             $rows    = $builder->get($size, $offset);
 

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Models;
 
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\EntityModel;
@@ -51,6 +53,62 @@ final class MiscellaneousModelTest extends LiveModelTestCase
 
         $this->assertSame(2, $chunkCount);
         $this->assertSame([2, 2], $numRowsInChunk);
+    }
+
+    public function testChunkArrayThrowsOnZeroSize(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('chunkArray() requires a positive integer for the $size argument.');
+
+        $this->createModel(UserModel::class)->chunkArray(0, static function ($row): void {});
+    }
+
+    public function testChunkThrowsOnNegativeSize(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('chunkArray() requires a positive integer for the $size argument.');
+
+        $this->createModel(UserModel::class)->chunkArray(-1, static function ($row): void {});
+    }
+
+    public function testChunkArrayEarlyExit(): void
+    {
+        $rowCount = 0;
+
+        $this->createModel(UserModel::class)->chunkArray(2, static function ($rows) use (&$rowCount): bool {
+            $rowCount++;
+
+            return false;
+        });
+
+        $this->assertSame(1, $rowCount);
+    }
+
+    public function testChunkArrayDoesNotRunExtraQuery(): void
+    {
+        $queryCount = 0;
+        $listener   = static function () use (&$queryCount): void {
+            $queryCount++;
+        };
+
+        Events::on('DBQuery', $listener);
+        $this->createModel(UserModel::class)->chunkArray(4, static function ($rows): void {});
+        Events::removeListener('DBQuery', $listener);
+
+        $this->assertSame(2, $queryCount);
+    }
+
+    public function testChunkArrayEmptyTable(): void
+    {
+        $this->db->table('user')->truncate();
+
+        $rowCount = 0;
+
+        $this->createModel(UserModel::class)->chunkArray(2, static function ($row) use (&$rowCount): void {
+            $rowCount++;
+        });
+
+        $this->assertSame(0, $rowCount);
     }
 
     public function testCanCreateAndSaveEntityClasses(): void

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -116,7 +116,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('$size must be a positive integer.');
 
-        $this->createModel(UserModel::class)->chunkRows(0, static function ($row): void {});;
+        $this->createModel(UserModel::class)->chunkRows(0, static function ($row): void {});
     }
 
     public function testChunkRowsThrowsOnNegativeSize(): void

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -39,6 +39,20 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->assertSame(4, $rowCount);
     }
 
+    public function testChunkArray(): void
+    {
+        $chunkCount = 0;
+        $numRowsInChunk = [];
+
+        $this->createModel(UserModel::class)->chunkArray(2, static function ($rows) use (&$chunkCount, &$numRowsInChunk): void {
+            $chunkCount++;
+            $numRowsInChunk[] = count($rows);
+        });
+
+        $this->assertSame(2, $chunkCount);
+        $this->assertSame([2, 2], $numRowsInChunk);
+    }
+
     public function testCanCreateAndSaveEntityClasses(): void
     {
         $entity = $this->createModel(EntityModel::class)->where('name', 'Developer')->first();

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -41,7 +41,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
 
     public function testChunkArray(): void
     {
-        $chunkCount = 0;
+        $chunkCount     = 0;
         $numRowsInChunk = [];
 
         $this->createModel(UserModel::class)->chunkArray(2, static function ($rows) use (&$chunkCount, &$numRowsInChunk): void {

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -44,7 +44,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
     public function testChunkThrowsOnZeroSize(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('chunk() requires a positive integer for the $size argument.');
+        $this->expectExceptionMessage('$size must be a positive integer.');
 
         $this->createModel(UserModel::class)->chunk(0, static function ($row): void {});
     }
@@ -52,7 +52,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
     public function testChunkThrowsOnNegativeSize(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('chunk() requires a positive integer for the $size argument.');
+        $this->expectExceptionMessage('$size must be a positive integer.');
 
         $this->createModel(UserModel::class)->chunk(-1, static function ($row): void {});
     }
@@ -97,12 +97,12 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->assertSame(0, $rowCount);
     }
 
-    public function testChunkArray(): void
+    public function testChunkRows(): void
     {
         $chunkCount     = 0;
         $numRowsInChunk = [];
 
-        $this->createModel(UserModel::class)->chunkArray(2, static function ($rows) use (&$chunkCount, &$numRowsInChunk): void {
+        $this->createModel(UserModel::class)->chunkRows(2, static function ($rows) use (&$chunkCount, &$numRowsInChunk): void {
             $chunkCount++;
             $numRowsInChunk[] = count($rows);
         });
@@ -111,27 +111,27 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->assertSame([2, 2], $numRowsInChunk);
     }
 
-    public function testChunkArrayThrowsOnZeroSize(): void
+    public function testChunkRowsThrowsOnZeroSize(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('chunkArray() requires a positive integer for the $size argument.');
+        $this->expectExceptionMessage('$size must be a positive integer.');
 
-        $this->createModel(UserModel::class)->chunkArray(0, static function ($row): void {});
+        $this->createModel(UserModel::class)->chunkRows(0, static function ($row): void {});;
     }
 
-    public function testChunkArrayThrowsOnNegativeSize(): void
+    public function testChunkRowsThrowsOnNegativeSize(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('chunkArray() requires a positive integer for the $size argument.');
+        $this->expectExceptionMessage('$size must be a positive integer.');
 
-        $this->createModel(UserModel::class)->chunkArray(-1, static function ($row): void {});
+        $this->createModel(UserModel::class)->chunkRows(-1, static function ($row): void {});
     }
 
-    public function testChunkArrayEarlyExit(): void
+    public function testChunkRowsEarlyExit(): void
     {
         $rowCount = 0;
 
-        $this->createModel(UserModel::class)->chunkArray(2, static function ($rows) use (&$rowCount): bool {
+        $this->createModel(UserModel::class)->chunkRows(2, static function ($rows) use (&$rowCount): bool {
             $rowCount++;
 
             return false;
@@ -140,7 +140,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->assertSame(1, $rowCount);
     }
 
-    public function testChunkArrayDoesNotRunExtraQuery(): void
+    public function testChunkRowsDoesNotRunExtraQuery(): void
     {
         $queryCount = 0;
         $listener   = static function () use (&$queryCount): void {
@@ -148,19 +148,19 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         };
 
         Events::on('DBQuery', $listener);
-        $this->createModel(UserModel::class)->chunkArray(4, static function ($rows): void {});
+        $this->createModel(UserModel::class)->chunkRows(4, static function ($rows): void {});
         Events::removeListener('DBQuery', $listener);
 
         $this->assertSame(2, $queryCount);
     }
 
-    public function testChunkArrayEmptyTable(): void
+    public function testChunkRowsEmptyTable(): void
     {
         $this->db->table('user')->truncate();
 
         $rowCount = 0;
 
-        $this->createModel(UserModel::class)->chunkArray(2, static function ($row) use (&$rowCount): void {
+        $this->createModel(UserModel::class)->chunkRows(2, static function ($row) use (&$rowCount): void {
             $rowCount++;
         });
 

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -71,7 +71,7 @@ Others
 Model
 =====
 
-- Added new ``chunkArray()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks. See :ref:`model-chunk-array` for usage.
+- Added new ``chunkArray()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks.
 
 Libraries
 =========

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -71,7 +71,7 @@ Others
 Model
 =====
 
-- Added new ``chunkArray()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks.
+- Added new ``chunkRows()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks.
 
 Libraries
 =========

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -56,6 +56,8 @@ Others
 Model
 =====
 
+- Added new ``chunkArray()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks. See :ref:`model-chunk-array` for usage.
+
 Libraries
 =========
 

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -908,6 +908,10 @@ This is best used during cronjobs, data exports, or other large tasks.
 
 .. literalinclude:: model/049.php
 
+On the other hand, if you want entire chunk to be passed to the Closure, you can use the chunkArray() method.
+
+.. literalinclude:: model/064.php
+
 .. _model-events-callbacks:
 
 Working with Query Builder

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -900,15 +900,24 @@ Processing Large Amounts of Data
 ================================
 
 Sometimes, you need to process large amounts of data and would run the risk of running out of memory.
-To make this simpler, you may use the chunk() method to get smaller chunks of data that you can then
+This is best used during cronjobs, data exports, or other large tasks. To make this simpler, you can
+process the data in smaller, manageable pieces using the methods below.
+
+chunk()
+-------
+
+You may use the ``chunk()`` method to get smaller chunks of data that you can then
 do your work on. The first parameter is the number of rows to retrieve in a single chunk. The second
 parameter is a Closure that will be called for each row of data.
 
-This is best used during cronjobs, data exports, or other large tasks.
-
 .. literalinclude:: model/049.php
 
-On the other hand, if you want entire chunk to be passed to the Closure, you can use the chunkArray() method.
+chunkRows()
+-----------
+
+.. versionadded:: 4.8.0
+
+On the other hand, if you want the entire chunk to be passed to the Closure at once, you can use the ``chunkRows()`` method.
 
 .. literalinclude:: model/064.php
 

--- a/user_guide_src/source/models/model/064.php
+++ b/user_guide_src/source/models/model/064.php
@@ -1,0 +1,6 @@
+<?php
+
+$userModel->chunkArray(100, static function ($rows) {
+    // do something.
+    // $rows is an array of rows representing chunk of 100 items.
+});

--- a/user_guide_src/source/models/model/064.php
+++ b/user_guide_src/source/models/model/064.php
@@ -1,6 +1,6 @@
 <?php
 
-$userModel->chunkArray(100, static function ($rows) {
+$userModel->chunkRows(100, static function ($rows) {
     // do something.
     // $rows is an array of rows representing chunk of 100 items.
 });


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
This PR adds a `chunkRows()` method in `CodeIgniter\Model` class which allows users to get chunk as a whole instead of single rows, so that they can easily use functions like `array_column(...)` inside the closure.

This PR also extracts common part from `chunk()` and `chunkRows()` method to reduce redundancy.

Related to [this](https://forum.codeigniter.com/showthread.php?tid=93822) forum thread.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
