### PR TITLE
docs: document Axios header configuration for AJAX

### DIFF
--- a/user_guide_src/source/general/ajax.rst
+++ b/user_guide_src/source/general/ajax.rst
@@ -25,6 +25,17 @@ Fetch API
         }
     });
 
+Axios
+=====
+
+If you are using Axios, it also does not include the ``X-Requested-With`` header by default.
+You can add it globally as follows:
+
+.. code-block:: javascript
+
+    axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+
 jQuery
 ======
 


### PR DESCRIPTION
Added instructions on how to set the X-Requested-With header globally when using Axios in the AJAX documentation.