### PR TITLE
refactor: cleanup deprecations in `CodeIgniter`

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -34,12 +34,7 @@ use CodeIgniter\Router\Router;
 use Config\App;
 use Config\Cache;
 use Config\Feature;
-use Config\Kint as KintConfig;
 use Config\Services;
-use Exception;
-use Kint;
-use Kint\Renderer\CliRenderer;
-use Kint\Renderer\RichRenderer;
 use Locale;
 use Throwable;
 
@@ -128,15 +123,6 @@ class CodeIgniter
     protected $output;
 
     /**
-     * Cache expiration time
-     *
-     * @var int seconds
-     *
-     * @deprecated 4.4.0 Moved to ResponseCache::$ttl. No longer used.
-     */
-    protected static $cacheTTL = 0;
-
-    /**
      * Context
      *  web:     Invoked by HTTP request
      *  php-cli: Invoked by CLI via `php public/index.php`
@@ -149,13 +135,6 @@ class CodeIgniter
      * Whether to enable Control Filters.
      */
     protected bool $enableFilters = true;
-
-    /**
-     * Whether to return Response object or send response.
-     *
-     * @deprecated 4.4.0 No longer used.
-     */
-    protected bool $returnResponse = false;
 
     /**
      * Application output buffering level
@@ -211,89 +190,6 @@ class CodeIgniter
     }
 
     /**
-     * Initializes Kint
-     *
-     * @return void
-     *
-     * @deprecated 4.5.0 Moved to Autoloader.
-     */
-    protected function initializeKint()
-    {
-        if (CI_DEBUG) {
-            $this->autoloadKint();
-            $this->configureKint();
-        } elseif (class_exists(Kint::class)) {
-            // In case that Kint is already loaded via Composer.
-            Kint::$enabled_mode = false;
-            // @codeCoverageIgnore
-        }
-
-        helper('kint');
-    }
-
-    /**
-     * @deprecated 4.5.0 Moved to Autoloader.
-     */
-    private function autoloadKint(): void
-    {
-        // If we have KINT_DIR it means it's already loaded via composer
-        if (! defined('KINT_DIR')) {
-            spl_autoload_register(function ($class): void {
-                $class = explode('\\', $class);
-
-                if (array_shift($class) !== 'Kint') {
-                    return;
-                }
-
-                $file = SYSTEMPATH . 'ThirdParty/Kint/' . implode('/', $class) . '.php';
-
-                if (is_file($file)) {
-                    require_once $file;
-                }
-            });
-
-            require_once SYSTEMPATH . 'ThirdParty/Kint/init.php';
-        }
-    }
-
-    /**
-     * @deprecated 4.5.0 Moved to Autoloader.
-     */
-    private function configureKint(): void
-    {
-        $config = new KintConfig();
-
-        Kint::$depth_limit         = $config->maxDepth;
-        Kint::$display_called_from = $config->displayCalledFrom;
-        Kint::$expanded            = $config->expanded;
-
-        if (isset($config->plugins) && is_array($config->plugins)) {
-            Kint::$plugins = $config->plugins;
-        }
-
-        $csp = Services::csp();
-        if ($csp->enabled()) {
-            RichRenderer::$js_nonce  = $csp->getScriptNonce();
-            RichRenderer::$css_nonce = $csp->getStyleNonce();
-        }
-
-        RichRenderer::$theme  = $config->richTheme;
-        RichRenderer::$folder = $config->richFolder;
-
-        if (isset($config->richObjectPlugins) && is_array($config->richObjectPlugins)) {
-            RichRenderer::$value_plugins = $config->richObjectPlugins;
-        }
-        if (isset($config->richTabPlugins) && is_array($config->richTabPlugins)) {
-            RichRenderer::$tab_plugins = $config->richTabPlugins;
-        }
-
-        CliRenderer::$cli_colors         = $config->cliColors;
-        CliRenderer::$force_utf8         = $config->cliForceUTF8;
-        CliRenderer::$detect_width       = $config->cliDetectWidth;
-        CliRenderer::$min_terminal_width = $config->cliMinWidth;
-    }
-
-    /**
      * Launch the application!
      *
      * This is "the loop" if you will. The main entry point into the script
@@ -337,7 +233,7 @@ class CodeIgniter
             $this->response = $possibleResponse;
         } else {
             try {
-                $this->response = $this->handleRequest($routes, config(Cache::class), $returnResponse);
+                $this->response = $this->handleRequest($routes);
             } catch (ResponsableInterface $e) {
                 $this->outputBufferingEnd();
 
@@ -365,9 +261,6 @@ class CodeIgniter
         return null;
     }
 
-    /**
-     * Run required before filters.
-     */
     private function runRequiredBeforeFilters(Filters $filters): ?ResponseInterface
     {
         $possibleResponse = $filters->runRequired('before');
@@ -381,14 +274,10 @@ class CodeIgniter
         return null;
     }
 
