### PR TITLE
refactor: fix typo in log messages

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1708,7 +1708,7 @@ class Email
             $success = $this->{$method}();
         } catch (ErrorException $e) {
             $success = false;
-            log_message('error', 'Email: ' . $method . ' throwed ' . $e);
+            log_message('error', 'Email: ' . $method . ' threw ' . $e);
         }
 
         if (! $success) {
@@ -2265,7 +2265,7 @@ class Email
             } catch (ErrorException $e) {
                 $protocol = $this->getProtocol();
                 $method   = 'sendWith' . ucfirst($protocol);
-                log_message('error', 'Email: ' . $method . ' throwed ' . $e);
+                log_message('error', 'Email: ' . $method . ' threw ' . $e);
             }
         }
     }


### PR DESCRIPTION
**Description**
Corrected two error messages using the wrong past tense of "throw"

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide