### PR TITLE
docs: fix typos

### DIFF
--- a/admin/apibot.md
+++ b/admin/apibot.md
@@ -6,7 +6,7 @@ The in-progress CI4 API docs, warts & all, are rebuilt and
 then copied to a nested
 repository clone (`build/api`), with the result
 optionally pushed to the `master` branch of the `api` repo.
-That would then be publically visible as the in-progress
+That would then be publicly visible as the in-progress
 version of the [API](https://codeigniter4.github.io/api/).
 
 ## Requirements

--- a/admin/docbot.md
+++ b/admin/docbot.md
@@ -5,7 +5,7 @@ Builds & deploys user guide.
 The in-progress CI4 user guide, warts & all, is rebuilt in a nested
 repository clone (`user_guide_src/build/html`), with the result
 optionally pushed to the `gh-pages` branch of the repo.
-That would then be publically visible as the in-progress
+That would then be publicly visible as the in-progress
 version of the [User Guide](https://codeigniter4.github.io/CodeIgniter4/).
 
 ## Requirements

--- a/rector.php
+++ b/rector.php
@@ -174,7 +174,7 @@ return RectorConfig::configure()
 
         CompactToVariablesRector::class,
 
-        // possibly isset() on purpose, on updated Config classes property accross versions
+        // possibly isset() on purpose, on updated Config classes property across versions
         IssetOnPropertyObjectToPropertyExistsRector::class,
 
         AssertFuncCallToPHPUnitAssertRector::class => [

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -321,7 +321,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Add permision statements for index value inserts
+     * Add permission statements for index value inserts
      */
     private function addIdentity(string $fullTable, string $insert): string
     {

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -629,7 +629,7 @@ class URI implements Stringable
     /**
      * Formats the URI as a string.
      *
-    * Warning: For backwards-compatibility this method
+     * Warning: For backwards-compatibility this method
      * assumes URIs with the same host as baseURL should
      * be relative to the project's configuration.
      * This aspect of __toString() is deprecated and should be avoided.

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -629,7 +629,7 @@ class URI implements Stringable
     /**
      * Formats the URI as a string.
      *
-     * Warning: For backwards-compatability this method
+    * Warning: For backwards-compatibility this method
      * assumes URIs with the same host as baseURL should
      * be relative to the project's configuration.
      * This aspect of __toString() is deprecated and should be avoided.

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -246,7 +246,7 @@ Routing
 Negotiator
 ==========
 
-- Added a feature flag ``Feature::$strictLocaleNegotiation`` to enable strict locale comparision.
+- Added a feature flag ``Feature::$strictLocaleNegotiation`` to enable strict locale comparison.
   Previously, response with language headers ``Accept-language: en-US,en-GB;q=0.9`` returned the first allowed language ``en`` could instead of the exact language ``en-US`` or ``en-GB``.
   Set the value to ``true`` to enable comparison not only by language code ('en' - ISO 639-1) but also by regional code ('en-US' - ISO 639-1 plus ISO 3166-1 alpha).
 


### PR DESCRIPTION
Fix typos (within comments) in different locations.