### PR TITLE
refactor: make random-order API tests deterministic

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -53,7 +53,15 @@ final class ResponseTraitTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        Services::superglobals()->setGetArray([]);
         $this->formatter = new JSONFormatter();
+    }
+
+    protected function tearDown(): void
+    {
+        Services::superglobals()->setGetArray([]);
+
+        parent::tearDown();
     }
 
     private function createAppConfig(): App
@@ -826,7 +834,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         // Create controller with page=2 in query string
         $controller = $this->makeController('/api/items?page=2');
-        Services::superglobals()->setGet('page', '2');
+        $this->request->setGlobal('get', ['page' => '2']);
 
         $this->invoke($controller, 'paginate', [$model, 20]);
 
@@ -847,8 +855,8 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $model = $this->createMockModelWithPager($data, 2, 20, 100, 5);
 
-        Services::superglobals()->setGet('page', '2');
         $controller = $this->makeController('/api/items?page=2');
+        $this->request->setGlobal('get', ['page' => '2']);
 
         $this->invoke($controller, 'paginate', [$model, 20]);
 
@@ -893,8 +901,8 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $model = $this->createMockModelWithPager($data, 3, 20, 50, 3);
 
-        Services::superglobals()->setGet('page', '3');
         $controller = $this->makeController('/api/items?page=3');
+        $this->request->setGlobal('get', ['page' => '3']);
 
         $this->invoke($controller, 'paginate', [$model, 20]);
 
@@ -912,8 +920,8 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $model = $this->createMockModelWithPager($data, 2, 20, 100, 5);
 
-        Services::superglobals()->setGet('page', '2');
         $controller = $this->makeController('/api/items?page=2');
+        $this->request->setGlobal('get', ['page' => '2']);
 
         $this->invoke($controller, 'paginate', [$model, 20]);
 
@@ -1018,9 +1026,8 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $model = $this->createMockModelWithPager($data, 1, 20, 50, 3);
 
-        Services::superglobals()->setGet('filter', 'active');
-        Services::superglobals()->setGet('sort', 'name');
         $controller = $this->makeController('/api/items?filter=active&sort=name');
+        $this->request->setGlobal('get', ['filter' => 'active', 'sort' => 'name']);
 
         $this->invoke($controller, 'paginate', [$model, 20]);
 

--- a/tests/system/API/TransformerTest.php
+++ b/tests/system/API/TransformerTest.php
@@ -19,6 +19,7 @@ use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
+use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
@@ -28,6 +29,20 @@ use stdClass;
 #[Group('Others')]
 final class TransformerTest extends CIUnitTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Services::superglobals()->setGetArray([]);
+    }
+
+    protected function tearDown(): void
+    {
+        Services::superglobals()->setGetArray([]);
+
+        parent::tearDown();
+    }
+
     private function createMockRequest(string $query = ''): IncomingRequest
     {
         $config    = new MockAppConfig();
@@ -318,6 +333,9 @@ final class TransformerTest extends CIUnitTestCase
                 return $resource;
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -341,6 +359,9 @@ final class TransformerTest extends CIUnitTestCase
                 return $resource;
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -367,11 +388,17 @@ final class TransformerTest extends CIUnitTestCase
                 return $resource;
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
             }
 
+            /**
+             * @return list<array{id: int, text: string}>
+             */
             protected function includeComments(): array
             {
                 return [['id' => 1, 'text' => 'Comment 1']];
@@ -399,6 +426,9 @@ final class TransformerTest extends CIUnitTestCase
                 return $resource;
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -427,6 +457,9 @@ final class TransformerTest extends CIUnitTestCase
                 return [];
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -450,6 +483,9 @@ final class TransformerTest extends CIUnitTestCase
                 return $resource;
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -502,6 +538,9 @@ final class TransformerTest extends CIUnitTestCase
                 return $resource;
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -561,6 +600,9 @@ final class TransformerTest extends CIUnitTestCase
                 return ['id' => $resource['id'], 'name' => $resource['name']];
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];
@@ -584,6 +626,9 @@ final class TransformerTest extends CIUnitTestCase
                 return ['id' => $resource['id'], 'name' => $resource['name']];
             }
 
+            /**
+             * @return list<array{id: int, title: string}>
+             */
             protected function includePosts(): array
             {
                 return [['id' => 1, 'title' => 'Post 1']];

--- a/utils/phpstan-baseline/function.alreadyNarrowedType.neon
+++ b/utils/phpstan-baseline/function.alreadyNarrowedType.neon
@@ -3,11 +3,11 @@
 parameters:
     ignoreErrors:
         -
-            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:190\) and ''stringAsHtml'' will always evaluate to true\.$#'
+            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:198\) and ''stringAsHtml'' will always evaluate to true\.$#'
             count: 1
             path: ../../tests/system/API/ResponseTraitTest.php
 
         -
-            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:310\) and ''stringAsHtml'' will always evaluate to true\.$#'
+            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:318\) and ''stringAsHtml'' will always evaluate to true\.$#'
             count: 1
             path: ../../tests/system/API/ResponseTraitTest.php

--- a/utils/phpstan-baseline/function.impossibleType.neon
+++ b/utils/phpstan-baseline/function.impossibleType.neon
@@ -8,11 +8,11 @@ parameters:
             path: ../../system/Debug/ExceptionHandler.php
 
         -
-            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:132\) and ''stringAsHtml'' will always evaluate to false\.$#'
+            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:140\) and ''stringAsHtml'' will always evaluate to false\.$#'
             count: 1
             path: ../../tests/system/API/ResponseTraitTest.php
 
         -
-            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:630\) and ''stringAsHtml'' will always evaluate to false\.$#'
+            message: '#^Call to function property_exists\(\) with \$this\(class@anonymous/tests/system/API/ResponseTraitTest\.php\:638\) and ''stringAsHtml'' will always evaluate to false\.$#'
             count: 1
             path: ../../tests/system/API/ResponseTraitTest.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2126 errors
+# total 2116 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1269 errors
+# total 1259 errors
 
 parameters:
     ignoreErrors:
@@ -4741,56 +4741,6 @@ parameters:
             message: '#^Method CodeIgniter\\View\\Parser\:\:replaceSingle\(\) has parameter \$pattern with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/View/Parser.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:315\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:338\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:364\:\:includeComments\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:364\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:396\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:419\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:447\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:499\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:558\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\API\\BaseTransformer@anonymous/tests/system/API/TransformerTest\.php\:581\:\:includePosts\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/API/TransformerTest.php
 
         -
             message: '#^Method CodeIgniter\\AutoReview\\ComposerJsonTest\:\:checkConfig\(\) has parameter \$fromComponent with no value type specified in iterable type array\.$#'


### PR DESCRIPTION
**Description**
This PR stabilizes API tests under random execution order and fixes some static analysis types.

Ref: #9968 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
