### PR TITLE
docs: clarify `Model::find()` note for null argument

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -492,8 +492,8 @@ of just one:
 
 .. literalinclude:: model/007.php
 
-.. note:: If no parameters are passed in, ``find()`` will return all rows in that model's table,
-    effectively acting like ``findAll()``, though less explicit.
+.. note:: If ``find()`` is called without parameters or with ``null``, it will return all rows in
+    that model's table, effectively acting like ``findAll()``, though less explicit.
 
 findColumn()
 ------------


### PR DESCRIPTION
**Description**
This PR clarifies the user guide note for `Model::find()` to explicitly state that calling it without arguments or with `null` returns all rows.

Closes #10071

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
