### PR TITLE
chore: resolve PHPStan nullCoalesce and isset errors on Config properties

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -653,7 +653,7 @@ abstract class BaseModel
      */
     public function findAll(?int $limit = null, int $offset = 0)
     {
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll) {
             $limit ??= 0;
         }

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -205,7 +205,7 @@ class Boot
     protected static function loadDotEnv(Paths $paths): void
     {
         require_once $paths->systemDirectory . '/Config/DotEnv.php';
-        $envDirectory = $paths->envDirectory ?? $paths->appDirectory . '/../';
+        $envDirectory = $paths->envDirectory ?? $paths->appDirectory . '/../'; // @phpstan-ignore nullCoalesce.property
         (new DotEnv($envDirectory))->load();
     }
 

--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -49,12 +49,8 @@ class CacheFactory
      */
     public static function getHandler(Cache $config, ?string $handler = null, ?string $backup = null)
     {
-        if (! isset($config->validHandlers) || $config->validHandlers === []) {
+        if ($config->validHandlers === []) {
             throw CacheException::forInvalidHandlers();
-        }
-
-        if (! isset($config->handler) || ! isset($config->backupHandler)) {
-            throw CacheException::forNoBackup();
         }
 
         $handler ??= $config->handler;

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -65,9 +65,7 @@ class PredisHandler extends BaseHandler
     {
         $this->prefix = $config->prefix;
 
-        if (isset($config->redis)) {
-            $this->config = array_merge($this->config, $config->redis);
-        }
+        $this->config = array_merge($this->config, $config->redis);
     }
 
     public function initialize(): void

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -186,10 +186,10 @@ class CodeIgniter
     public function initialize()
     {
         // Set default locale on the server
-        Locale::setDefault($this->config->defaultLocale ?? 'en');
+        Locale::setDefault($this->config->defaultLocale);
 
         // Set default timezone on the server
-        date_default_timezone_set($this->config->appTimezone ?? 'UTC');
+        date_default_timezone_set($this->config->appTimezone);
     }
 
     /**
@@ -452,7 +452,7 @@ class CodeIgniter
             if ($routeFilters !== null) {
                 $filters->enableFilters($routeFilters, 'before');
 
-                $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+                $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
                 if (! $oldFilterOrder) {
                     $routeFilters = array_reverse($routeFilters);
                 }
@@ -521,7 +521,7 @@ class CodeIgniter
         }
 
         // Execute controller attributes' after() methods AFTER framework filters
-        if ((config('Routing')->useControllerAttributes ?? true) === true) {
+        if ((config('Routing')->useControllerAttributes ?? true) === true) { // @phpstan-ignore nullCoalesce.property
             $this->benchmark->start('route_attributes_after');
             $this->response = $this->router->executeAfterAttributes($this->request, $this->response);
             $this->benchmark->stop('route_attributes_after');
@@ -887,7 +887,7 @@ class CodeIgniter
 
         // Execute route attributes' before() methods
         // This runs after routing/validation but BEFORE expensive controller instantiation
-        if ((config('Routing')->useControllerAttributes ?? true) === true) {
+        if ((config('Routing')->useControllerAttributes ?? true) === true) { // @phpstan-ignore nullCoalesce.property
             $this->benchmark->start('route_attributes_before');
             $attributeResponse = $this->router->executeBeforeAttributes($this->request);
             $this->benchmark->stop('route_attributes_before');

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -102,7 +102,7 @@ class GenerateKey extends BaseCommand
         // force DotEnv to reload the new env vars
         putenv('encryption.key');
         unset($_ENV['encryption.key'], $_SERVER['encryption.key']);
-        $dotenv = new DotEnv((new Paths())->envDirectory ?? ROOTPATH);
+        $dotenv = new DotEnv((new Paths())->envDirectory ?? ROOTPATH); // @phpstan-ignore nullCoalesce.property
         $dotenv->load();
 
         CLI::write('Application\'s new encryption key was successfully set.', 'green');
@@ -156,7 +156,7 @@ class GenerateKey extends BaseCommand
     protected function writeNewEncryptionKeyToFile(string $oldKey, string $newKey): bool
     {
         $baseEnv = ROOTPATH . 'env';
-        $envFile = ((new Paths())->envDirectory ?? ROOTPATH) . '.env';
+        $envFile = ((new Paths())->envDirectory ?? ROOTPATH) . '.env'; // @phpstan-ignore nullCoalesce.property
 
         if (! is_file($envFile)) {
             if (! is_file($baseEnv)) {

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -121,7 +121,7 @@ final class Environment extends BaseCommand
         putenv('CI_ENVIRONMENT');
         unset($_ENV['CI_ENVIRONMENT']);
         service('superglobals')->unsetServer('CI_ENVIRONMENT');
-        (new DotEnv((new Paths())->envDirectory ?? ROOTPATH))->load();
+        (new DotEnv((new Paths())->envDirectory ?? ROOTPATH))->load(); // @phpstan-ignore nullCoalesce.property
 
         CLI::write(sprintf('Environment is successfully changed to "%s".', $env), 'green');
         CLI::write('The ENVIRONMENT constant will be changed in the next script execution.');
@@ -136,7 +136,7 @@ final class Environment extends BaseCommand
     private function writeNewEnvironmentToEnvFile(string $newEnv): bool
     {
         $baseEnv = ROOTPATH . 'env';
-        $envFile = ((new Paths())->envDirectory ?? ROOTPATH) . '.env';
+        $envFile = ((new Paths())->envDirectory ?? ROOTPATH) . '.env'; // @phpstan-ignore nullCoalesce.property
 
         if (! is_file($envFile)) {
             if (! is_file($baseEnv)) {

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -122,7 +122,7 @@ class Routes extends BaseCommand
         }
 
         if ($collection->shouldAutoRoute()) {
-            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
+            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved;
 
             if ($autoRoutesImproved) {
                 $autoRouteCollector = new AutoRouteCollectorImproved(

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -56,7 +56,7 @@ final readonly class FilterFinder
             // Add route filters
             $routeFilters = $this->getRouteFilters($uri);
             $this->filters->enableFilters($routeFilters, 'before');
-            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
             if (! $oldFilterOrder) {
                 $routeFilters = array_reverse($routeFilters);
             }
@@ -91,7 +91,7 @@ final readonly class FilterFinder
             // Add route filters
             $routeFilters = $this->getRouteFilters($uri);
             $this->filters->enableFilters($routeFilters, 'before');
-            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
             if (! $oldFilterOrder) {
                 $routeFilters = array_reverse($routeFilters);
             }

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1513,7 +1513,7 @@ class BaseBuilder
      */
     public function limit(?int $value = null, ?int $offset = 0)
     {
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll && $value === 0) {
             $value = null;
         }
@@ -1635,7 +1635,7 @@ class BaseBuilder
      */
     public function get(?int $limit = null, int $offset = 0, bool $reset = true)
     {
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll && $limit === 0) {
             $limit = null;
         }
@@ -1773,7 +1773,7 @@ class BaseBuilder
             $this->where($where);
         }
 
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll && $limit === 0) {
             $limit = null;
         }
