### PR TITLE
fix: preserve JSON body when CSRF token is sent in header

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -307,6 +307,11 @@ class Security implements SecurityInterface
 
         // If the token is found in form-encoded data, we can safely remove it.
         parse_str($body, $result);
+
+        if (! array_key_exists($tokenName, $result)) {
+            return;
+        }
+
         unset($result[$tokenName]);
         $request->setBody(http_build_query($result));
     }

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -298,19 +298,17 @@ class Security implements SecurityInterface
             $json = null;
         }
 
-        if (is_object($json) && property_exists($json, $tokenName)) {
-            unset($json->{$tokenName});
-            $request->setBody(json_encode($json));
+        if (is_object($json)) {
+            if (property_exists($json, $tokenName)) {
+                unset($json->{$tokenName});
+                $request->setBody(json_encode($json));
+            }
 
             return;
         }
 
         // If the token is found in form-encoded data, we can safely remove it.
         parse_str($body, $result);
-
-        if (! array_key_exists($tokenName, $result)) {
-            return;
-        }
 
         unset($result[$tokenName]);
         $request->setBody(http_build_query($result));

--- a/tests/system/Security/SecurityCSRFSessionTest.php
+++ b/tests/system/Security/SecurityCSRFSessionTest.php
@@ -251,6 +251,37 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $this->assertSame('{"foo":"bar"}', $request->getBody());
     }
 
+    public function testCSRFVerifyHeaderWithJsonBodyPreservesBody(): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+
+        $request = $this->createIncomingRequest();
+        $body    = '{"foo":"bar"}';
+
+        $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
+        $request->setBody($body);
+        $security = $this->createSecurity();
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+        $this->assertSame($body, $request->getBody());
+    }
+
+    public function testCSRFVerifyHeaderWithJsonBodyStripsTokenFromBody(): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+
+        $request = $this->createIncomingRequest();
+
+        $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
+        $request->setBody('{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a","foo":"bar"}');
+        $security = $this->createSecurity();
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+        $this->assertSame('{"foo":"bar"}', $request->getBody());
+    }
+
     public function testRegenerateWithFalseSecurityRegenerateProperty(): void
     {
         service('superglobals')

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -204,6 +204,39 @@ final class SecurityTest extends CIUnitTestCase
         $this->assertSame('{"foo":"bar"}', $request->getBody());
     }
 
+    public function testCsrfVerifyHeaderWithJsonBodyPreservesBody(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+        $body     = '{"foo":"bar"}';
+
+        $request->setHeader('X-CSRF-TOKEN', self::CORRECT_CSRF_HASH);
+        $request->setBody($body);
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertSame($body, $request->getBody());
+    }
+
+    public function testCsrfVerifyHeaderWithJsonBodyStripsTokenFromBody(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $request->setHeader('X-CSRF-TOKEN', self::CORRECT_CSRF_HASH);
+        $request->setBody('{"csrf_test_name":"' . self::CORRECT_CSRF_HASH . '","foo":"bar"}');
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertSame('{"foo":"bar"}', $request->getBody());
+    }
+
     public function testCsrfVerifyPutBodyThrowsExceptionOnNoMatch(): void
     {
         service('superglobals')

--- a/user_guide_src/source/changelogs/v4.7.2.rst
+++ b/user_guide_src/source/changelogs/v4.7.2.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Security:** Fixed a bug where the CSRF filter could corrupt JSON request bodies after successful verification when the CSRF token was provided via the ``X-CSRF-TOKEN`` header. This caused ``IncomingRequest::getJSON()`` to fail on valid ``application/json`` requests.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
This PR fixes a regression in CSRF verification introduced in #9969.

When the CSRF token was sent via the `X-CSRF-TOKEN` header, the CSRF filter could still parse the raw request body as form data and rewrite valid JSON into a URL-encoded string. As a result, `IncomingRequest::getJSON()` failed for `application/json` requests.

I am not sure whether this should be patched in 4.7.1 or included in 4.7.2.

Fixes #10063

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
