### PR TITLE
refactor: make random-order CLI tests deterministic

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1131,6 +1131,34 @@ class CLI
      *
      * @testTag
      */
+    public static function reset(): void
+    {
+        static::$initialized = false;
+        static::$segments    = [];
+        static::$options     = [];
+        static::$lastWrite   = 'write';
+        static::$height      = null;
+        static::$width       = null;
+        static::$isColored   = false;
+
+        static::resetInputOutput();
+    }
+
+    /**
+     * Testing purpose only
+     *
+     * @testTag
+     */
+    public static function resetLastWrite(): void
+    {
+        static::$lastWrite = null;
+    }
+
+    /**
+     * Testing purpose only
+     *
+     * @testTag
+     */
     public static function setInputOutput(InputOutput $io): void
     {
         static::$io = $io;

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1139,7 +1139,7 @@ class CLI
         static::$lastWrite   = 'write';
         static::$height      = null;
         static::$width       = null;
-        static::$isColored   = false;
+        static::$isColored   = static::hasColorSupport(STDOUT);
 
         static::resetInputOutput();
     }

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1129,7 +1129,7 @@ class CLI
     /**
      * Testing purpose only
      *
-     * @testTag
+     * @internal
      */
     public static function reset(): void
     {
@@ -1147,7 +1147,7 @@ class CLI
     /**
      * Testing purpose only
      *
-     * @testTag
+     * @internal
      */
     public static function resetLastWrite(): void
     {
@@ -1157,7 +1157,7 @@ class CLI
     /**
      * Testing purpose only
      *
-     * @testTag
+     * @internal
      */
     public static function setInputOutput(InputOutput $io): void
     {
@@ -1167,7 +1167,7 @@ class CLI
     /**
      * Testing purpose only
      *
-     * @testTag
+     * @internal
      */
     public static function resetInputOutput(): void
     {

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -36,6 +36,15 @@ final class CLITest extends CIUnitTestCase
         parent::setUp();
 
         Services::injectMock('superglobals', new Superglobals());
+
+        CLI::init();
+    }
+
+    protected function tearDown(): void
+    {
+        CLI::reset();
+
+        parent::tearDown();
     }
 
     public function testNew(): void
@@ -286,10 +295,6 @@ final class CLITest extends CIUnitTestCase
 
     public function testColor(): void
     {
-        // After the tests on NO_COLOR and TERM_PROGRAM above,
-        // the $isColored variable is rigged. So we reset this.
-        CLI::init();
-
         $this->assertSame(
             "\033[1;37m\033[42m\033[4mtest\033[0m",
             CLI::color('test', 'white', 'green', 'underline'),
@@ -330,6 +335,8 @@ final class CLITest extends CIUnitTestCase
 
     public function testWrite(): void
     {
+        CLI::resetLastWrite();
+
         CLI::write('test');
 
         $expected = PHP_EOL . 'test' . PHP_EOL;

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -37,6 +37,7 @@ final class ConsoleTest extends CIUnitTestCase
         parent::setUp();
 
         Services::injectMock('superglobals', new Superglobals());
+        CLI::init();
 
         $env = new DotEnv(ROOTPATH);
         $env->load();
@@ -48,6 +49,13 @@ final class ConsoleTest extends CIUnitTestCase
 
         $this->app = new MockCodeIgniter(new MockCLIConfig());
         $this->app->initialize();
+    }
+
+    protected function tearDown(): void
+    {
+        CLI::reset();
+
+        parent::tearDown();
     }
 
     public function testHeader(): void


### PR DESCRIPTION
**Description**
This PR stabilizes CLI tests under random execution order and fixes some static analysis types.

Ref: https://github.com/codeigniter4/CodeIgniter4/issues/9968

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
