### PR TITLE
docs: add `none` parameter example to the query builder `like()` method

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -444,7 +444,7 @@ searches.
     .. literalinclude:: query_builder/039.php
 
     If you want to control where the wildcard (**%**) is placed, you can use
-    an optional third argument. Your options are ``before``, ``after`` and
+    an optional third argument. Your options are ``none``, ``before``, ``after`` and
     ``both`` (which is the default).
 
     .. literalinclude:: query_builder/040.php

--- a/user_guide_src/source/database/query_builder/040.php
+++ b/user_guide_src/source/database/query_builder/040.php
@@ -1,5 +1,6 @@
 <?php
 
+$builder->like('title', 'match', 'none'); // Produces: WHERE `title` LIKE 'match' ESCAPE '!'
 $builder->like('title', 'match', 'before'); // Produces: WHERE `title` LIKE '%match' ESCAPE '!'
 $builder->like('title', 'match', 'after');  // Produces: WHERE `title` LIKE 'match%' ESCAPE '!'
 $builder->like('title', 'match', 'both');   // Produces: WHERE `title` LIKE '%match%' ESCAPE '!'

--- a/user_guide_src/source/database/query_builder/040.php
+++ b/user_guide_src/source/database/query_builder/040.php
@@ -1,6 +1,6 @@
 <?php
 
-$builder->like('title', 'match', 'none'); // Produces: WHERE `title` LIKE 'match' ESCAPE '!'
+$builder->like('title', 'match', 'none');   // Produces: WHERE `title` LIKE 'match' ESCAPE '!'
 $builder->like('title', 'match', 'before'); // Produces: WHERE `title` LIKE '%match' ESCAPE '!'
 $builder->like('title', 'match', 'after');  // Produces: WHERE `title` LIKE 'match%' ESCAPE '!'
 $builder->like('title', 'match', 'both');   // Produces: WHERE `title` LIKE '%match%' ESCAPE '!'


### PR DESCRIPTION
**Description**
This PR updates the user guide with an example of the `none` parameter for Query Builder `like*` methods.

Fixes #10018

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
