### PR TITLE
refactor: revert property promotion on `Exceptions`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -125,11 +125,12 @@ return RectorConfig::configure()
         // use mt_rand instead of random_int on purpose on non-cryptographically random
         RandomFunctionRector::class,
 
-        // PHP 8.0 features but cause breaking changes
+        // CPP of untyped properties may break code of extended classes
         ClassPropertyAssignToConstructorPromotionRector::class => [
             __DIR__ . '/system/Database/BaseResult.php',
             __DIR__ . '/system/Database/RawSql.php',
             __DIR__ . '/system/Debug/BaseExceptionHandler.php',
+            __DIR__ . '/system/Debug/Exceptions.php',
             __DIR__ . '/system/Filters/Filters.php',
             __DIR__ . '/system/HTTP/CURLRequest.php',
             __DIR__ . '/system/HTTP/DownloadResponse.php',

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -34,6 +34,13 @@ class Exceptions
     use ResponseTrait;
 
     /**
+     * Config for debug exceptions.
+     *
+     * @var ExceptionsConfig
+     */
+    protected $config;
+
+    /**
      * The request.
      *
      * @var CLIRequest|IncomingRequest
@@ -49,9 +56,9 @@ class Exceptions
 
     private ?Throwable $exceptionCaughtByExceptionHandler = null;
 
-    public function __construct(
-        protected ExceptionsConfig $config,
-    ) {
+    public function __construct(ExceptionsConfig $config)
+    {
+        $this->config = $config;
     }
 
     /**


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
I promoted the $config in Exceptions without realizing it may break existing extended classes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
