### PR TITLE
fix: generate inputs for all route params in Debug Toolbar

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -762,7 +762,7 @@ var ciDebugBar = {
         var rowGet = this.toolbar.querySelectorAll(
             'td[data-debugbar-route="GET"]'
         );
-        var patt = /\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\)/;
+        var patt = /\(.+?\)/g;
 
         for (var i = 0; i < rowGet.length; i++) {
             row = rowGet[i];
@@ -788,10 +788,9 @@ var ciDebugBar = {
                     '<form data-debugbar-route-tpl="' +
                     ciDebugBar.trimSlash(row.innerText.replace(patt, "?")) +
                     '">' +
-                    row.innerText.replace(
-                        patt,
-                        '<input id="debugbar-route-id-' + i + '" type="text" placeholder="$1">'
-                    ) +
+                    row.innerText.replace(patt, function (match) {
+                        return '<input type="text" placeholder="' + match + '">';
+                    }) +
                     '<input type="submit" value="Go" class="debug-bar-mleft4">' +
                     "</form>";
             }

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -44,6 +44,7 @@ Bugs Fixed
 - **Model:** Fixed a bug where ``BaseModel::updateBatch()`` threw an exception when ``updateOnlyChanged`` was ``true`` and the index field value did not change.
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.
+- **Toolbar:** Fixed a bug in the Routes panel where only the first route parameter was converted to an input field on hover.
 - **View:** Fixed a bug where ``View`` would throw an error if the ``appOverridesFolder`` config property was not defined.
 
 See the repo's


### PR DESCRIPTION
**Description**
This PR fixes a bug where only the first route parameter was converted to an input field on hover in the Debug Toolbar Routes panel. 

The regex in `routerLink()` was missing the global flag (`g`), causing `String.replace()` to stop after the first match. The fix adds the `g` flag and simplifies the regex to `/\(.+?\)/g`. The replacement now also uses the actual matched pattern (e.g. (`[0-9]+)`, `(.*)`) as the input placeholder instead of the literal `$1`.

Closes #7324
Ref: #3070

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
