### PR TITLE
feat: pass log context as structured data to handlers instead of appending message

### DIFF
--- a/system/Log/Handlers/BaseHandler.php
+++ b/system/Log/Handlers/BaseHandler.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Log\Handlers;
 
+use JsonException;
+
 /**
  * Base class for logging
  */
@@ -57,5 +59,21 @@ abstract class BaseHandler implements HandlerInterface
         $this->dateFormat = $format;
 
         return $this;
+    }
+
+    /**
+     * Encodes the context array as a JSON string.
+     * Returns the JSON string on success, or a descriptive error string if
+     * encoding fails (e.g. context contains a resource or invalid UTF-8).
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function encodeContext(array $context): string
+    {
+        try {
+            return json_encode($context, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            return '[context: JSON encoding failed - ' . $e->getMessage() . ']';
+        }
     }
 }

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Log\Handlers;
 
 use CodeIgniter\HTTP\ResponseInterface;
+use JsonException;
 
 /**
  * Allows for logging items to the Chrome console for debugging.
@@ -99,10 +100,11 @@ class ChromeLoggerHandler extends BaseHandler
      * will stop. Any handlers that have not run, yet, will not
      * be run.
      *
-     * @param string $level
-     * @param string $message
+     * @param string               $level
+     * @param string               $message
+     * @param array<string, mixed> $context
      */
-    public function handle($level, $message): bool
+    public function handle($level, $message, array $context = []): bool
     {
         $message = $this->format($message);
 
@@ -121,7 +123,9 @@ class ChromeLoggerHandler extends BaseHandler
             $type = $this->levels[$level];
         }
 
-        $this->json['rows'][] = [[$message], $backtraceMessage, $type];
+        $logArgs = $context !== [] ? [$message, $context] : [$message];
+
+        $this->json['rows'][] = [$logArgs, $backtraceMessage, $type];
 
         $this->sendLogs();
 
@@ -162,8 +166,17 @@ class ChromeLoggerHandler extends BaseHandler
             $response = service('response', null, true);
         }
 
