### PR TITLE
refactor: fix dependency on test execution order

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1136,7 +1136,7 @@ class CLI
         static::$initialized = false;
         static::$segments    = [];
         static::$options     = [];
-        static::$lastWrite   = 'write';
+        static::$lastWrite   = null;
         static::$height      = null;
         static::$width       = null;
         static::$isColored   = static::hasColorSupport(STDOUT);

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -347,7 +347,7 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::write('test', 'red');
 
-        $expected = "\033[0;31mtest\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;31mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -355,7 +355,7 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::write(CLI::color('green', 'green') . ' red', 'red');
 
-        $expected = "\033[0;32mgreen\033[0m\033[0;31m red\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;32mgreen\033[0m\033[0;31m red\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -363,7 +363,7 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::write('red ' . CLI::color('green', 'green'), 'red');
 
-        $expected = "\033[0;31mred \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;31mred \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -377,7 +377,7 @@ final class CLITest extends CIUnitTestCase
             'red',
         );
 
-        $expected = "\033[0;32mgreen\033[0m\033[0;31m red \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;32mgreen\033[0m\033[0;31m red \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -385,7 +385,7 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::write('test', 'red', 'green');
 
-        $expected = "\033[0;31m\033[42mtest\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;31m\033[42mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -427,7 +427,7 @@ final class CLITest extends CIUnitTestCase
         CLI::write('third.');
         CLI::showProgress(1, 20);
 
-        $expected = 'first.' . PHP_EOL .
+        $expected = PHP_EOL . 'first.' . PHP_EOL .
                     "[\033[32m#.........\033[0m]   5% Complete" . PHP_EOL .
                     "\033[1A[\033[32m#####.....\033[0m]  50% Complete" . PHP_EOL .
                     "\033[1A[\033[32m##########\033[0m] 100% Complete" . PHP_EOL .
@@ -447,7 +447,7 @@ final class CLITest extends CIUnitTestCase
         CLI::showProgress(false, 20);
         CLI::showProgress(false, 20);
 
-        $expected = 'first.' . PHP_EOL . "\007\007\007";
+        $expected = PHP_EOL . 'first.' . PHP_EOL . "\007\007\007";
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -620,6 +620,7 @@ final class CLITest extends CIUnitTestCase
             [
                 $oneRow,
                 [],
+                PHP_EOL .
                 '+---+-----+' . PHP_EOL .
                 '| 1 | bar |' . PHP_EOL .
                 '+---+-----+' . PHP_EOL . PHP_EOL,
@@ -627,6 +628,7 @@ final class CLITest extends CIUnitTestCase
             [
                 $oneRow,
                 $head,
+                PHP_EOL .
                 '+----+-------+' . PHP_EOL .
                 '| ID | Title |' . PHP_EOL .
                 '+----+-------+' . PHP_EOL .
@@ -636,6 +638,7 @@ final class CLITest extends CIUnitTestCase
             [
                 $manyRows,
                 [],
+                PHP_EOL .
                 '+---+-----------------+' . PHP_EOL .
                 '| 1 | bar             |' . PHP_EOL .
                 '| 2 | bar * 2         |' . PHP_EOL .
@@ -645,6 +648,7 @@ final class CLITest extends CIUnitTestCase
             [
                 $manyRows,
                 $head,
+                PHP_EOL .
                 '+----+-----------------+' . PHP_EOL .
                 '| ID | Title           |' . PHP_EOL .
                 '+----+-----------------+' . PHP_EOL .
@@ -665,6 +669,7 @@ final class CLITest extends CIUnitTestCase
                     'ID',
                     'タイトル',
                 ],
+                PHP_EOL .
                 '+------+----------+' . PHP_EOL .
                 '| ID   | タイトル |' . PHP_EOL .
                 '+------+----------+' . PHP_EOL .

--- a/tests/system/CLI/SignalTest.php
+++ b/tests/system/CLI/SignalTest.php
@@ -53,6 +53,13 @@ final class SignalTest extends CIUnitTestCase
         $this->command = new SignalCommand($this->logger, service('commands'));
     }
 
+    protected function tearDown(): void
+    {
+        CLI::reset();
+
+        parent::tearDown();
+    }
+
     public function testSignalRegistration(): void
     {
         $this->command->testRegisterSignals([SIGTERM, SIGINT], [SIGTERM => 'customTermHandler']);


### PR DESCRIPTION
**Description**
This PR resets `CLI::$lastWrite` to `null` in `CLI::reset()` (the original initial state) instead of `'write'`.

This prevents a random test order from affecting results and ensures each test starts with a clean CLI state.
`tests/system/CLI/CLITest.php` assertions were updated to match the first `CLI::write()` output.

Ref: #9968
Follow-up for: #9998 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
