### PR TITLE
fix: store SPL closures in `register()` so `unregister()` can remove them

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Autoloader;
 
+use Closure;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Exceptions\RuntimeException;
@@ -93,6 +94,14 @@ class Autoloader
      */
     protected $helpers = ['url'];
 
+    /**
+     * Stores the closures registered with spl_autoload_register()
+     * so that unregister() can remove the exact same instances.
+     *
+     * @var list<Closure(string): void>
+     */
+    private array $registeredClosures = [];
+
     public function __construct(private readonly string $composerPath = COMPOSER_PATH)
     {
     }
@@ -170,8 +179,17 @@ class Autoloader
      */
     public function register()
     {
-        spl_autoload_register($this->loadClassmap(...), true);
-        spl_autoload_register($this->loadClass(...), true);
+        // Store the exact Closure instances so unregister() can remove them.
+        // First-class callable syntax (e.g. $this->loadClass(...)) creates a
+        // new Closure object on every call, so we must reuse the same instances.
+        $loadClassmap = $this->loadClassmap(...);
+        $loadClass    = $this->loadClass(...);
+
+        $this->registeredClosures[] = $loadClassmap;
+        $this->registeredClosures[] = $loadClass;
+
+        spl_autoload_register($loadClassmap, true);
+        spl_autoload_register($loadClass, true);
 
         foreach ($this->files as $file) {
             $this->includeFile($file);
@@ -183,8 +201,11 @@ class Autoloader
      */
     public function unregister(): void
     {
-        spl_autoload_unregister($this->loadClass(...));
-        spl_autoload_unregister($this->loadClassmap(...));
+        foreach ($this->registeredClosures as $closure) {
+            spl_autoload_unregister($closure);
+        }
+
+        $this->registeredClosures = [];
     }
 
     /**

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -123,6 +123,45 @@ final class AutoloaderTest extends CIUnitTestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testUnregisterRemovesClosuresFromSplStack(): void
+    {
+        $countBefore = count(spl_autoload_functions());
+
+        $config                      = new Autoload();
+        $modules                     = new Modules();
+        $modules->discoverInComposer = false;
+        $config->psr4                = ['CodeIgniter' => SYSTEMPATH];
+
+        $loader = new Autoloader();
+        $loader->initialize($config, $modules)->register();
+
+        $this->assertCount($countBefore + 2, spl_autoload_functions());
+
+        $loader->unregister();
+
+        $this->assertCount($countBefore, spl_autoload_functions());
+    }
+
+    public function testUnregisterRemovesAllClosuresAfterMultipleRegistrations(): void
+    {
+        $countBefore = count(spl_autoload_functions());
+
+        $config                      = new Autoload();
+        $modules                     = new Modules();
+        $modules->discoverInComposer = false;
+        $config->psr4                = ['CodeIgniter' => SYSTEMPATH];
+
+        $loader = new Autoloader();
+        $loader->initialize($config, $modules)->register();
+        $loader->register();
+
+        $this->assertCount($countBefore + 4, spl_autoload_functions());
+
+        $loader->unregister();
+
+        $this->assertCount($countBefore, spl_autoload_functions());
+    }
+
     public function testServiceAutoLoader(): void
     {
         $autoloader = service('autoloader', false);

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Autoloader:** Fixed a bug where ``Autoloader::unregister()`` (used during tests) silently failed to remove handlers from the SPL autoload stack, causing closures to accumulate permanently.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixed a bug where `Autoloader::unregister()` could fail to remove handlers from the SPL autoload stack during tests. First-class callable syntax (`$this->loadClass(...)`) creates a new `Closure` object on each call, so the callbacks passed to `spl_autoload_unregister()` did not match the ones originally registered with `spl_autoload_register()`. As a result, autoload handlers accumulated on the SPL stack instead of being removed.    

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
