### PR TITLE
chore: fix PHPStan null coalescing warnings for Config properties

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -2129,7 +2129,7 @@ abstract class BaseConnection implements ConnectionInterface
         // Auto-sync with app timezone
         if ($this->timezone === true) {
             $appConfig = config('App');
-            $timezone  = $appConfig->appTimezone ?? 'UTC';
+            $timezone  = $appConfig->appTimezone;
         } else {
             // Use specific timezone from config
             $timezone = $this->timezone;

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -181,10 +181,10 @@ class Logger implements LoggerInterface
             $this->logCache = [];
         }
 
-        $this->logGlobalContext   = $config->logGlobalContext ?? $this->logGlobalContext;
-        $this->logContext         = $config->logContext ?? $this->logContext;
-        $this->logContextTrace    = $config->logContextTrace ?? $this->logContextTrace;
-        $this->logContextUsedKeys = $config->logContextUsedKeys ?? $this->logContextUsedKeys;
+        $this->logGlobalContext   = $config->logGlobalContext ?? $this->logGlobalContext; // @phpstan-ignore nullCoalesce.property
+        $this->logContext         = $config->logContext ?? $this->logContext; // @phpstan-ignore nullCoalesce.property
+        $this->logContextTrace    = $config->logContextTrace ?? $this->logContextTrace; // @phpstan-ignore nullCoalesce.property
+        $this->logContextUsedKeys = $config->logContextUsedKeys ?? $this->logContextUsedKeys; // @phpstan-ignore nullCoalesce.property
     }
 
     /**

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -186,7 +186,7 @@ final class ConnectTest extends CIUnitTestCase
         $timezone = $this->getDatabaseTimezone($db, $driver);
 
         $appConfig      = config('App');
-        $appTimezone    = $appConfig->appTimezone ?? 'UTC';
+        $appTimezone    = $appConfig->appTimezone;
         $expectedOffset = $this->getPrivateMethodInvoker($db, 'convertTimezoneToOffset')($appTimezone);
 
         $this->assertSame($expectedOffset, $timezone);


### PR DESCRIPTION
**Description**
This is a follow-up of #10081, but for the `4.8` branch, with the same rules applied.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