+        try {
+            $encoded = json_encode($this->json, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            $encoded = json_encode($this->json, JSON_PARTIAL_OUTPUT_ON_ERROR);
+            if ($encoded === false) {
+                return;
+            }
+        }
+
         $data = base64_encode(
-            mb_convert_encoding(json_encode($this->json), 'UTF-8', mb_list_encodings()),
+            mb_convert_encoding($encoded, 'UTF-8', mb_list_encodings()),
         );
 
         $response->setHeader($this->header, $data);

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -66,11 +66,16 @@ class ErrorlogHandler extends BaseHandler
      * will stop. Any handlers that have not run, yet, will not
      * be run.
      *
-     * @param string $level
-     * @param string $message
+     * @param string               $level
+     * @param string               $message
+     * @param array<string, mixed> $context
      */
-    public function handle($level, $message): bool
+    public function handle($level, $message, array $context = []): bool
     {
+        if ($context !== []) {
+            $message .= ' ' . $this->encodeContext($context);
+        }
+
         $message = strtoupper($level) . ' --> ' . $message . "\n";
 
         return $this->errorLog($message, $this->messageType);

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -69,12 +69,13 @@ class FileHandler extends BaseHandler
      * will stop. Any handlers that have not run, yet, will not
      * be run.
      *
-     * @param string $level
-     * @param string $message
+     * @param string               $level
+     * @param string               $message
+     * @param array<string, mixed> $context
      *
      * @throws Exception
      */
-    public function handle($level, $message): bool
+    public function handle($level, $message, array $context = []): bool
     {
         $filepath = $this->path . 'log-' . date('Y-m-d') . '.' . $this->fileExtension;
 
@@ -102,6 +103,10 @@ class FileHandler extends BaseHandler
             $date           = $date->format($this->dateFormat);
         } else {
             $date = date($this->dateFormat);
+        }
+
+        if ($context !== []) {
+            $message .= ' ' . $this->encodeContext($context);
         }
 
         $msg .= strtoupper($level) . ' - ' . $date . ' --> ' . $message . "\n";

--- a/system/Log/Handlers/HandlerInterface.php
+++ b/system/Log/Handlers/HandlerInterface.php
@@ -19,15 +19,24 @@ namespace CodeIgniter\Log\Handlers;
 interface HandlerInterface
 {
     /**
+     * The reserved key under which global CI context data is stored
+     * in the log context array. This data comes from the Context service
+     * and is injected by the Logger when $logGlobalContext is enabled.
+     */
+    public const GLOBAL_CONTEXT_KEY = '_ci_context';
+
+    /**
      * Handles logging the message.
      * If the handler returns false, then execution of handlers
      * will stop. Any handlers that have not run, yet, will not
      * be run.
      *
-     * @param string $level
-     * @param string $message
+     * @param string               $level
+     * @param string               $message
+     * @param array<string, mixed> $context Full context array; may contain
+     *                                      GLOBAL_CONTEXT_KEY with CI global data
      */
-    public function handle($level, $message): bool;
+    public function handle($level, $message, array $context = []): bool;
 
     /**
      * Checks whether the Handler will handle logging items of this

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -264,7 +264,7 @@ class Logger implements LoggerInterface
         if ($this->logGlobalContext) {
             $globalContext = service('context')->getAll();
             if ($globalContext !== []) {
-                $message .= ' ' . json_encode($globalContext);
+                $context[HandlerInterface::GLOBAL_CONTEXT_KEY] = $globalContext;
             }
         }
 
@@ -284,7 +284,7 @@ class Logger implements LoggerInterface
             }
 
             // If the handler returns false, then we don't execute any other handlers.
-            if (! $handler->setDateFormat($this->dateFormat)->handle($level, $message)) {
+            if (! $handler->setDateFormat($this->dateFormat)->handle($level, $message, $context)) {
                 break;
             }
         }

--- a/tests/_support/Log/Handlers/TestHandler.php
+++ b/tests/_support/Log/Handlers/TestHandler.php
@@ -31,6 +31,13 @@ class TestHandler extends FileHandler
      */
     protected static $logs = [];
 
+    /**
+     * Local storage for log contexts.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected static array $contexts = [];
+
     protected string $destination;
 
     /**
@@ -45,7 +52,8 @@ class TestHandler extends FileHandler
         $this->handles     = $config['handles'] ?? [];
         $this->destination = $this->path . 'log-' . Time::now()->format('Y-m-d') . '.' . $this->fileExtension;
 
-        self::$logs = [];
+        self::$logs     = [];
+        self::$contexts = [];
     }
 
     /**
@@ -54,14 +62,16 @@ class TestHandler extends FileHandler
      * will stop. Any handlers that have not run, yet, will not
      * be run.
      *
-     * @param string $level
-     * @param string $message
+     * @param string               $level
+     * @param string               $message
+     * @param array<string, mixed> $context
      */
-    public function handle($level, $message): bool
+    public function handle($level, $message, array $context = []): bool
     {
         $date = Time::now()->format($this->dateFormat);
 
-        self::$logs[] = strtoupper($level) . ' - ' . $date . ' --> ' . $message;
+        self::$logs[]     = strtoupper($level) . ' - ' . $date . ' --> ' . $message;
+        self::$contexts[] = $context;
 
         return true;
     }
@@ -69,5 +79,13 @@ class TestHandler extends FileHandler
     public static function getLogs()
     {
         return self::$logs;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function getContexts(): array
+    {
+        return self::$contexts;
     }
 }

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -74,6 +74,26 @@ final class ChromeLoggerHandlerTest extends CIUnitTestCase
         $this->assertSame('F j, Y', $this->getPrivateProperty($logger, 'dateFormat'));
     }
 
+    public function testHandleIncludesContextInRow(): void
+    {
+        Services::injectMock('response', new MockResponse());
+        $response = service('response');
+
+        $config                                                              = new LoggerConfig();
+        $config->handlers['CodeIgniter\Log\Handlers\TestHandler']['handles'] = ['debug'];
+
+        $logger = new ChromeLoggerHandler($config->handlers['CodeIgniter\Log\Handlers\TestHandler']);
+        $logger->handle('debug', 'Test message', [HandlerInterface::GLOBAL_CONTEXT_KEY => ['foo' => 'bar']]);
+
+        $this->assertTrue($response->hasHeader('X-ChromeLogger-Data'));
+
+        $decoded = json_decode(base64_decode($response->getHeaderLine('X-ChromeLogger-Data'), true), true);
+        $logArgs = $decoded['rows'][0][0];
+
+        $this->assertSame('Test message', $logArgs[0]);
+        $this->assertSame([HandlerInterface::GLOBAL_CONTEXT_KEY => ['foo' => 'bar']], $logArgs[1]);
+    }
+
     public function testChromeLoggerHeaderSent(): void
     {
         Services::injectMock('response', new MockResponse());

--- a/tests/system/Log/Handlers/ErrorlogHandlerTest.php
+++ b/tests/system/Log/Handlers/ErrorlogHandlerTest.php
@@ -38,6 +38,15 @@ final class ErrorlogHandlerTest extends CIUnitTestCase
         $this->assertTrue($logger->handle('error', 'Test message.'));
     }
 
+    public function testErrorLoggingAppendsContextAsJson(): void
+    {
+        $logger = $this->getMockedHandler(['handles' => ['critical', 'error']]);
+        $logger->method('errorLog')->willReturn(true);
+        $logger->expects($this->once())->method('errorLog')
+            ->with("ERROR --> Test message. {\"_ci_context\":{\"foo\":\"bar\"}}\n", 0);
+        $this->assertTrue($logger->handle('error', 'Test message.', [HandlerInterface::GLOBAL_CONTEXT_KEY => ['foo' => 'bar']]));
+    }
+
     /**
      * @param array{handles?: list<string>, messageType?: int} $config
      *

--- a/tests/system/Log/Handlers/FileHandlerTest.php
+++ b/tests/system/Log/Handlers/FileHandlerTest.php
@@ -79,6 +79,24 @@ final class FileHandlerTest extends CIUnitTestCase
         $this->assertStringContainsString($expectedResult, (string) $line);
     }
 
+    public function testHandleAppendsContextAsJson(): void
+    {
+        $config                                       = new LoggerConfig();
+        $config->handlers[TestHandler::class]['path'] = $this->start;
+        $logger                                       = new MockFileLogger($config->handlers[TestHandler::class]);
+
+        $logger->setDateFormat('Y-m-d');
+        $expected = 'log-' . date('Y-m-d') . '.log';
+        vfsStream::newFile($expected)->at(vfsStream::setup('root'))->withContent('');
+        $logger->handle('debug', 'Test message', [HandlerInterface::GLOBAL_CONTEXT_KEY => ['foo' => 'bar']]);
+
+        $fp   = fopen($config->handlers[TestHandler::class]['path'] . $expected, 'rb');
+        $line = fgets($fp);
+        fclose($fp);
+
+        $this->assertStringContainsString('Test message {"_ci_context":{"foo":"bar"}}', (string) $line);
+    }
+
     public function testHandleDateTimeCorrectly(): void
     {
         $config                                       = new LoggerConfig();

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -452,14 +452,16 @@ final class LoggerTest extends CIUnitTestCase
 
         service('context')->set('foo', 'bar');
 
-        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Test message {"foo":"bar"}';
+        $expectedMessage = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Test message';
 
         $logger->log('debug', 'Test message');
 
-        $logs = TestHandler::getLogs();
+        $logs     = TestHandler::getLogs();
+        $contexts = TestHandler::getContexts();
 
         $this->assertCount(1, $logs);
-        $this->assertSame($expected, $logs[0]);
+        $this->assertSame($expectedMessage, $logs[0]);
+        $this->assertSame(['_ci_context' => ['foo' => 'bar']], $contexts[0]);
     }
 
     public function testDoesNotLogGlobalContext(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -37,6 +37,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
         update your implementations to include the new methods or method changes to ensure compatibility.
 
+- **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
 
 Method Signature Changes
@@ -174,6 +175,7 @@ Libraries
 =========
 
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
+- **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 
 Helpers and Functions
 =====================

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -1,0 +1,77 @@
+#############################
+Upgrading from 4.7.x to 4.8.0
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+**********************
+Mandatory File Changes
+**********************
+
+****************
+Breaking Changes
+****************
+
+*********************
+Breaking Enhancements
+*********************
+
+Log Handler Interface
+=====================
+
+``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now accepts a third
+parameter ``array $context = []``.
+
+If you have a custom log handler that overrides the ``handle()`` method
+(whether implementing ``HandlerInterface`` directly or extending a built-in
+handler class), you must update your ``handle()`` method signature:
+
+.. code-block:: php
+
+    // Before
+    public function handle($level, $message): bool
+
+    // After
+    public function handle($level, $message, array $context = []): bool
+
+The context array may contain the CI global context data under the
+``HandlerInterface::GLOBAL_CONTEXT_KEY`` (``'_ci_context'``) key when
+``$logGlobalContext`` is enabled in ``Config\Logger``.
+
+*************
+Project Files
+*************
+
+Some files in the **project space** (root, app, public, writable) received updates. Due to
+these files being outside of the **system** scope they will not be changed without your intervention.
+
+.. note:: There are some third-party CodeIgniter modules available to assist
+    with merging changes to the project space:
+    `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+Content Changes
+===============
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+Config
+------
+
+- @TODO
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+- @TODO

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -22,6 +22,7 @@ Alternatively, replace it with a new file and add your previous lines.
 
     backward_compatibility_notes
 
+    upgrade_480
     upgrade_471
     upgrade_470
     upgrade_465


### PR DESCRIPTION
**Description**
This PR passes the log context as structured data to handlers instead of appending it as a JSON string to the message inside the Logger.

`HandlerInterface::handle()` gains a third `array $context = []` parameter carrying the full log context, with CI global context stored under `HandlerInterface::GLOBAL_CONTEXT_KEY`.

This allows handlers (such as `ChromeHandler`) to present the context as a structured object instead of a JSON-encoded string. Custom loggers can also take advantage of this to render context data natively (e.g., as expandable objects in browser dev tools or structured fields in external logging systems).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
