### PR TITLE
test: fix `CreateNewChangelogTest` removing uncommitted changes

### DIFF
--- a/tests/system/AutoReview/CreateNewChangelogTest.php
+++ b/tests/system/AutoReview/CreateNewChangelogTest.php
@@ -65,6 +65,12 @@ final class CreateNewChangelogTest extends TestCase
     #[DataProvider('provideCreateNewChangelog')]
     public function testCreateNewChangelog(string $mode): void
     {
+        $output = exec('git status --porcelain | wc -l');
+
+        if ($output !== '0') {
+            $this->markTestIncomplete('You may have uncommited changes.');
+        }
+
         $currentVersion = $this->currentVersion;
         $newVersion     = $this->incrementVersion($currentVersion, $mode);
 

--- a/tests/system/AutoReview/CreateNewChangelogTest.php
+++ b/tests/system/AutoReview/CreateNewChangelogTest.php
@@ -68,7 +68,7 @@ final class CreateNewChangelogTest extends TestCase
         $output = exec('git status --porcelain | wc -l');
 
         if ($output !== '0') {
-            $this->markTestIncomplete('You may have uncommited changes.');
+            $this->markTestSkipped('You have uncommitted operations that will be erased by this test.');
         }
 
         $currentVersion = $this->currentVersion;


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/9951#discussion_r2877706712

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
