### PR TITLE
refactor: update `Console::run()` to allow it be called in `command()` function

### DIFF
--- a/system/Boot.php
+++ b/system/Boot.php
@@ -162,7 +162,7 @@ class Boot
 
         static::initializeCodeIgniter();
 
-        return static::runCommand(new Console());
+        return static::runCommand(static::initializeConsole());
     }
 
     /**
@@ -421,24 +421,9 @@ class Boot
         $factoriesCache->save('config');
     }
 
-    /**
-     * @deprecated 4.8.0 No longer used.
-     */
     protected static function initializeConsole(): Console
     {
-        @trigger_error(sprintf('The static %s() method is deprecated and no longer used.', __METHOD__), E_USER_DEPRECATED);
-
-        $console = new Console();
-
-        // Show basic information before we do anything else.
-        if (is_int($suppress = array_search('--no-header', $_SERVER['argv'], true))) {
-            unset($_SERVER['argv'][$suppress]);
-            $suppress = true;
-        }
-
-        $console->showHeader($suppress);
-
-        return $console;
+        return new Console();
     }
 
     protected static function runCommand(Console $console): int

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -161,9 +161,8 @@ class Boot
         static::autoloadHelpers();
 
         static::initializeCodeIgniter();
-        $console = static::initializeConsole();
 
-        return static::runCommand($console);
+        return static::runCommand(new Console());
     }
 
     /**
@@ -422,8 +421,13 @@ class Boot
         $factoriesCache->save('config');
     }
 
+    /**
+     * @deprecated 4.8.0 No longer used.
+     */
     protected static function initializeConsole(): Console
     {
+        @trigger_error(sprintf('The static %s() method is deprecated and no longer used.', __METHOD__), E_USER_DEPRECATED);
+
         $console = new Console();
 
         // Show basic information before we do anything else.
@@ -439,8 +443,13 @@ class Boot
 
     protected static function runCommand(Console $console): int
     {
-        $exit = $console->run();
+        $exitCode = $console->initialize()->run();
 
-        return is_int($exit) ? $exit : EXIT_SUCCESS;
+        if (! is_int($exitCode)) {
+            @trigger_error(sprintf('Starting with CodeIgniter v4.8.0, commands must return an integer exit code. Last command exited with %s. Defaulting to EXIT_SUCCESS.', get_debug_type($exitCode)), E_USER_DEPRECATED);
+            $exitCode = EXIT_SUCCESS;
+        }
+
+        return $exitCode;
     }
 }

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -16,35 +16,61 @@ namespace CodeIgniter\CLI;
 use CodeIgniter\CodeIgniter;
 use Config\App;
 use Config\Services;
