### PR TITLE
chore: fix wrong trigger name for manually runnable workflow

### DIFF
--- a/.github/workflows/test-random-execution.yml
+++ b/.github/workflows/test-random-execution.yml
@@ -25,7 +25,7 @@ on:
       - 'system/**.php'
       - 'tests/**.php'
 
-  workflow_call:
+  workflow_dispatch:
     inputs:
       quiet:
         description: Suppress debug output


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
`workflow_call` is for reusable workflows. `workflow_dispatch` is for manually runnable workflows

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
