### PR TITLE
fix: `FeatureTestTrait::withRoutes()` may throw all sorts of errors on invalid HTTP methods

### DIFF
--- a/system/HTTP/Method.php
+++ b/system/HTTP/Method.php
@@ -102,7 +102,7 @@ class Method
     /**
      * Returns all HTTP methods.
      *
-     * @return list<string>
+     * @return list<uppercase-string>
      */
     public static function all(): array
     {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Test;
 
 use Closure;
 use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Method;
@@ -76,11 +77,16 @@ trait FeatureTestTrait
                     );
                 }
 
-                /**
-                 * @TODO For backward compatibility. Remove strtolower() in the future.
-                 * @deprecated 4.5.0
-                 */
-                $method = strtolower($route[0]);
+                // @todo v4.7.1 Remove the strtoupper() and use 'add' in v4.8.0
+                if (! in_array(strtoupper($route[0]), ['ADD', 'CLI', ...Method::all()], true)) {
+                    throw new RuntimeException(sprintf(
+                        'Invalid HTTP method "%s" provided for route "%s".',
+                        $route[0],
+                        $route[1],
+                    ));
+                }
+
+                $method = strtolower($route[0]); // convert to method of RouteCollection
 
                 if (isset($route[3])) {
                     $collection->{$method}($route[1], $route[2], $route[3]);

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Test;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
@@ -688,5 +689,34 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 
         // Do not redirect.
         $response->assertStatus(200);
+    }
+
+    #[DataProvider('provideWithRoutesWithInvalidMethod')]
+    public function testWithRoutesWithInvalidMethod(string $method): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Invalid HTTP method "%s" provided for route "home".', $method));
+
+        $this->withRoutes([
+            [
+                $method,
+                'home',
+                static fn (): string => 'Hello World',
+            ],
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function provideWithRoutesWithInvalidMethod(): iterable
+    {
+        foreach (['ADD', 'CLI', ...Method::all()] as $method) {
+            yield "wrong {$method}" => [$method . 'S'];
+        }
+
+        yield 'route collection addRedirect' => ['addRedirect'];
+
+        yield 'route collection setHTTPVerb' => ['setHTTPVerb'];
     }
 }

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -56,6 +56,7 @@ Bugs Fixed
 - **Session:** Fixed a bug in ``MemcachedHandler`` where the constructor incorrectly threw an exception when ``savePath`` was not empty.
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.
 - **Toolbar:** Fixed a bug in the Routes panel where only the first route parameter was converted to an input field on hover.
+- **Testing:** Fixed a bug in ``FeatureTestTrait::withRoutes()`` where invalid HTTP methods were not properly validated, thus passing them all to ``RouteCollection``.
 - **View:** Fixed a bug where ``View`` would throw an error if the ``appOverridesFolder`` config property was not defined.
 
 See the repo's


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Per documentation, `withRoutes()` accepts a list of 3 to 4 element arrays where the first element is the HTTP verb (or the special `add` to mean all verbs). However, there's no validation for invalid methods and is just directly called upon `RouteCollection` which may result in unknown method, TypeError for parameter, etc.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
