### PR TITLE
refactor: remove deprecations in HTTP

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -313,7 +313,7 @@ class CURLRequest extends OutgoingRequest
     protected function parseOptions(array $options)
     {
         if (array_key_exists('baseURI', $options)) {
-            $this->baseURI = $this->baseURI->setURI($options['baseURI']);
+            $this->baseURI = new URI($options['baseURI'], true);
             unset($options['baseURI']);
         }
 

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -61,39 +61,6 @@ class Message implements MessageInterface
     }
 
     /**
-     * Returns an array containing all headers.
-     *
-     * @return array<string, Header> An array of the request headers
-     *
-     * @deprecated 4.0.5 Use Message::headers() to make room for PSR-7
-     *
-     * @TODO Incompatible return value with PSR-7
-     *
-     * @codeCoverageIgnore
-     */
-    public function getHeaders(): array
-    {
-        return $this->headers();
-    }
-
-    /**
-     * Returns a single header object. If multiple headers with the same
-     * name exist, then will return an array of header objects.
-     *
-     * @return array|Header|null
-     *
-     * @deprecated 4.0.5 Use Message::header() to make room for PSR-7
-     *
-     * @TODO Incompatible return value with PSR-7
-     *
-     * @codeCoverageIgnore
-     */
-    public function getHeader(string $name)
-    {
-        return $this->header($name);
-    }
-
-    /**
      * Determines whether a header exists.
      */
     public function hasHeader(string $name): bool

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -36,12 +36,8 @@ trait RequestTrait
 
     /**
      * IP address of the current user.
-     *
-     * @var string
-     *
-     * @deprecated 4.0.5 Will become private in a future release
      */
-    protected $ipAddress = '';
+    private string $ipAddress = '';
 
     /**
      * Stores values we've retrieved from PHP globals.
@@ -78,11 +74,11 @@ trait RequestTrait
             );
         }
 
-        $this->ipAddress = $this->getServer('REMOTE_ADDR');
+        $this->ipAddress = $this->getServer('REMOTE_ADDR') ?? '0.0.0.0';
 
-        // If this is a CLI request, $this->ipAddress is null.
-        if ($this->ipAddress === null) {
-            return $this->ipAddress = '0.0.0.0';
+        // If this is a CLI request, $this->ipAddress is '0.0.0.0'.
+        if ($this->ipAddress === '0.0.0.0') {
+            return $this->ipAddress;
         }
 
         // @TODO Extract all this IP address logic to another class.
@@ -204,23 +200,6 @@ trait RequestTrait
     public function getServer($index = null, $filter = null, $flags = null)
     {
         return $this->fetchGlobal('server', $index, $filter, $flags);
-    }
-
-    /**
-     * Fetch an item from the $_ENV array.
-     *
-     * @param array|string|null $index  Index for item to be fetched from $_ENV
-     * @param int|null          $filter A filter name to be applied
-     * @param array|int|null    $flags
-     *
-     * @return mixed
-     *
-     * @deprecated 4.4.4 This method does not work from the beginning. Use `env()`.
-     */
-    public function getEnv($index = null, $filter = null, $flags = null)
-    {
-        // @phpstan-ignore-next-line
-        return $this->fetchGlobal('env', $index, $filter, $flags);
     }
 
     /**

--- a/system/HTTP/SiteURI.php
+++ b/system/HTTP/SiteURI.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\Exceptions\BadMethodCallException;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
@@ -53,26 +52,10 @@ class SiteURI extends URI
      *       1 => 'public',
      *       2 => 'index.php',
      *   ];
+     *
+     * @var list<string>
      */
     private array $baseSegments;
