### PR TITLE
fix: Validation lang typo

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -65,7 +65,7 @@ return [
     'valid_json'            => 'The {field} field must contain a valid json.',
 
     // Credit Cards
-    'valid_cc_num' => '{field} does not appear to be a valid credit card number.',
+    'valid_cc_number' => '{field} does not appear to be a valid credit card number.',
 
     // Files
     'uploaded' => '{field} is not a valid uploaded file.',

--- a/user_guide_src/source/changelogs/v4.7.1.rst
+++ b/user_guide_src/source/changelogs/v4.7.1.rst
@@ -19,6 +19,7 @@ Message Changes
 ***************
 
 - Updated ``Images.unsupportedImageCreate``.
+- Renamed the ``Validation.valid_cc_num`` key to ``Validation.valid_cc_number``.
 
 *******
 Changes
@@ -58,6 +59,7 @@ Bugs Fixed
 - **Toolbar:** Fixed a bug where the standalone toolbar page loaded from ``?debugbar_time=...`` was not interactive.
 - **Toolbar:** Fixed a bug in the Routes panel where only the first route parameter was converted to an input field on hover.
 - **Testing:** Fixed a bug in ``FeatureTestTrait::withRoutes()`` where invalid HTTP methods were not properly validated, thus passing them all to ``RouteCollection``.
+- **Validation:** Rule ``valid_cc_number`` now has the correct translation.
 - **View:** Fixed a bug where ``View`` would throw an error if the ``appOverridesFolder`` config property was not defined.
 
 See the repo's


### PR DESCRIPTION
**Description**
From forum thread [90878](https://forum.codeigniter.com/showthread.php?tid=90878&highlight=valid_cc_num)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