-    /**
-     * Run required after filters.
-     */
     private function runRequiredAfterFilters(Filters $filters): void
     {
         $filters->setResponse($this->response);
 
-        // Run required after filters
         $this->benchmark->start('required_after_filters');
         $response = $filters->runRequired('after');
         $this->benchmark->stop('required_after_filters');
@@ -429,11 +318,14 @@ class CodeIgniter
      *
      * @throws PageNotFoundException
      * @throws RedirectException
-     *
-     * @deprecated $returnResponse is deprecated.
      */
-    protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
+    protected function handleRequest(?RouteCollectionInterface $routes, ?Cache $cacheConfig = null)
     {
+        if (func_num_args() > 1) {
+            // @todo v4.8.0: Remove this check and the $cacheConfig parameter from the method signature.
+            @trigger_error(sprintf('Since v4.8.0, the $cacheConfig parameter of %s is deprecated and no longer used.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         if ($this->request instanceof IncomingRequest && $this->request->getMethod() === 'CLI') {
             return $this->response->setStatusCode(405)->setBody('Method Not Allowed');
         }
@@ -481,7 +373,7 @@ class CodeIgniter
 
         // If startController returned a Response (from an attribute or Closure), use it
         if ($returned instanceof ResponseInterface) {
-            $this->gatherOutput($cacheConfig, $returned);
+            $this->gatherOutput($returned);
         }
         // Closure controller has run in startController().
         elseif (! is_callable($this->controller)) {
@@ -503,7 +395,7 @@ class CodeIgniter
         // If $returned is a string, then the controller output something,
         // probably a view, instead of echoing it directly. Send it along
         // so it can be used with the output.
-        $this->gatherOutput($cacheConfig, $returned);
+        $this->gatherOutput($returned);
 
         if ($this->enableFilters) {
             /** @var Filters $filters */
@@ -540,55 +432,6 @@ class CodeIgniter
         unset($uri);
 
         return $this->response;
-    }
-
-    /**
-     * You can load different configurations depending on your
-     * current environment. Setting the environment also influences
-     * things like logging and error reporting.
-     *
-     * This can be set to anything, but default usage is:
-     *
-     *     development
-     *     testing
-     *     production
-     *
-     * @codeCoverageIgnore
-     *
-     * @return void
-     *
-     * @deprecated 4.4.0 No longer used. Moved to index.php and spark.
-     */
-    protected function detectEnvironment()
-    {
-        // Make sure ENVIRONMENT isn't already set by other means.
-        if (! defined('ENVIRONMENT')) {
-            define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
-        }
-    }
-
-    /**
-     * Load any custom boot files based upon the current environment.
-     *
-     * If no boot file exists, we shouldn't continue because something
-     * is wrong. At the very least, they should have error reporting setup.
-     *
-     * @return void
-     *
-     * @deprecated 4.5.0 Moved to system/bootstrap.php.
-     */
-    protected function bootstrapEnvironment()
-    {
-        if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
-            require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
-        } else {
-            // @codeCoverageIgnoreStart
-            header('HTTP/1.1 503 Service Unavailable.', true, 503);
-            echo 'The application environment is not set correctly.';
-
-            exit(EXIT_ERROR); // EXIT_ERROR
-            // @codeCoverageIgnoreEnd
-        }
     }
 
     /**
@@ -671,86 +514,6 @@ class CodeIgniter
     }
 
     /**
-     * Force Secure Site Access? If the config value 'forceGlobalSecureRequests'
-     * is true, will enforce that all requests to this site are made through
-     * HTTPS. Will redirect the user to the current page with HTTPS, as well
-     * as set the HTTP Strict Transport Security header for those browsers
-     * that support it.
-     *
-     * @param int $duration How long the Strict Transport Security
-     *                      should be enforced for this URL.
-     *
-     * @return void
-     *
-     * @deprecated 4.5.0 No longer used. Moved to ForceHTTPS filter.
-     */
-    protected function forceSecureAccess($duration = 31_536_000)
-    {
-        if ($this->config->forceGlobalSecureRequests !== true) {
-            return;
-        }
-
-        force_https($duration, $this->request, $this->response);
-    }
-
-    /**
-     * Determines if a response has been cached for the given URI.
-     *
-     * @return false|ResponseInterface
-     *
-     * @throws Exception
-     *
-     * @deprecated 4.5.0 PageCache required filter is used. No longer used.
-     * @deprecated 4.4.2 The parameter $config is deprecated. No longer used.
-     */
-    public function displayCache(Cache $config)
-    {
-        $cachedResponse = $this->pageCache->get($this->request, $this->response);
-        if ($cachedResponse instanceof ResponseInterface) {
-            $this->response = $cachedResponse;
-
-            $this->totalTime = $this->benchmark->getElapsedTime('total_execution');
-            $output          = $this->displayPerformanceMetrics($cachedResponse->getBody());
-            $this->response->setBody($output);
-
-            return $this->response;
-        }
-
-        return false;
-    }
-
-    /**
-     * Tells the app that the final output should be cached.
-     *
-     * @deprecated 4.4.0 Moved to ResponseCache::setTtl(). No longer used.
-     *
-     * @return void
-     */
-    public static function cache(int $time)
-    {
-        static::$cacheTTL = $time;
-    }
-
-    /**
-     * Caches the full response from the current request. Used for
-     * full-page caching for very high performance.
-     *
-     * @return bool
-     *
-     * @deprecated 4.4.0 No longer used.
-     */
-    public function cachePage(Cache $config)
-    {
-        $headers = [];
-
-        foreach ($this->response->headers() as $header) {
-            $headers[$header->getName()] = $header->getValueLine();
-        }
-
-        return cache()->save($this->generateCacheName($config), serialize(['headers' => $headers, 'output' => $this->output]), static::$cacheTTL);
-    }
-
-    /**
      * Returns an array with our basic performance stats collected.
      */
     public function getPerformanceStats(): array
@@ -762,40 +525,6 @@ class CodeIgniter
             'startTime' => $this->startTime,
             'totalTime' => $this->totalTime,
         ];
-    }
-
-    /**
-     * Generates the cache name to use for our full-page caching.
-     *
-     * @deprecated 4.4.0 No longer used.
-     */
-    protected function generateCacheName(Cache $config): string
-    {
-        if ($this->request instanceof CLIRequest) {
-            return md5($this->request->getPath());
-        }
-
-        $uri = clone $this->request->getUri();
-
-        $query = $config->cacheQueryString
-            ? $uri->getQuery(is_array($config->cacheQueryString) ? ['only' => $config->cacheQueryString] : [])
-            : '';
-
-        return md5((string) $uri->setFragment('')->setQuery($query));
-    }
-
-    /**
-     * Replaces the elapsed_time and memory_usage tag.
-     *
-     * @deprecated 4.5.0 PerformanceMetrics required filter is used. No longer used.
-     */
-    public function displayPerformanceMetrics(string $output): string
-    {
-        return str_replace(
-            ['{elapsed_time}', '{memory_usage}'],
-            [(string) $this->totalTime, number_format(memory_get_peak_usage() / 1024 / 1024, 3)],
-            $output,
-        );
     }
 
     /**
@@ -838,19 +567,6 @@ class CodeIgniter
         $this->benchmark->stop('routing');
 
         return $this->router->getFilters();
-    }
-
-    /**
-     * Determines the path to use for us to try to route to, based
-     * on the CLI/IncomingRequest path.
-     *
-     * @return string
-     *
-     * @deprecated 4.5.0 No longer used.
-     */
-    protected function determinePath()
-    {
-        return $this->request->getPath();
     }
 
     /**
@@ -989,8 +705,7 @@ class CodeIgniter
 
             unset($override);
 
-            $cacheConfig = config(Cache::class);
-            $this->gatherOutput($cacheConfig, $returned);
+            $this->gatherOutput($returned);
 
             return $this->response;
         }
@@ -1007,14 +722,11 @@ class CodeIgniter
      * Gathers the script output from the buffer, replaces some execution
      * time tag in the output and displays the debug toolbar, if required.
      *
-     * @param Cache|null                    $cacheConfig Deprecated. No longer used.
      * @param ResponseInterface|string|null $returned
-     *
-     * @deprecated $cacheConfig is deprecated.
      *
      * @return void
      */
-    protected function gatherOutput(?Cache $cacheConfig = null, $returned = null)
+    protected function gatherOutput($returned = null)
     {
         $this->output = $this->outputBufferingEnd();
 
@@ -1123,24 +835,6 @@ class CodeIgniter
     protected function sendResponse()
     {
         $this->response->send();
-    }
-
-    /**
-     * Exits the application, setting the exit code for CLI-based applications
-     * that might be watching.
-     *
-     * Made into a separate method so that it can be mocked during testing
-     * without actually stopping script execution.
-     *
-     * @param int $code
-     *
-     * @deprecated 4.4.0 No longer Used. Moved to index.php.
-     *
-     * @return void
-     */
-    protected function callExit($code)
-    {
-        exit($code); // @codeCoverageIgnore
     }
 
     /**

--- a/system/Test/Mock/MockCodeIgniter.php
+++ b/system/Test/Mock/MockCodeIgniter.php
@@ -18,14 +18,4 @@ use CodeIgniter\CodeIgniter;
 class MockCodeIgniter extends CodeIgniter
 {
     protected ?string $context = 'web';
-
-    /**
-     * @param int $code
-     *
-     * @deprecated 4.4.0 No longer Used. Moved to index.php.
-     */
-    protected function callExit($code)
-    {
-        // Do not call exit() in testing.
-    }
 }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -789,12 +789,9 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $routes = service('routes');
         $routes->add('test', static function () {
-            CodeIgniter::cache(3600);
+            service('responsecache')->setTtl(3600);
 
-            $response = service('response');
-            $string   = 'This is a test page. Elapsed time: {elapsed_time}';
-
-            return $response->setBody($string);
+            return service('response')->setBody('This is a test page. Elapsed time: {elapsed_time}');
         });
         $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -34,6 +34,14 @@ Interface Changes
 Method Signature Changes
 ========================
 
+- **CodeIgniter:** The deprecated parameters in methods have been removed:
+    - ``CodeIgniter\CodeIgniter::handleRequest()`` no longer accepts the deprecated ``$cacheConfig`` and ``$returnResponse`` parameters.
+       - ``$cacheConfig`` is no longer used and is now hard deprecated. A deprecation notice will be triggered if this is passed to the method.
+       - ``$returnResponse`` is now removed since already deprecated and unused.
+       - The updated method signature is now ``handleRequest(?RouteCollectionInterface $routes, ?Cache $cacheConfig = null)``.
+    - ``CodeIgniter\CodeIgniter::gatherOutput()`` no longer accepts the deprecated ``$cacheConfig`` parameter.
+       As this is the first parameter, custom uses of this method will need to be updated to remove the parameter.
+
 Removed Deprecated Items
 ========================
 
@@ -45,6 +53,21 @@ Removed Deprecated Items
     - ``CodeIgniter\Cache\Handlers\FileHandler::deleteFile()``
     - ``CodeIgniter\Cache\Handlers\FileHandler::getDirFileInfo()``
     - ``CodeIgniter\Cache\Handlers\FileHandler::getFileInfo()``
+- **CodeIgniter:** Removed the following properties and methods deprecated:
+    - ``CodeIgniter\CodeIgniter::$cacheTTL``
+    - ``CodeIgniter\CodeIgniter::$returnResponse``
+    - ``CodeIgniter\CodeIgniter::initializeKint()``
+    - ``CodeIgniter\CodeIgniter::detectEnvironment()``
+    - ``CodeIgniter\CodeIgniter::bootstrapEnvironment()``
+    - ``CodeIgniter\CodeIgniter::forceSecureAccess()``
+    - ``CodeIgniter\CodeIgniter::displayCache()``
+    - ``CodeIgniter\CodeIgniter::cache()``
+    - ``CodeIgniter\CodeIgniter::cachePage()``
+    - ``CodeIgniter\CodeIgniter::generateCacheName()``
+    - ``CodeIgniter\CodeIgniter::displayPerformanceMetrics()``
+    - ``CodeIgniter\CodeIgniter::determinePath()``
+    - ``CodeIgniter\CodeIgniter::callExit()``
+    - ``CodeIgniter\Test\MockCodeIgniter::callExit()``
 - **Exceptions:** Removed the following properties and methods deprecated since v4.4.0:
     - ``CodeIgniter\Debug\Exceptions::$ob_level``
     - ``CodeIgniter\Debug\Exceptions::$viewPath``


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
- Removes deprecated properties and methods
- Deprecated `$cacheConfig` parameter in `gatherOutput()` is removed
- Updated `handleRequest()`:
   * `$returnResponse` is now removed since already deprecated before
   * `$cacheConfig` is now unused because of above change in `gatherOutput()` thus hard deprecated

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