-use Exception;
 
 /**
- * Console
- *
  * @see \CodeIgniter\CLI\ConsoleTest
  */
 class Console
 {
+    private const DEFAULT_COMMAND = 'list';
+
+    /**
+     * @var array<string, string|null>
+     */
+    private array $options = [];
+
     /**
      * Runs the current command discovered on the CLI.
      *
-     * @return int|void Exit code
+     * @param list<string> $tokens
      *
-     * @throws Exception
+     * @return int|null Exit code or null for legacy commands that don't return an exit code.
      */
-    public function run()
+    public function run(array $tokens = [])
     {
-        // Create CLIRequest
-        $appConfig = config(App::class);
-        Services::createRequest($appConfig, true);
-        // Load Routes
+        if ($tokens === []) {
+            $tokens = service('superglobals')->server('argv', []);
+        }
+
+        $parser = new CommandLineParser($tokens);
+
+        $arguments     = $parser->getArguments();
+        $this->options = $parser->getOptions();
+
+        $this->showHeader($this->hasParameterOption(['no-header']));
+        unset($this->options['no-header']);
+
+        if ($this->hasParameterOption(['help'])) {
+            unset($this->options['help']);
+
+            if ($arguments === []) {
+                $arguments = ['help', self::DEFAULT_COMMAND];
+            } elseif ($arguments[0] !== 'help') {
+                array_unshift($arguments, 'help');
+            }
+        }
+
+        $command = array_shift($arguments) ?? self::DEFAULT_COMMAND;
+
+        return service('commands')->run($command, array_merge($arguments, $this->options));
+    }
+
+    public function initialize(): static
+    {
+        Services::createRequest(config(App::class), true);
         service('routes')->loadRoutes();
 
-        $params  = array_merge(CLI::getSegments(), CLI::getOptions());
-        $params  = $this->parseParamsForHelpOption($params);
-        $command = array_shift($params) ?? 'list';
-
-        return service('commands')->run($command, $params);
+        return $this;
     }
 
     /**
@@ -67,24 +93,18 @@ class Console
     }
 
     /**
-     * Introspects the `$params` passed for presence of the
-     * `--help` option.
+     * Checks whether any of the options are present in the command line.
      *
-     * If present, it will be found as `['help' => null]`.
-     * We'll remove that as an option from `$params` and
-     * unshift it as argument instead.
-     *
-     * @param array<int|string, string|null> $params
+     * @param list<string> $options
      */
-    private function parseParamsForHelpOption(array $params): array
+    private function hasParameterOption(array $options): bool
     {
-        if (array_key_exists('help', $params)) {
-            unset($params['help']);
-
-            $params = $params === [] ? ['list'] : $params;
-            array_unshift($params, 'help');
+        foreach ($options as $option) {
+            if (array_key_exists($option, $this->options)) {
+                return true;
+            }
         }
 
-        return $params;
+        return false;
     }
 }

--- a/system/Common.php
+++ b/system/Common.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 
 use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\CLI\Console;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Context\Context;
@@ -127,7 +128,7 @@ if (! function_exists('command')) {
         $regexString = '([^\s]+?)(?:\s|(?<!\\\\)"|(?<!\\\\)\'|$)';
         $regexQuoted = '(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')';
 
-        $args   = [];
+        $tokens = [];
         $length = strlen($command);
         $cursor = 0;
 
@@ -140,9 +141,9 @@ if (! function_exists('command')) {
             if (preg_match('/\s+/A', $command, $match, 0, $cursor)) {
                 // nothing to do
             } elseif (preg_match('/' . $regexQuoted . '/A', $command, $match, 0, $cursor)) {
-                $args[] = stripcslashes(substr($match[0], 1, strlen($match[0]) - 2));
+                $tokens[] = stripcslashes(substr($match[0], 1, strlen($match[0]) - 2));
             } elseif (preg_match('/' . $regexString . '/A', $command, $match, 0, $cursor)) {
-                $args[] = stripcslashes($match[1]);
+                $tokens[] = stripcslashes($match[1]);
             } else {
                 // @codeCoverageIgnoreStart
                 throw new InvalidArgumentException(sprintf(
@@ -155,39 +156,21 @@ if (! function_exists('command')) {
             $cursor += strlen($match[0]);
         }
 
-        /** @var array<int|string, string|null> */
-        $params      = [];
-        $command     = array_shift($args);
-        $optionValue = false;
-
-        foreach ($args as $i => $arg) {
-            if (mb_strpos($arg, '-') !== 0) {
-                if ($optionValue) {
-                    // if this was an option value, it was already
-                    // included in the previous iteration
-                    $optionValue = false;
-                } else {
-                    // add to segments if not starting with '-'
-                    // and not an option value
-                    $params[] = $arg;
-                }
-
-                continue;
+        // Don't show the header as it is not needed when running commands from code.
+        if (! in_array('--no-header', $tokens, true)) {
+            if (! in_array('--', $tokens, true)) {
+                $tokens[] = '--no-header';
+            } else {
+                $index = (int) array_search('--', $tokens, true);
+                array_splice($tokens, $index, 0, '--no-header');
             }
-
-            $arg   = ltrim($arg, '-');
-            $value = null;
-
-            if (isset($args[$i + 1]) && mb_strpos($args[$i + 1], '-') !== 0) {
-                $value       = $args[$i + 1];
-                $optionValue = true;
-            }
-
-            $params[$arg] = $value;
         }
 
+        // Prepend an application name, as Console expects one.
+        array_unshift($tokens, 'spark');
+
         ob_start();
-        service('commands')->run($command, $params);
+        (new Console())->run($tokens);
 
         return ob_get_clean();
     }

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -39,13 +39,7 @@ final class ConsoleTest extends CIUnitTestCase
         Services::injectMock('superglobals', new Superglobals());
         CLI::init();
 
-        $env = new DotEnv(ROOTPATH);
-        $env->load();
-
-        // Set environment values that would otherwise stop the framework from functioning during tests.
-        if (service('superglobals')->server('app.baseURL') === null) {
-            service('superglobals')->setServer('app.baseURL', 'http://example.com/');
-        }
+        (new DotEnv(ROOTPATH))->load();
 
         $this->app = new MockCodeIgniter(new MockCLIConfig());
         $this->app->initialize();
@@ -53,39 +47,38 @@ final class ConsoleTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        CLI::reset();
-
         parent::tearDown();
+
+        CLI::reset();
     }
 
-    public function testHeader(): void
+    public function testHeaderShowsNormally(): void
     {
-        $console = new Console();
-        $console->showHeader();
-        $this->assertGreaterThan(
-            0,
-            strpos(
-                $this->getStreamFilterBuffer(),
-                sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION),
-            ),
+        $this->initializeConsole();
+        (new Console())->run();
+
+        $this->assertStringContainsString(
+            sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION),
+            $this->getStreamFilterBuffer(),
         );
     }
 
-    public function testNoHeader(): void
+    public function testHeaderDoesNotShowOnNoHeader(): void
     {
-        $console = new Console();
-        $console->showHeader(true);
-        $this->assertSame('', $this->getStreamFilterBuffer());
+        $this->initializeConsole('--no-header');
+        (new Console())->run();
+
+        $this->assertStringNotContainsString(
+            sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION),
+            $this->getStreamFilterBuffer(),
+        );
     }
 
     public function testRun(): void
     {
-        $this->initCLI();
+        $this->initializeConsole();
+        (new Console())->run();
 
-        $console = new Console();
-        $console->run();
-
-        // make sure the result looks like a command list
         $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
         $this->assertStringContainsString('Displays basic usage information.', $this->getStreamFilterBuffer());
     }
@@ -97,10 +90,8 @@ final class ConsoleTest extends CIUnitTestCase
             $result = 'fired';
         });
 
-        $this->initCLI();
-
-        $console = new Console();
-        $console->run();
+        $this->initializeConsole();
+        (new Console())->run();
 
         $this->assertEventTriggered('pre_command');
         $this->assertSame('fired', $result);
@@ -113,10 +104,8 @@ final class ConsoleTest extends CIUnitTestCase
             $result = 'fired';
         });
 
