### PR TITLE
refactor: prepend `Autoloader`'s own autoload functions

### DIFF
--- a/.github/workflows/test-random-execution.yml
+++ b/.github/workflows/test-random-execution.yml
@@ -213,8 +213,8 @@ jobs:
             args+=("--max-jobs" "${{ inputs.max-jobs }}")
           fi
 
-          # Add --repeat flag (always, default is 10)
-          args+=("--repeat" "${{ inputs.repeat || '10' }}")
+          # Add --repeat flag (always, default is 50)
+          args+=("--repeat" "${{ inputs.repeat || '50' }}")
 
           # Add --timeout flag (always, default is 300)
           args+=("--timeout" "${{ inputs.timeout || '300' }}")

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -188,8 +188,8 @@ class Autoloader
         $this->registeredClosures[] = $loadClassmap;
         $this->registeredClosures[] = $loadClass;
 
-        spl_autoload_register($loadClassmap, true);
-        spl_autoload_register($loadClass, true);
+        spl_autoload_register($loadClassmap, prepend: true);
+        spl_autoload_register($loadClass, prepend: true);
 
         foreach ($this->files as $file) {
             $this->includeFile($file);
@@ -217,22 +217,24 @@ class Autoloader
      */
     public function addNamespace($namespace, ?string $path = null)
     {
-        if (is_array($namespace)) {
-            foreach ($namespace as $prefix => $namespacedPath) {
-                $prefix = trim($prefix, '\\');
-
-                if (is_array($namespacedPath)) {
-                    foreach ($namespacedPath as $dir) {
-                        $this->prefixes[$prefix][] = rtrim($dir, '\\/') . DIRECTORY_SEPARATOR;
-                    }
-
-                    continue;
-                }
-
-                $this->prefixes[$prefix][] = rtrim($namespacedPath, '\\/') . DIRECTORY_SEPARATOR;
+        if (is_string($namespace)) {
+            if ($path === null) {
+                return $this;
             }
-        } else {
-            $this->prefixes[trim($namespace, '\\')][] = rtrim($path, '\\/') . DIRECTORY_SEPARATOR;
+
+            $namespace = [$namespace => $path];
+        }
+
+        foreach ($namespace as $prefix => $paths) {
+            $prefix = trim($prefix, '\\');
+
+            if (is_string($paths)) {
+                $paths = [$paths];
+            }
+
+            foreach ($paths as $path) {
+                $this->prefixes[$prefix][] = rtrim($path, '\\/') . DIRECTORY_SEPARATOR;
+            }
         }
 
         return $this;


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Random tests fail haphazardly with cannot autoload `CodeIgniter\CodeIgniter`.

From this failing test details for DataCaster, it looks to me that composer's autoloader are in effect here.
<details>
  <pre><code>
> vendor/bin/phpunit tests/system/DataCaster --colors=never --no-coverage --order-by=random --random-order-seed=1775670338

PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.4
Configuration: /home/runner/work/CodeIgniter4/CodeIgniter4/phpunit.xml.dist
Random Seed:   1775670338

E                                                                   1 / 1 (100%)

Time: 00:00.011, Memory: 12.00 MB

There was 1 error:

1) CodeIgniter\DataCaster\DataCasterTest::testCastInvalidMethodException
ErrorException: include(/home/runner/work/CodeIgniter4/CodeIgniter4/vendor/composer/../../system/CodeIgniter.php): Failed to open stream: No such file or directory

/home/runner/work/CodeIgniter4/CodeIgniter4/system/Test/Mock/MockCodeIgniter.php:18
/home/runner/work/CodeIgniter4/CodeIgniter4/system/Test/CIUnitTestCase.php:519
/home/runner/work/CodeIgniter4/CodeIgniter4/system/Test/CIUnitTestCase.php:245

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.

Execution order file: /home/runner/work/CodeIgniter4/CodeIgniter4/build/random-tests/random_test_order_176_DataCaster.txt
Failed test: CodeIgniter\DataCaster\DataCasterTest::testCastInvalidMethodException
Previous test: (none - failed test ran first)

Exit code: 1
Elapsed time: 176

  </code></pre>
</details>

I temporarily upped the run limit of random tests to 50 to see if there are still flaky tests.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide