### PR TITLE
refactor: pass `--do-not-cache-result` to prevent shared cache corruption

### DIFF
--- a/.github/scripts/run-random-tests.sh
+++ b/.github/scripts/run-random-tests.sh
@@ -486,6 +486,7 @@ run_component_tests() {
         "$test_dir"
         "--colors=never"
         "--no-coverage"
+        "--do-not-cache-result"
         "--order-by=random"
         "--random-order-seed=${random_seed}"
         "--log-events-text"

--- a/.github/scripts/run-random-tests.sh
+++ b/.github/scripts/run-random-tests.sh
@@ -612,7 +612,7 @@ run_component_tests() {
         fi
 
         {
-            echo "> ${phpunit_args[@]:0:6}"
+            echo "> ${phpunit_args[@]:0:7}"
             echo ""
             echo "$output"
             echo "$predecessor_info"


### PR DESCRIPTION
**Description**
The random test script runs test jobs in parallel. Disabling PHPUnit result caching avoids cache reuse or cache writes interfering across concurrent runs, which can lead to shared cache corruption and make failures harder to trust.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