-
-    /**
-     * List of URI segments after indexPage.
-     *
-     * The word "URI Segments" originally means only the URI path part relative
-     * to the baseURL.
-     *
-     * If the URI is "http://localhost:8888/ci431/public/index.php/test?a=b",
-     * and the baseURL is "http://localhost:8888/ci431/public/", then:
-     *   $segments = [
-     *       0 => 'test',
-     *   ];
-     *
-     * @var array<int, string>
-     *
-     * @deprecated 4.4.0 This property will be private.
-     */
-    protected $segments;
 
     /**
      * URI path relative to baseURL.
@@ -149,9 +132,9 @@ class SiteURI extends URI
 
         // Update scheme
         if ($scheme !== null && $scheme !== '') {
-            $uri->setScheme($scheme);
+            $uri = $uri->withScheme($scheme);
         } elseif ($configApp->forceGlobalSecureRequests) {
-            $uri->setScheme('https');
+            $uri = $uri->withScheme('https');
         }
 
         // Update host
@@ -220,25 +203,9 @@ class SiteURI extends URI
     }
 
     /**
-     * @deprecated 4.4.0
-     */
-    public function setBaseURL(string $baseURL): void
-    {
-        throw new BadMethodCallException('Cannot use this method.');
-    }
-
-    /**
-     * @deprecated 4.4.0
-     */
-    public function setURI(?string $uri = null)
-    {
-        throw new BadMethodCallException('Cannot use this method.');
-    }
-
-    /**
      * Returns the baseURL.
      *
-     * @interal
+     * @internal
      */
     public function getBaseURL(): string
     {
@@ -298,23 +265,21 @@ class SiteURI extends URI
     }
 
     /**
-     * Converts path to segments
+     * @return list<string>
      */
     private function convertToSegments(string $path): array
     {
         $tempPath = trim($path, '/');
 
-        return ($tempPath === '') ? [] : explode('/', $tempPath);
+        return $tempPath === '' ? [] : explode('/', $tempPath);
     }
 
     /**
      * Sets the path portion of the URI based on segments.
      *
      * @return $this
-     *
-     * @deprecated 4.4.0 This method will be private.
      */
-    public function refreshPath()
+    protected function refreshPath(): self
     {
         $allSegments = array_merge($this->baseSegments, $this->segments);
         $this->path  = '/' . $this->filterPath(implode('/', $allSegments));
@@ -364,11 +329,7 @@ class SiteURI extends URI
             $this->fragment = $parts['fragment'];
         }
 