@@ -2500,7 +2500,7 @@ class BaseBuilder
             $this->where($where);
         }
 
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll && $limit === 0) {
             $limit = null;
         }
@@ -2547,7 +2547,7 @@ class BaseBuilder
             $valStr[] = $key . ' = ' . $val;
         }
 
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll) {
             return 'UPDATE ' . $this->compileIgnore('update') . $table . ' SET ' . implode(', ', $valStr)
                 . $this->compileWhereHaving('QBWhere')
@@ -2824,7 +2824,7 @@ class BaseBuilder
 
         $sql = $this->_delete($this->removeAlias($table));
 
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll && $limit === 0) {
             $limit = null;
         }
@@ -3099,7 +3099,7 @@ class BaseBuilder
             . $this->compileWhereHaving('QBHaving')
             . $this->compileOrderBy();
 
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll) {
             if ($this->QBLimit) {
                 $sql = $this->_limit($sql . "\n");

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -145,9 +145,9 @@ class MigrationRunner
      */
     public function __construct(MigrationsConfig $config, $db = null)
     {
-        $this->enabled = $config->enabled ?? false;
-        $this->table   = $config->table ?? 'migrations';
-        $this->lock    = $config->lock ?? false;
+        $this->enabled = $config->enabled;
+        $this->table   = $config->table;
+        $this->lock    = $config->lock ?? false; // @phpstan-ignore nullCoalesce.property
 
         // Even if a DB connection is passed, since it is a test,
         // it is assumed to use the default group name

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -337,7 +337,7 @@ class Builder extends BaseBuilder
         // DatabaseException:
         //   [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The number of
         //   rows provided for a FETCH clause must be greater then zero.
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if (! $limitZeroAsAll && $this->QBLimit === 0) {
             return "SELECT * \nFROM " . $this->_fromTables() . ' WHERE 1=0 ';
         }
@@ -624,7 +624,7 @@ class Builder extends BaseBuilder
             . $this->compileOrderBy(); // ORDER BY
 
         // LIMIT
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll) {
             if ($this->QBLimit) {
                 $sql = $this->_limit($sql . "\n");
@@ -644,7 +644,7 @@ class Builder extends BaseBuilder
      */
     public function get(?int $limit = null, int $offset = 0, bool $reset = true)
     {
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll && $limit === 0) {
             $limit = null;
         }

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -78,7 +78,7 @@ class Seeder
      */
     public function __construct(Database $config, ?BaseConnection $db = null)
     {
-        $this->seedPath = $config->filesPath ?? APPPATH . 'Database/';
+        $this->seedPath = $config->filesPath;
 
         if ($this->seedPath === '') {
             throw new InvalidArgumentException('Invalid filesPath set in the Config\Database.');

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -336,7 +336,7 @@ class Toolbar
      */
     protected function collectVarData(): array
     {
-        if (! ($this->config->collectVarData ?? true)) {
+        if (! $this->config->collectVarData) {
             return [];
         }
 
@@ -585,7 +585,7 @@ class Toolbar
     private function shouldDisableToolbar(IncomingRequest $request): bool
     {
         // Fallback for older installations where the config option is missing (e.g. after upgrading from a previous version).
-        $headers = $this->config->disableOnHeaders ?? ['X-Requested-With' => 'xmlhttprequest'];
+        $headers = $this->config->disableOnHeaders ?? ['X-Requested-With' => 'xmlhttprequest']; // @phpstan-ignore nullCoalesce.property
 
         foreach ($headers as $headerName => $expectedValue) {
             if (! $request->hasHeader($headerName)) {

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -93,7 +93,7 @@ class Encryption
 
         $this->key    = $config->key;
         $this->driver = $config->driver;
-        $this->digest = $config->digest ?? 'SHA512';
+        $this->digest = $config->digest;
 
         $this->handlers = [
             'OpenSSL' => extension_loaded('openssl'),
@@ -118,7 +118,7 @@ class Encryption
         if ($config instanceof EncryptionConfig) {
             $this->key    = $config->key;
             $this->driver = $config->driver;
-            $this->digest = $config->digest ?? 'SHA512';
+            $this->digest = $config->digest;
         }
 
         if (empty($this->driver)) {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -465,7 +465,7 @@ class Filters
         // Decode URL-encoded string
         $uri = urldecode($uri ?? '');
 
-        $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+        $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
         if ($oldFilterOrder) {
             $this->processGlobals($uri);
             $this->processMethods();
@@ -669,10 +669,6 @@ class Filters
      */
     protected function processGlobals(?string $uri = null)
     {
-        if (! isset($this->config->globals) || ! is_array($this->config->globals)) {
-            return;
-        }
-
         $uri = strtolower(trim($uri ?? '', '/ '));
 
         // Add any global filters, unless they are excluded for this URI
@@ -706,7 +702,7 @@ class Filters
         }
 
         if (isset($filters['before'])) {
-            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
             if ($oldFilterOrder) {
                 $this->filters['before'] = array_merge($this->filters['before'], $filters['before']);
             } else {
@@ -726,10 +722,6 @@ class Filters
      */
     protected function processMethods()
     {
-        if (! isset($this->config->methods) || ! is_array($this->config->methods)) {
-            return;
-        }
-
         $method = $this->request->getMethod();
 
         $found = false;
@@ -752,7 +744,7 @@ class Filters
         }
 
         if ($found) {
-            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
             if ($oldFilterOrder) {
                 $this->filters['before'] = array_merge($this->filters['before'], $this->config->methods[$method]);
             } else {
@@ -770,7 +762,7 @@ class Filters
      */
     protected function processFilters(?string $uri = null)
     {
-        if (! isset($this->config->filters) || $this->config->filters === []) {
+        if ($this->config->filters === []) {
             return;
         }
 
@@ -802,7 +794,7 @@ class Filters
             }
         }
 
-        $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+        $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false; // @phpstan-ignore nullCoalesce.property
 
         if (isset($filters['before'])) {
             if ($oldFilterOrder) {

--- a/system/Filters/PageCache.php
+++ b/system/Filters/PageCache.php
@@ -39,7 +39,7 @@ class PageCache implements FilterInterface
         $config ??= config('Cache');
 
         $this->pageCache        = service('responsecache');
-        $this->cacheStatusCodes = $config->cacheStatusCodes ?? [];
+        $this->cacheStatusCodes = $config->cacheStatusCodes ?? []; // @phpstan-ignore nullCoalesce.property
     }
 
     /**

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -41,7 +41,7 @@ class JSONFormatter implements FormatterInterface
             $options |= JSON_PRETTY_PRINT;
         }
 
-        $result = json_encode($data, $options, $config->jsonEncodeDepth ?? 512);
+        $result = json_encode($data, $options, $config->jsonEncodeDepth);
 
         if (! in_array(json_last_error(), [JSON_ERROR_NONE, JSON_ERROR_RECURSION], true)) {
             throw FormatException::forInvalidJSON(json_last_error_msg());

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -132,13 +132,13 @@ class CURLRequest extends OutgoingRequest
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 
-        $this->shareOptions = config(ConfigCURLRequest::class)->shareOptions ?? true;
+        $this->shareOptions = config(ConfigCURLRequest::class)->shareOptions;
 
         $this->config = $this->defaultConfig;
         $this->parseOptions($options);
 
         // Share Connection
-        $optShareConnection = config(ConfigCURLRequest::class)->shareConnectionOptions ?? [
+        $optShareConnection = config(ConfigCURLRequest::class)->shareConnectionOptions ?? [ // @phpstan-ignore nullCoalesce.property
             CURL_LOCK_DATA_CONNECT,
             CURL_LOCK_DATA_DNS,
         ];

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -46,8 +46,6 @@ class Honeypot
             $this->config->container = '<div style="display:none">{template}</div>';
         }
 
-        $this->config->containerId ??= 'hpc';
-
         if ($this->config->template === '') {
             throw HoneypotException::forNoTemplate();
         }

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -138,9 +138,7 @@ class Logger implements LoggerInterface
             $this->loggableLevels[] = $stringLevel;
         }
 
-        if (isset($config->dateFormat)) {
-            $this->dateFormat = $config->dateFormat;
-        }
+        $this->dateFormat = $config->dateFormat;
 
         if ($config->handlers === []) {
             throw LogException::forNoHandlers('LoggerConfig');

--- a/system/Model.php
+++ b/system/Model.php
@@ -232,7 +232,7 @@ class Model extends BaseModel
      */
     protected function doFindAll(?int $limit = null, int $offset = 0)
     {
-        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true;
+        $limitZeroAsAll = config(Feature::class)->limitZeroAsAll ?? true; // @phpstan-ignore nullCoalesce.property
         if ($limitZeroAsAll) {
             $limit ??= 0;
         }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -157,9 +157,7 @@ class Router implements RouterInterface
     {
         $config = config(App::class);
 
-        if (isset($config->permittedURIChars)) {
-            $this->permittedURIChars = $config->permittedURIChars;
-        }
+        $this->permittedURIChars = $config->permittedURIChars;
 
         $this->collection = $routes;
 
@@ -172,7 +170,7 @@ class Router implements RouterInterface
         $this->translateURIDashes = $this->collection->shouldTranslateURIDashes();
 
         if ($this->collection->shouldAutoRoute()) {
-            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
+            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved;
             if ($autoRoutesImproved) {
                 assert($this->collection instanceof RouteCollection);
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -72,8 +72,8 @@ class Session implements SessionInterface
             'domain'   => $cookie->domain,
             'secure'   => $cookie->secure,
             'httponly' => true, // for security
-            'samesite' => $cookie->samesite ?? Cookie::SAMESITE_LAX,
-            'raw'      => $cookie->raw ?? false,
+            'samesite' => $cookie->samesite,
+            'raw'      => $cookie->raw,
         ]))->withPrefix(''); // Cookie prefix should be ignored.
 
         helper('array');

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -331,7 +331,7 @@ class Typography
         $docTypes = new DocTypes();
 
         for ($ex = explode('pre>', $str), $ct = count($ex), $i = 0; $i < $ct; $i++) {
-            $xhtml = ! ($docTypes->html5 ?? false);
+            $xhtml = ! $docTypes->html5;
             $newstr .= (($i % 2) === 0) ? nl2br($ex[$i], $xhtml) : $ex[$i];
 
             if ($ct - 1 !== $i) {

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -202,7 +202,7 @@ class View implements RendererInterface
         $this->renderVars['file'] = $this->viewPath . $this->renderVars['view'];
 
         if (str_contains($this->renderVars['view'], '\\')) {
-            $appOverridesFolder = $this->config->appOverridesFolder ?? 'overrides';
+            $appOverridesFolder = $this->config->appOverridesFolder ?? 'overrides'; // @phpstan-ignore nullCoalesce.property
 
             $overrideFolder = $appOverridesFolder !== ''
                  ? trim($appOverridesFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR

--- a/system/View/ViewDecoratorTrait.php
+++ b/system/View/ViewDecoratorTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\View;
 
 use CodeIgniter\View\Exceptions\ViewException;
-use Config\View as ViewConfig;
 
 trait ViewDecoratorTrait
 {
@@ -24,7 +23,7 @@ trait ViewDecoratorTrait
      */
     protected function decorateOutput(string $html): string
     {
-        $decorators = $this->config->decorators ?? config(ViewConfig::class)->decorators;
+        $decorators = $this->config->decorators;
 
         foreach ($decorators as $decorator) {
             if (! is_subclass_of($decorator, ViewDecoratorInterface::class)) {

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -24,6 +24,7 @@ use CodeIgniter\HTTP\Response;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Config\Filters as FiltersConfig;
 use Config\Honeypot as HoneypotConfig;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;
@@ -162,15 +163,11 @@ final class HoneypotTest extends CIUnitTestCase
 
     public function testHoneypotFilterBefore(): void
     {
-        $config = [
-            'aliases' => ['trap' => \CodeIgniter\Filters\Honeypot::class],
-            'globals' => [
-                'before' => ['trap'],
-                'after'  => [],
-            ],
-        ];
+        $config          = new FiltersConfig();
+        $config->aliases = ['trap' => \CodeIgniter\Filters\Honeypot::class];
+        $config->globals = ['before' => ['trap'], 'after' => []];
 
-        $filters = new Filters((object) $config, $this->request, $this->response);
+        $filters = new Filters($config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';
 
         $this->expectException(HoneypotException::class);
@@ -179,15 +176,11 @@ final class HoneypotTest extends CIUnitTestCase
 
     public function testHoneypotFilterAfter(): void
     {
-        $config = [
-            'aliases' => ['trap' => \CodeIgniter\Filters\Honeypot::class],
-            'globals' => [
-                'before' => [],
-                'after'  => ['trap'],
-            ],
-        ];
+        $config          = new FiltersConfig();
+        $config->aliases = ['trap' => \CodeIgniter\Filters\Honeypot::class];
+        $config->globals = ['before' => [], 'after' => ['trap']];
 
-        $filters = new Filters((object) $config, $this->request, $this->response);
+        $filters = new Filters($config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';
 
         $this->response->setBody('<form></form>');

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,4 +1,4 @@
-# total 84 errors
+# total 82 errors
 
 parameters:
     ignoreErrors:
@@ -161,11 +161,6 @@ parameters:
             message: '#^Parameter \#1 \$request of method CodeIgniter\\CodeIgniter\:\:setRequest\(\) expects CodeIgniter\\HTTP\\CLIRequest\|CodeIgniter\\HTTP\\IncomingRequest, CodeIgniter\\HTTP\\Request given\.$#'
             count: 1
             path: ../../tests/system/HomeTest.php
-
-        -
-            message: '#^Parameter \#1 \$config of class CodeIgniter\\Filters\\Filters constructor expects Config\\Filters, object\{aliases\: array\<string, string\>, globals\: array\<string, list\<string\>\>\}&stdClass given\.$#'
-            count: 2
-            path: ../../tests/system/Honeypot/HoneypotTest.php
 
         -
             message: '#^Parameter \#1 \$data of method CodeIgniter\\HTTP\\Message\:\:setBody\(\) expects string, null given\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2062 errors
+# total 2060 errors
 
 includes:
     - argument.type.neon


### PR DESCRIPTION
**Description**
This PR fixes two types of PHPStan errors:
- `nullCoalesce.property` - using `??` on non-nullable Config properties
- `isset.property` - using `isset()` on non-nullable Config properties                                                                                                                                                                
                                                            
Rules applied:

**Config properties introduced before 4.5** - `??` and `isset()` guards removed entirely. These properties are old enough that users are expected to have updated their config files through normal upgrade cycles.                                                                                                                                                                     
   
**Config properties introduced in 4.5 or later** - `??` guards kept with `// @phpstan-ignore nullCoalesce.property` to preserve backward compatibility for users who have not yet updated their config files after a recent upgrade.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