-        $this->initCLI();
-
-        $console = new Console();
-        $console->run();
+        $this->initializeConsole();
+        (new Console())->run();
 
         $this->assertEventTriggered('post_command');
         $this->assertSame('fired', $result);
@@ -124,23 +113,17 @@ final class ConsoleTest extends CIUnitTestCase
 
     public function testBadCommand(): void
     {
-        $this->initCLI('bogus');
+        $this->initializeConsole('bogus');
+        (new Console())->run();
 
-        $console = new Console();
-        $console->run();
-
-        // make sure the result looks like a command list
         $this->assertStringContainsString('Command "bogus" not found', $this->getStreamFilterBuffer());
     }
 
     public function testHelpCommandDetails(): void
     {
-        $this->initCLI('help', 'make:migration');
+        $this->initializeConsole('help', 'make:migration');
+        (new Console())->run();
 
-        $console = new Console();
-        $console->run();
-
-        // make sure the result looks like more detailed help
         $this->assertStringContainsString('Description:', $this->getStreamFilterBuffer());
         $this->assertStringContainsString('Usage:', $this->getStreamFilterBuffer());
         $this->assertStringContainsString('Options:', $this->getStreamFilterBuffer());
@@ -148,8 +131,7 @@ final class ConsoleTest extends CIUnitTestCase
 
     public function testHelpCommandUsingHelpOption(): void
     {
-        $this->initCLI('env', '--help');
-
+        $this->initializeConsole('env', '--help');
         (new Console())->run();
 
         $this->assertStringContainsString('env [<environment>]', $this->getStreamFilterBuffer());
@@ -161,8 +143,7 @@ final class ConsoleTest extends CIUnitTestCase
 
     public function testHelpOptionIsOnlyPassed(): void
     {
-        $this->initCLI('--help');
-
+        $this->initializeConsole('--help');
         (new Console())->run();
 
         // Since calling `php spark` is the same as calling `php spark list`,
@@ -172,21 +153,18 @@ final class ConsoleTest extends CIUnitTestCase
 
     public function testHelpArgumentAndHelpOptionCombined(): void
     {
-        $this->initCLI('help', '--help');
-
+        $this->initializeConsole('help', '--help');
         (new Console())->run();
 
         // Same as calling `php spark help` only
         $this->assertStringContainsString('Displays basic usage information.', $this->getStreamFilterBuffer());
     }
 
-    /**
-     * @param string ...$command
-     */
-    protected function initCLI(...$command): void
+    private function initializeConsole(string ...$tokens): void
     {
-        service('superglobals')->setServer('argv', ['spark', ...$command]);
-        service('superglobals')->setServer('argc', count(service('superglobals')->server('argv')));
+        service('superglobals')
+            ->setServer('argv', ['spark', ...$tokens])
+            ->setServer('argc', count($tokens) + 1);
 
         CLI::init();
     }

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -165,11 +165,11 @@ final class CommandTest extends CIUnitTestCase
             ],
             [
                 'reveal seg1 seg2 -opt1 val1 seg3',
-                ['seg1', 'seg2', 'opt1' => 'val1', 'seg3'],
+                ['seg1', 'seg2', 'seg3', 'opt1' => 'val1'],
             ],
             [
                 'reveal as df -gh -jk -qw 12 zx cv',
-                ['as', 'df', 'gh' => null, 'jk' => null, 'qw' => '12', 'zx', 'cv'],
+                ['as', 'df', 'zx', 'cv', 'gh' => null, 'jk' => null, 'qw' => '12'],
             ],
             [
                 'reveal as -df "some stuff" -jk 12 -sd "Some longer stuff" -fg \'using single quotes\'',

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
+use CodeIgniter\CodeIgniter;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use PHPUnit\Framework\Attributes\Group;
@@ -62,5 +63,27 @@ final class HelpCommandTest extends CIUnitTestCase
         command('help clear');
         $this->assertStringContainsString('Command "clear" not found.', $this->getBuffer());
         $this->assertStringContainsString('Did you mean one of these?', $this->getBuffer());
+    }
+
+    public function testNormalHelpCommandHasNoBanner(): void
+    {
+        command('help');
+
+        $this->assertStringNotContainsString(
+            sprintf('CodeIgniter %s Command Line Tool', CodeIgniter::CI_VERSION),
+            $this->getBuffer(),
+        );
+        $this->assertStringContainsString('Displays basic usage information.', $this->getBuffer());
+    }
+
+    public function testHelpCommandWithDoubleHyphenStillRemovesBanner(): void
+    {
+        command('help -- list');
+
+        $this->assertStringNotContainsString(
+            sprintf('CodeIgniter %s Command Line Tool', CodeIgniter::CI_VERSION),
+            $this->getBuffer(),
+        );
+        $this->assertStringContainsString('Lists the available commands.', $this->getBuffer());
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -23,6 +23,8 @@ BREAKING
 Behavior Changes
 ================
 
+- The static ``Boot::initializeConsole()`` method no longer handles the display of the console header. This is now handled within ``Console::run()``.
+    If you have overridden ``Boot::initializeConsole()``, you should remove any code related to displaying the console header, as this is now the responsibility of the ``Console`` class.
 - **Commands:** The ``filter:check`` command now requires the HTTP method argument to be uppercase (e.g., ``spark filter:check GET /`` instead of ``spark filter:check get /``).
 - **Database:** The Postgre driver's ``$db->error()['code']`` previously always returned ``''``. It now returns the 5-character SQLSTATE string for query and transaction failures (e.g., ``'42P01'``), or ``'08006'`` for connection-level failures. Code that relied on ``$db->error()['code'] === ''`` will need updating.
 - **Filters:** HTTP method matching for method-based filters is now case-sensitive. The keys in ``Config\Filters::$methods`` must exactly match the request method
@@ -268,7 +270,6 @@ Changes
 Deprecations
 ************
 
-- The ``Boot::initializeConsole()`` method is now deprecated and will be removed in a future release.
 - **CLI:** The ``CLI::parseCommandLine()`` method is now deprecated and will be removed in a future release. The ``CLI`` class now uses the new ``CommandLineParser`` class to handle command-line argument parsing.
 - **CLI:** Returning a non-integer exit code from a command is now deprecated and will trigger a deprecation notice. Command methods should return an integer exit code (e.g., ``0`` for success, non-zero for errors) to ensure proper behavior across all platforms.
 - **HTTP:** The ``CLIRequest::parseCommand()`` method is now deprecated and will be removed in a future release. The ``CLIRequest`` class now uses the new ``CommandLineParser`` class to handle command-line argument parsing.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,6 +43,7 @@ Interface Changes
 Method Signature Changes
 ========================
 
+- **CLI:** The ``Console::run()`` method now accepts an optional ``array $tokens`` parameter. This allows you to pass an array of command tokens directly to the console runner, which is useful for testing or programmatically running commands. If not provided, it will default to using the global ``$argv``.
 - **CodeIgniter:** The deprecated parameters in methods have been removed:
     - ``CodeIgniter\CodeIgniter::handleRequest()`` no longer accepts the deprecated ``$cacheConfig`` and ``$returnResponse`` parameters.
        - ``$cacheConfig`` is no longer used and is now hard deprecated. A deprecation notice will be triggered if this is passed to the method.
@@ -175,6 +176,7 @@ Commands
     This provides more flexibility in how you can pass options to commands.
 - ``CLI`` now supports parsing array options written multiple times (e.g., ``--option=value1 --option=value2``) into an array of values. This allows you to easily pass multiple values for the same option without needing to use a comma-separated string.
     When used with ``CLI::getOption()``, an array option will return its last value (for example, in this case, ``value2``). To retrieve all values for an array option, use ``CLI::getRawOption()``.
+- Likewise, the ``command()`` function now also supports the above enhancements for command-line option parsing when using the function to run commands from code.
 
 Testing
 =======
@@ -266,7 +268,9 @@ Changes
 Deprecations
 ************
 
+- The ``Boot::initializeConsole()`` method is now deprecated and will be removed in a future release.
 - **CLI:** The ``CLI::parseCommandLine()`` method is now deprecated and will be removed in a future release. The ``CLI`` class now uses the new ``CommandLineParser`` class to handle command-line argument parsing.
+- **CLI:** Returning a non-integer exit code from a command is now deprecated and will trigger a deprecation notice. Command methods should return an integer exit code (e.g., ``0`` for success, non-zero for errors) to ensure proper behavior across all platforms.
 - **HTTP:** The ``CLIRequest::parseCommand()`` method is now deprecated and will be removed in a future release. The ``CLIRequest`` class now uses the new ``CommandLineParser`` class to handle command-line argument parsing.
 - **HTTP:** ``URI::setSilent()`` is now hard deprecated. This method was only previously marked as deprecated. It will now trigger a deprecation notice when used.
 

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -20,6 +20,13 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Console Exit Codes
+==================
+
+Previously, returning a non-integer value from a command run through ``spark`` would be treated as a successful execution (exit code ``0``).
+Starting with v4.8.0, this behavior is still supported but will trigger a deprecation notice. Commands should now return an integer exit code
+to ensure proper behavior across all platforms.
+
 *********************
 Breaking Enhancements
 *********************

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2028 errors
+# total 2027 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1231 errors
+# total 1230 errors
 
 parameters:
     ignoreErrors:
@@ -56,11 +56,6 @@ parameters:
             message: '#^Method CodeIgniter\\CLI\\CLI\:\:validate\(\) has parameter \$rules with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/CLI/CLI.php
-
-        -
-            message: '#^Method CodeIgniter\\CLI\\Console\:\:parseParamsForHelpOption\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/CLI/Console.php
 
         -
             message: '#^Method CodeIgniter\\CodeIgniter\:\:getPerformanceStats\(\) return type has no value type specified in iterable type array\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This refactors `Console::run()` so that it can accept a list of tokens to parse (defaulting to `$_SERVER['argv']` if empty) when `run()` is called. This consequently allows it to be called inside the `command()` function so that the latter can also enjoy the enhancements to command line parsing.

A behavior break that I am seeing is that `command()` now receives the `$params` as a merge of arguments and options, instead of the previous how-it-was-parsed order. However, since getting the params passed to a command by this function is not an intended use, I believe its impact is minimal.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [X] User guide updated
- [x] Conforms to style guide
