### PR TITLE
test: fix determinism of `CacheTest`

### DIFF
--- a/tests/system/Router/Attributes/CacheTest.php
+++ b/tests/system/Router/Attributes/CacheTest.php
@@ -22,6 +22,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @internal
@@ -33,9 +34,8 @@ final class CacheTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        // Clear cache before each test
         cache()->clean();
-
+        Services::resetSingle('response');
         Time::setTestNow('2026-01-10 12:00:00');
     }
 
@@ -43,6 +43,8 @@ final class CacheTest extends CIUnitTestCase
     {
         parent::tearDown();
 
+        cache()->clean();
+        Services::resetSingle('response');
         Time::setTestNow();
     }
 
@@ -215,11 +217,17 @@ final class CacheTest extends CIUnitTestCase
 
         $request = $this->getMockBuilder(IncomingRequest::class)
             ->setConstructorArgs([$config, $uri, null, $userAgent])
-            ->onlyMethods(['isCLI'])
+            ->onlyMethods(['isCLI', 'withMethod', 'getMethod'])
             ->getMock();
         $request->method('isCLI')->willReturn(false);
-        $request->setMethod($method);
+        $request->method('withMethod')->willReturnCallback(
+            static function (string $method) use ($request): MockObject&IncomingRequest {
+                $request->method('getMethod')->willReturn($method);
 
-        return $request;
+                return $request;
+            },
+        );
+
+        return $request->withMethod($method);
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
When running `vendor/bin/phpunit --filter Response`, `CodeIgniter\Router\Attributes\CacheTest::testAfterCachesGetRequestResponse` will fail because the previous test (`testBeforeReturnsCachedResponseWhenFound()`) pollutes the cache entries and response object. This can also be validated by running `vendor/bin/phpunit --filter CacheTest --order-by=random`.

To test, both mentioned should pass.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
