### PR TITLE
refactor: remove case-insensitive comparison for HTTP methods in `FilterCollector`

### DIFF
--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -37,7 +37,8 @@ final readonly class FilterCollector
     }
 
     /**
-     * Returns filters for the URI
+     * Returns filters for the URI based on the HTTP method.
+     * The HTTP method is compared case-sensitively.
      *
      * @param string $method HTTP verb like `GET`,`POST` or `CLI`.
      * @param string $uri    URI path to find filters for
@@ -46,25 +47,8 @@ final readonly class FilterCollector
      */
     public function get(string $method, string $uri): array
     {
-        if ($method === strtolower($method)) {
-            @trigger_error(
-                'Passing lowercase HTTP method "' . $method . '" is deprecated.'
-                . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
-                E_USER_DEPRECATED,
-            );
-        }
-
-        /**
-         * @deprecated 4.5.0
-         * @TODO Remove this in the future.
-         */
-        $method = strtoupper($method);
-
         if ($method === 'CLI') {
-            return [
-                'before' => [],
-                'after'  => [],
-            ];
+            return ['before' => [], 'after' => []];
         }
 
         $request = service('incomingrequest', null, false);
@@ -79,7 +63,8 @@ final readonly class FilterCollector
     }
 
     /**
-     * Returns filter classes for the URI
+     * Returns filter classes for the URI based on the HTTP method.
+     * The HTTP method is compared case-sensitively.
      *
      * @param string $method HTTP verb like `GET`,`POST` or `CLI`.
      * @param string $uri    URI path to find filters for
@@ -88,25 +73,8 @@ final readonly class FilterCollector
      */
     public function getClasses(string $method, string $uri): array
     {
-        if ($method === strtolower($method)) {
-            @trigger_error(
-                'Passing lowercase HTTP method "' . $method . '" is deprecated.'
-                . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
-                E_USER_DEPRECATED,
-            );
-        }
-
-        /**
-         * @deprecated 4.5.0
-         * @TODO Remove this in the future.
-         */
-        $method = strtoupper($method);
-
         if ($method === 'CLI') {
-            return [
-                'before' => [],
-                'after'  => [],
-            ];
+            return ['before' => [], 'after' => []];
         }
 
         $request = service('incomingrequest', null, false);

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -34,12 +34,6 @@ final class FilterCollectorTest extends CIUnitTestCase
 
         $filters = $collector->get(Method::GET, '/');
 
-        $expected = [
-            'before' => [
-            ],
-            'after' => [
-            ],
-        ];
-        $this->assertSame($expected, $filters);
+        $this->assertSame(['before' => [], 'after' => []], $filters);
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -23,6 +23,9 @@ BREAKING
 Behavior Changes
 ================
 
+- **Commands:** The ``get()`` and ``getClasses()`` methods of ``FilterCollector`` now compare the HTTP method case-sensitively.
+    This may affect filters defined for methods like `get`, `post`, etc., which should be updated to uppercase (e.g., `GET`, `POST`) to ensure they are applied correctly.
+
 Interface Changes
 =================
 

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -23,8 +23,7 @@ BREAKING
 Behavior Changes
 ================
 
-- **Commands:** The ``get()`` and ``getClasses()`` methods of ``FilterCollector`` now compare the HTTP method case-sensitively.
-    This may affect filters defined for methods like `get`, `post`, etc., which should be updated to uppercase (e.g., `GET`, `POST`) to ensure they are applied correctly.
+- **Commands:** The ``filter:check`` command now requires the HTTP method argument to be uppercase (e.g., ``spark filter:check GET /`` instead of ``spark filter:check get /``).
 
 Interface Changes
 =================


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.7"__

-->
**Description**
The case-insensitive comparison was hard deprecated in v4.5

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