-        if (isset($parts['scheme'])) {
-            $this->setScheme(rtrim($parts['scheme'], ':/'));
-        } else {
-            $this->setScheme('http');
-        }
+        $this->scheme = $this->withScheme($parts['scheme'] ?? 'http')->getScheme();
 
         if (isset($parts['port'])) {
             // Valid port numbers are enforced by earlier parse_url or setPort()

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -245,7 +245,13 @@ class URI implements Stringable
      */
     public function __construct(?string $uri = null, bool $useRawQueryString = false)
     {
-        $this->useRawQueryString($useRawQueryString)->setUri($uri);
+        $this->useRawQueryString($useRawQueryString);
+
+        if ($uri === null) {
+            return;
+        }
+
+        $this->setUri($uri);
     }
 
     /**
@@ -285,12 +291,8 @@ class URI implements Stringable
      *
      * @throws HTTPException
      */
-    private function setUri(?string $uri = null): self
+    private function setUri(string $uri): self
     {
-        if ($uri === null) {
-            return $this;
-        }
-
         $parts = parse_url($uri);
 
         if (is_array($parts)) {

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\Exceptions\BadMethodCallException;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
@@ -36,22 +35,6 @@ class URI implements Stringable
      * Unreserved characters used in paths, query strings, and fragments.
      */
     public const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
-
-    /**
-     * Current URI string
-     *
-     * @var string
-     *
-     * @deprecated 4.4.0 Not used.
-     */
-    protected $uriString;
-
-    /**
-     * The Current baseURL.
-     *
-     * @deprecated 4.4.0 Use SiteURI instead.
-     */
-    private ?string $baseURL = null;
 
     /**
      * List of URI segments.
@@ -260,9 +243,9 @@ class URI implements Stringable
      * @TODO null for param $uri should be removed.
      *      See https://www.php-fig.org/psr/psr-17/#26-urifactoryinterface
      */
-    public function __construct(?string $uri = null)
+    public function __construct(?string $uri = null, bool $useRawQueryString = false)
     {
-        $this->setURI($uri);
+        $this->useRawQueryString($useRawQueryString)->setUri($uri);
     }
 
     /**
@@ -275,6 +258,8 @@ class URI implements Stringable
      */
     public function setSilent(bool $silent = true)
     {
+        @trigger_error(sprintf('The %s method is deprecated and will be removed in CodeIgniter 5.0.', __METHOD__), E_USER_DEPRECATED);
+
         $this->silent = $silent;
 
         return $this;
@@ -298,13 +283,9 @@ class URI implements Stringable
     /**
      * Sets and overwrites any current URI information.
      *
-     * @return URI
-     *
      * @throws HTTPException
-     *
-     * @deprecated 4.4.0 This method will be private.
      */
-    public function setURI(?string $uri = null)
+    private function setUri(?string $uri = null): self
     {
         if ($uri === null) {
             return $this;
@@ -336,9 +317,7 @@ class URI implements Stringable
      * The trailing ":" character is not part of the scheme and MUST NOT be
      * added.
      *
-     * @see    https://tools.ietf.org/html/rfc3986#section-3.1
-     *
-     * @return string The URI scheme.
+     * @see https://tools.ietf.org/html/rfc3986#section-3.1
      */
     public function getScheme(): string
     {
@@ -712,26 +691,6 @@ class URI implements Stringable
     }
 
     /**
-     * Sets the scheme for this URI.
-     *
-     * Because of the large number of valid schemes we cannot limit this
-     * to only http or https.
-     *
-     * @see https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
-     *
-     * @return $this
-     *
-     * @deprecated 4.4.0 Use `withScheme()` instead.
-     */
-    public function setScheme(string $str)
-    {
-        $str          = strtolower($str);
-        $this->scheme = preg_replace('#:(//)?$#', '', $str);
-
-        return $this;
-    }
-
-    /**
      * Return an instance with the specified scheme.
      *
      * This method MUST retain the state of the current instance, and return
@@ -836,41 +795,11 @@ class URI implements Stringable
     }
 
     /**
-     * Sets the current baseURL.
-     *
-     * @interal
-     *
-     * @deprecated 4.4.0 Use SiteURI instead.
-     */
-    public function setBaseURL(string $baseURL): void
-    {
-        $this->baseURL = $baseURL;
-    }
-
-    /**
-     * Returns the current baseURL.
-     *
-     * @interal
-     *
-     * @deprecated 4.4.0 Use SiteURI instead.
-     */
-    public function getBaseURL(): string
-    {
-        if ($this->baseURL === null) {
-            throw new BadMethodCallException('The $baseURL is not set.');
-        }
-
-        return $this->baseURL;
-    }
-
-    /**
      * Sets the path portion of the URI based on segments.
      *
      * @return $this
-     *
-     * @deprecated 4.4.0 This method will be private.
      */
-    public function refreshPath()
+    protected function refreshPath(): self
     {
         $this->path = $this->filterPath(implode('/', $this->segments));
 
@@ -1077,11 +1006,7 @@ class URI implements Stringable
             $this->fragment = $parts['fragment'];
         }
 
-        if (isset($parts['scheme'])) {
-            $this->setScheme(rtrim($parts['scheme'], ':/'));
-        } else {
-            $this->setScheme('http');
-        }
+        $this->scheme = $this->withScheme($parts['scheme'] ?? 'http')->getScheme();
 
         if (isset($parts['port'])) {
             // Valid port numbers are enforced by earlier parse_url or setPort()
@@ -1113,11 +1038,10 @@ class URI implements Stringable
          * NOTE: We don't use removeDotSegments in this
          * algorithm since it's already done by this line!
          */
-        $relative = new self();
-        $relative->setURI($uri);
+        $relative = new self($uri);
 
         if ($relative->getScheme() === $this->getScheme()) {
-            $relative->setScheme('');
+            $relative = $relative->withScheme('');
         }
 
         $transformed = clone $relative;
@@ -1150,8 +1074,7 @@ class URI implements Stringable
             $transformed->setAuthority($this->getAuthority());
         }
 
-        $transformed->setScheme($this->getScheme());
-
+        $transformed = $transformed->withScheme($this->getScheme());
         $transformed->setFragment($relative->getFragment());
 
         return $transformed;

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -1040,7 +1040,7 @@ class URI implements Stringable
          * NOTE: We don't use removeDotSegments in this
          * algorithm since it's already done by this line!
          */
-        $relative = new self($uri);
+        $relative = new self($uri, $this->rawQueryString);
 
         if ($relative->getScheme() === $this->getScheme()) {
             $relative = $relative->withScheme('');

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -57,10 +57,6 @@ return [
     'methodNotFound'     => 'Controller method is not found: "{0}"',
     'localeNotSupported' => 'Locale is not supported: {0}',
 
-    // CSRF
-    // @deprecated 4.0.5 use 'Security.disallowedAction'
-    'disallowedAction' => 'The action you requested is not allowed.',
-
     // Uploaded file moving
     'alreadyMoved' => 'The uploaded file has already been moved.',
     'invalidFile'  => 'The original file is not a valid file.',

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -427,7 +427,7 @@ class Pager implements PagerInterface
         if (array_key_exists($group, $this->segment)) {
             try {
                 $this->groups[$group]['currentPage'] = (int) $this->groups[$group]['currentUri']
-                    ->setSilent(false)->getSegment($this->segment[$group]);
+                    ->getSegment($this->segment[$group]);
             } catch (HTTPException) {
                 $this->groups[$group]['currentPage'] = 1;
             }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -94,6 +94,17 @@ class CURLRequestTest extends CIUnitTestCase
         $this->assertSame('http://www.foo.com/api/v1/products', $options[CURLOPT_URL]);
     }
 
+    public function testGetPreservesDottedQueryKeysFromBaseURI(): void
+    {
+        $request = $this->getRequest(['baseURI' => 'https://api.example.com/resource?foo.bar=baz']);
+
+        $request->get('');
+
+        $options = $request->curl_options;
+
+        $this->assertSame('https://api.example.com/resource?foo.bar=baz', $options[CURLOPT_URL]);
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1029
      */

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -174,16 +174,6 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertNull($this->request->getServer('TESTY'));
     }
 
-    public function testCanGrabEnvVars(): void
-    {
-        $server                = $this->getPrivateProperty($this->request, 'globals');
-        $server['env']['TEST'] = 5;
-        $this->setPrivateProperty($this->request, 'globals', $server);
-
-        $this->assertSame('5', $this->request->getEnv('TEST'));
-        $this->assertNull($this->request->getEnv('TESTY'));
-    }
-
     public function testCanGrabCookieVars(): void
     {
         service('superglobals')->setCookie('TEST', '5');

--- a/tests/system/HTTP/SiteURITest.php
+++ b/tests/system/HTTP/SiteURITest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\Exceptions\BadMethodCallException;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -386,17 +385,6 @@ final class SiteURITest extends CIUnitTestCase
         $uri->setSegment(4, 'four');
     }
 
-    public function testSetSegmentSilentOutOfRange(): void
-    {
-        $config = new App();
-        $uri    = new SiteURI($config);
-        $uri->setPath('one/method');
-        $uri->setSilent();
-
-        $uri->setSegment(4, 'four');
-        $this->assertSame(['one', 'method'], $uri->getSegments());
-    }
-
     public function testSetSegmentZero(): void
     {
         $this->expectException(HTTPException::class);
@@ -470,26 +458,6 @@ final class SiteURITest extends CIUnitTestCase
         $uri    = new SiteURI($config);
 
         $this->assertSame(0, $uri->getTotalSegments());
-    }
-
-    public function testSetURI(): void
-    {
-        $this->expectException(BadMethodCallException::class);
-
-        $config = new App();
-        $uri    = new SiteURI($config);
-
-        $uri->setURI('http://another.site.example.jp/');
-    }
-
-    public function testSetBaseURI(): void
-    {
-        $this->expectException(BadMethodCallException::class);
-
-        $config = new App();
-        $uri    = new SiteURI($config);
-
-        $uri->setBaseURL('http://another.site.example.jp/');
     }
 
     public function testGetBaseURL(): void

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -477,7 +477,16 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expected, (string) $uri);
     }
 
-    public function testSetQuerySetsValueWithUseRawQueryString(): void
+    public function testUseRawQueryStringAtConstructor(): void
+    {
+        $url = 'http://example.com/path?key=value&second.key=value.2';
+        $uri = new URI($url, true);
+
+        $this->assertSame('key=value&second.key=value.2', $uri->getQuery());
+        $this->assertSame($url, (string) $uri);
+    }
+
+    public function testUseRawQueryStringAtSetter(): void
     {
         $url = 'http://example.com/path';
         $uri = new URI($url);
@@ -485,8 +494,7 @@ final class URITest extends CIUnitTestCase
         $uri->useRawQueryString()->setQuery('?key=value&second.key=value.2');
 
         $this->assertSame('key=value&second.key=value.2', $uri->getQuery());
-        $expected = 'http://example.com/path?key=value&second.key=value.2';
-        $this->assertSame($expected, (string) $uri);
+        $this->assertSame('http://example.com/path?key=value&second.key=value.2', (string) $uri);
     }
 
     public function testSetQueryArraySetsValue(): void

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -68,14 +68,6 @@ final class URITest extends CIUnitTestCase
         $uri->getSegment(5);
     }
 
-    public function testSegmentOutOfRangeWithSilent(): void
-    {
-        $url = 'http://abc.com/a123/b/c';
-        $uri = new URI($url);
-
-        $this->assertSame('', $uri->setSilent()->getSegment(22));
-    }
-
     public function testSegmentOutOfRangeWithDefaultValue(): void
     {
         $this->expectException(HTTPException::class);
@@ -83,40 +75,6 @@ final class URITest extends CIUnitTestCase
         $url = 'http://abc.com/a123/b/c';
         $uri = new URI($url);
         $uri->getSegment(22, 'something');
-    }
-
-    public function testSegmentOutOfRangeWithSilentAndDefaultValue(): void
-    {
-        $url = 'http://abc.com/a123/b/c';
-        $uri = new URI($url);
-
-        $this->assertSame('something', $uri->setSilent()->getSegment(22, 'something'));
-    }
-
-    public function testSegmentsWithDefaultValueAndSilent(): void
-    {
-        $uri = new URI('http://hostname/path/to');
-        $uri->setSilent();
-
-        $this->assertSame(['path', 'to'], $uri->getSegments());
-        $this->assertSame('path', $uri->getSegment(1));
-        $this->assertSame('to', $uri->getSegment(2, 'different'));
-        $this->assertSame('script', $uri->getSegment(3, 'script'));
-        $this->assertSame('', $uri->getSegment(3));
-
-        $this->assertSame(2, $uri->getTotalSegments());
-    }
-
-    public function testSegmentOutOfRangeWithDefaultValuesAndSilent(): void
-    {
-        $uri = new URI('http://hostname/path/to/script');
-        $uri->setSilent();
-
-        $this->assertSame('', $uri->getSegment(22));
-        $this->assertSame('something', $uri->getSegment(33, 'something'));
-
-        $this->assertSame(3, $uri->getTotalSegments());
-        $this->assertSame(['path', 'to', 'script'], $uri->getSegments());
     }
 
     public function testCanCastAsString(): void
@@ -222,34 +180,18 @@ final class URITest extends CIUnitTestCase
 
     public function testSchemeSub(): void
     {
-        $url = 'example.com';
-        $uri = new URI('http://' . $url);
-        $uri->setScheme('x');
+        $uri = (new URI('http://example.com'))->withScheme('x');
 
-        $this->assertSame('x://' . $url, (string) $uri);
-    }
-
-    public function testSetSchemeSetsValue(): void
-    {
-        $url = 'http://example.com/path';
-        $uri = new URI($url);
-
-        $uri->setScheme('https');
-
-        $this->assertSame('https', $uri->getScheme());
-        $expected = 'https://example.com/path';
-        $this->assertSame($expected, (string) $uri);
+        $this->assertSame('x://example.com', (string) $uri);
     }
 
     public function testWithScheme(): void
     {
-        $url = 'example.com';
-        $uri = new URI('http://' . $url);
-
+        $uri = new URI('http://example.com');
         $new = $uri->withScheme('x');
 
-        $this->assertSame('x://' . $url, (string) $new);
-        $this->assertSame('http://' . $url, (string) $uri);
+        $this->assertSame('x://example.com', (string) $new);
+        $this->assertSame('http://example.com', (string) $uri);
     }
 
     public function testWithSchemeSetsHttps(): void
@@ -347,16 +289,6 @@ final class URITest extends CIUnitTestCase
         $uri->setPort(70000);
     }
 
-    public function testSetPortInvalidValuesSilent(): void
-    {
-        $url = 'http://example.com/path';
-        $uri = new URI($url);
-
-        $uri->setSilent()->setPort(70000);
-
-        $this->assertNull($uri->getPort());
-    }
-
     public function testSetPortTooSmall(): void
     {
         $url = 'http://example.com/path';
@@ -383,9 +315,7 @@ final class URITest extends CIUnitTestCase
     {
         $this->expectException(HTTPException::class);
 
-        $url = 'http://username:password@hostname:90909/path?arg=value#anchor';
-        $uri = new URI();
-        $uri->setURI($url);
+        new URI('http://username:password@hostname:90909/path?arg=value#anchor');
     }
 
     public function testSetPathSetsValue(): void
@@ -591,16 +521,6 @@ final class URITest extends CIUnitTestCase
         $this->expectException(HTTPException::class);
 
         $uri->setQuery('?key=value#fragment');
-    }
-
-    public function testSetQueryThrowsErrorWhenFragmentPresentSilent(): void
-    {
-        $url = 'http://example.com/path';
-        $uri = new URI($url);
-
-        $uri->setSilent()->setQuery('?key=value#fragment');
-
-        $this->assertSame('', $uri->getQuery());
     }
 
     /**
@@ -1034,17 +954,6 @@ final class URITest extends CIUnitTestCase
         $uri->setSegment(6, 'banana');
     }
 
-    public function testSetBadSegmentSilent(): void
-    {
-        $base     = 'http://example.com/foo/bar/baz';
-        $uri      = new URI($base);
-        $segments = $uri->getSegments();
-
-        $uri->setSilent()->setSegment(6, 'banana');
-
-        $this->assertSame($segments, $uri->getSegments());
-    }
-
     // Exploratory testing, investigating https://github.com/codeigniter4/CodeIgniter4/issues/2016
 
     public function testBasedNoIndex(): void
@@ -1176,23 +1085,10 @@ final class URITest extends CIUnitTestCase
 
     public function testSetURI(): void
     {
-        $url = ':';
-        $uri = new URI();
-
         $this->expectException(HTTPException::class);
-        $this->expectExceptionMessage(lang('HTTP.cannotParseURI', [$url]));
+        $this->expectExceptionMessage(lang('HTTP.cannotParseURI', [':']));
 
-        $uri->setURI($url);
-    }
-
-    public function testSetURISilent(): void
-    {
-        $url = ':';
-        $uri = new URI();
-
-        $uri->setSilent()->setURI($url);
-
-        $this->assertTrue(true);
+        new URI(':');
     }
 
     public function testCreateURIStringNoArguments(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -124,6 +124,21 @@ Removed Deprecated Items
     - ``CodeIgniter\Filters\Filters::$arguments`` (deprecated since v4.6.0)
     - ``CodeIgniter\Filters\Filters::$argumentsClass`` (deprecated since v4.6.0)
     - ``CodeIgniter\Filters\Filters::getArguments()`` (deprecated since v4.6.0)
+- **HTTP:** Removed the following properties and methods deprecated:
+    - ``CodeIgniter\HTTP\Message::getHeaders()`` (deprecated since v4.0.5)
+    - ``CodeIgniter\HTTP\Message::getHeader()`` (deprecated since v4.0.5)
+    - ``CodeIgniter\HTTP\RequestTrait::getEnv()`` (deprecated since v4.4.4)
+    - ``CodeIgniter\HTTP\URI::$uriString`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\URI::$baseURL`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\URI::setBaseURL()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\URI::getBaseURL()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\URI::setURI()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\URI::setScheme()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\URI::refreshPath()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\SiteURI::$segments`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\SiteURI::setBaseURL()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\SiteURI::setURI()`` (deprecated since v4.4.0)
+    - ``CodeIgniter\HTTP\SiteURI::refreshPath()`` (deprecated since v4.4.0)
 - **Security:** Removed the following properties and methods deprecated:
     - ``CodeIgniter\Security\SecurityInterface::sanitizeFilename()`` (deprecated since v4.6.2)
     - ``CodeIgniter\Security\Security::sanitizeFilename()`` (deprecated since v4.6.2)
@@ -202,6 +217,9 @@ HTTP
 - ``CLIRequest`` now supports options with values specified using an equals sign (e.g., ``--option=value``) in addition to the existing space-separated syntax (e.g., ``--option value``).
     This provides more flexibility in how you can pass options to CLI requests.
 - Added ``$enableStyleNonce`` and ``$enableScriptNonce`` options to ``Config\App`` to automatically add nonces to control whether to add nonces to style-* and script-* directives in the Content Security Policy (CSP) header when CSP is enabled. See :ref:`csp-control-nonce-generation` for details.
+- ``URI`` now accepts an optional boolean second parameter in the constructor, defaulting to ``false``, to control how the query string is parsed in instantiation.
+    This is the behavior of ``->useRawQueryString()`` brought into the constructor for convenience. Previously, you need to call ``$uri->useRawQueryString(true)->setURI($uri)`` to get this behavior.
+    Now you can simply do ``new URI($uri, true)``.
 
 Validation
 ==========
@@ -218,6 +236,7 @@ Message Changes
 - Removed deprecated language keys tied to removed exception constructors:
     - ``Core.missingExtension`` (``FrameworkException::forMissingExtension()``)
     - ``HTTP.cannotSetCache`` (``DownloadException::forCannotSetCache()``)
+    - ``HTTP.disallowedAction``
     - ``HTTP.invalidSameSiteSetting`` (``HTTPException::forInvalidSameSiteSetting()``)
     - ``Security.invalidSameSite`` (``SecurityException::forInvalidSameSite()``)
     - ``Session.invalidSameSiteSetting`` (``SessionException::forInvalidSameSiteSetting()``)
@@ -234,6 +253,7 @@ Deprecations
 
 - **CLI:** The ``CLI::parseCommandLine()`` method is now deprecated and will be removed in a future release. The ``CLI`` class now uses the new ``CommandLineParser`` class to handle command-line argument parsing.
 - **HTTP:** The ``CLIRequest::parseCommand()`` method is now deprecated and will be removed in a future release. The ``CLIRequest`` class now uses the new ``CommandLineParser`` class to handle command-line argument parsing.
+- **HTTP:** ``URI::setSilent()`` is now hard deprecated. This method was only previously marked as deprecated. It will now trigger a deprecation notice when used.
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -54,6 +54,20 @@ Method Signature Changes
 - **Database:** The following methods have had their signatures updated to remove deprecated parameters:
     - ``CodeIgniter\Database\Forge::_createTable()`` no longer accepts the deprecated ``$ifNotExists`` parameter. The method signature is now ``_createTable(string $table, array $attributes)``.
 
+Property Scope Changes
+======================
+
+- **HTTP:** The following properties have changed their scope (visibility):
+    - ``CodeIgniter\HTTP\RequestTrait::$ipAddress`` is now private (previously protected).
+
+Method Scope Changes
+====================
+
+- **HTTP:** The following methods have changed their scope (visibility):
+    - ``CodeIgniter\HTTP\URI::setUri()`` is now private (previously public).
+    - ``CodeIgniter\HTTP\URI::refreshPath()`` is now protected (previously public).
+    - ``CodeIgniter\HTTP\SiteURI::refreshPath()`` is now protected (previously public).
+
 Removed Deprecated Items
 ========================
 
@@ -132,13 +146,10 @@ Removed Deprecated Items
     - ``CodeIgniter\HTTP\URI::$baseURL`` (deprecated since v4.4.0)
     - ``CodeIgniter\HTTP\URI::setBaseURL()`` (deprecated since v4.4.0)
     - ``CodeIgniter\HTTP\URI::getBaseURL()`` (deprecated since v4.4.0)
-    - ``CodeIgniter\HTTP\URI::setURI()`` (deprecated since v4.4.0)
     - ``CodeIgniter\HTTP\URI::setScheme()`` (deprecated since v4.4.0)
-    - ``CodeIgniter\HTTP\URI::refreshPath()`` (deprecated since v4.4.0)
     - ``CodeIgniter\HTTP\SiteURI::$segments`` (deprecated since v4.4.0)
     - ``CodeIgniter\HTTP\SiteURI::setBaseURL()`` (deprecated since v4.4.0)
     - ``CodeIgniter\HTTP\SiteURI::setURI()`` (deprecated since v4.4.0)
-    - ``CodeIgniter\HTTP\SiteURI::refreshPath()`` (deprecated since v4.4.0)
 - **Security:** Removed the following properties and methods deprecated:
     - ``CodeIgniter\Security\SecurityInterface::sanitizeFilename()`` (deprecated since v4.6.2)
     - ``CodeIgniter\Security\Security::sanitizeFilename()`` (deprecated since v4.6.2)

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -35,28 +35,6 @@ Class Reference
         .. important:: This method takes into account the ``Config\App::$proxyIPs`` setting and will
             return the reported client IP address by the HTTP header for the allowed IP address.
 
-    .. php:method:: isValidIP($ip[, $which = ''])
-
-        .. deprecated:: 4.0.5
-           Use :doc:`../libraries/validation` instead.
-
-        .. important:: This method is deprecated. It will be removed in future releases.
-
-        :param    string $ip: IP address
-        :param    string $which: IP protocol (``ipv4`` or ``ipv6``)
-        :returns: true if the address is valid, false if not
-        :rtype:   bool
-
-        Takes an IP address as input and returns true or false (boolean) depending
-        on whether it is valid or not.
-
-        .. note:: The $request->getIPAddress() method above automatically validates the IP address.
-
-            .. literalinclude:: request/002.php
-
-        Accepts an optional second string parameter of ``ipv4`` or ``ipv6`` to specify
-        an IP format. The default checks for both formats.
-
     .. php:method:: getMethod()
 
         :returns: HTTP request method
@@ -100,27 +78,6 @@ Class Reference
         as an array.
 
         .. literalinclude:: request/005.php
-
-    .. php:method:: getEnv([$index = null[, $filter = null[, $flags = null]]])
-
-        .. deprecated:: 4.4.4 This method does not work from the beginning. Use
-            :php:func:`env()` instead.
-
-        :param    mixed     $index: Value name
-        :param    int       $filter: The type of filter to apply. A list of filters can be found in `PHP manual <https://www.php.net/manual/en/filters.php>`__.
-        :param    int|array $flags: Flags to apply. A list of flags can be found in `PHP manual <https://www.php.net/manual/en/filter.constants.php#filter.constants.flags.generic>`__.
-        :returns: ``$_ENV`` item value if found, null if not
-        :rtype:   mixed
-
-        This method is identical to the ``getPost()``, ``getGet()`` and ``getCookie()`` methods from the
-        :doc:`IncomingRequest Class <./incomingrequest>`, only it fetches env data (``$_ENV``):
-
-        .. literalinclude:: request/006.php
-
-        To return an array of multiple ``$_ENV`` values, pass all the required keys
-        as an array.
-
-        .. literalinclude:: request/007.php
 
     .. php:method:: setGlobal($method, $value)
 

--- a/user_guide_src/source/incoming/request/002.php
+++ b/user_guide_src/source/incoming/request/002.php
@@ -1,7 +1,0 @@
-<?php
-
-if (! $request->isValidIP($ip)) {
-    echo 'Not Valid';
-} else {
-    echo 'Valid';
-}

--- a/user_guide_src/source/incoming/request/006.php
+++ b/user_guide_src/source/incoming/request/006.php
@@ -1,3 +1,0 @@
-<?php
-
-$request->getEnv('some_data');

--- a/user_guide_src/source/incoming/request/007.php
+++ b/user_guide_src/source/incoming/request/007.php
@@ -1,3 +1,0 @@
-<?php
-
-$request->getEnv(['CI_ENVIRONMENT', 'S3_BUCKET']);

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -238,8 +238,7 @@ You can also set a different default value for a particular segment by using the
 .. literalinclude:: uri/024.php
 
 .. note:: You can get the last +1 segment. When you try to get the last +2 or
-    more segment, an exception will be thrown by default. You could prevent
-    throwing exceptions with the ``setSilent()`` method.
+    more segment, an exception will be thrown by default.
 
 You can get a count of the total segments:
 
@@ -255,5 +254,9 @@ Disable Throwing Exceptions
 
 By default, some methods of this class may throw an exception. If you want to disable it, you can set a special flag
 that will prevent throwing exceptions.
+
+.. deprecated:: 4.4.0
+    This method is deprecated and will be removed in a future version.
+    It is recommended to handle exceptions properly instead of disabling them.
 
 .. literalinclude:: uri/027.php

--- a/user_guide_src/source/libraries/uri/008.php
+++ b/user_guide_src/source/libraries/uri/008.php
@@ -1,6 +1,7 @@
 <?php
 
 $uri = new \CodeIgniter\HTTP\URI('http://www.example.com/some/path');
-
 echo $uri->getScheme(); // 'http'
-$uri->setScheme('https');
+
+$uri = $uri->withScheme('https');
+echo $uri->getScheme(); // 'https'

--- a/user_guide_src/source/libraries/uri/024.php
+++ b/user_guide_src/source/libraries/uri/024.php
@@ -8,7 +8,3 @@ echo $uri->getSegment(3, 'foo');
 echo $uri->getSegment(4, 'bar');
 // will throw an exception
 echo $uri->getSegment(5, 'baz');
-// will print 'baz'
-echo $uri->setSilent()->getSegment(5, 'baz');
-// will print '' (empty string)
-echo $uri->setSilent()->getSegment(5);

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2040 errors
+# total 2034 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/method.alreadyNarrowedType.neon
+++ b/utils/phpstan-baseline/method.alreadyNarrowedType.neon
@@ -1,4 +1,4 @@
-# total 22 errors
+# total 21 errors
 
 parameters:
     ignoreErrors:
@@ -46,11 +46,6 @@ parameters:
             message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array\{1\: array\{DETAIL\: ''asdf''\}, 2\: array\{DETAIL\: ''sdfg''\}\} will always evaluate to true\.$#'
             count: 1
             path: ../../tests/system/HTTP/RequestTest.php
-
-        -
-            message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/URITest.php
 
         -
             message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsString\(\) with string will always evaluate to true\.$#'

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1242 errors
+# total 1237 errors
 
 parameters:
     ignoreErrors:
@@ -2773,11 +2773,6 @@ parameters:
             path: ../../system/HTTP/IncomingRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\Message\:\:getHeader\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/Message.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\Message\:\:setHeader\(\) has parameter \$value with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/Message.php
@@ -2893,16 +2888,6 @@ parameters:
             path: ../../system/HTTP/Request.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\Request\:\:getEnv\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/Request.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\Request\:\:getEnv\(\) has parameter \$index with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/Request.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\Request\:\:getServer\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/Request.php
@@ -2988,11 +2973,6 @@ parameters:
             path: ../../system/HTTP/SiteURI.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\SiteURI\:\:convertToSegments\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/SiteURI.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\SiteURI\:\:parseRelativePath\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/SiteURI.php
@@ -3004,11 +2984,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\HTTP\\SiteURI\:\:stringifyRelativePath\(\) has parameter \$relativePath with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/SiteURI.php
-
-        -
-            message: '#^Property CodeIgniter\\HTTP\\SiteURI\:\:\$baseSegments type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/SiteURI.php
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Sending this early to get the `#10000` slot. 😂

This is not yet complete, but initially there are quite breaking changes:
- ~Removed the deprecated assumption that URIs with the same host as baseURL should be relative to the project's configuration (deprecated by #4646 and reinforced in #5730)~
- ~`URI::setSilent()` is removed, meaning it will always throw exceptions on invalid URIs instead of continuing.~

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
