### PR TITLE
fix: ensure output buffer is closed after use of `command()`

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -185,10 +185,14 @@ if (! function_exists('command')) {
             $params[$arg] = $value;
         }
 
-        ob_start();
-        service('commands')->run($command, $params);
+        try {
+            ob_start();
+            service('commands')->run($command, $params);
 
-        return ob_get_clean();
+            return ob_get_contents();
+        } finally {
+            ob_end_clean();
+        }
     }
 }
 

--- a/tests/_support/Commands/DestructiveCommand.php
+++ b/tests/_support/Commands/DestructiveCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Commands;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class DestructiveCommand extends AbstractInfo
+{
+    protected $group       = 'demo';
+    protected $name        = 'app:destructive';
+    protected $description = 'This command is destructive.';
+
+    public function run(array $params): never
+    {
+        throw new RuntimeException('This command is destructive and should not be run.');
+    }
+}

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -19,6 +19,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
 use Tests\Support\Commands\AppInfo;
 use Tests\Support\Commands\ParamsReveal;
 
@@ -134,6 +135,13 @@ final class CommandTest extends CIUnitTestCase
         $this->assertStringContainsString('Command "clear" not found.', $this->getBuffer());
         $this->assertStringContainsString('Did you mean one of these?', $this->getBuffer());
         $this->assertStringContainsString(':clear', $this->getBuffer());
+    }
+
+    public function testDestructiveCommandIsNotRisky(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        command('app:destructive');
     }
 
     /**

--- a/tests/system/Commands/Translation/LocalizationSyncTest.php
+++ b/tests/system/Commands/Translation/LocalizationSyncTest.php
@@ -171,7 +171,6 @@ final class LocalizationSyncTest extends CIUnitTestCase
             TEXT_WRAP;
 
         file_put_contents(self::$languageTestPath . self::$locale . '/SyncInvalid.php', $langWithNullValue);
-        ob_get_flush();
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessageMatches('/Only "array" or "string" is allowed/');
@@ -192,7 +191,6 @@ final class LocalizationSyncTest extends CIUnitTestCase
             TEXT_WRAP;
 
         file_put_contents(self::$languageTestPath . self::$locale . '/SyncInvalid.php', $langWithIntegerValue);
-        ob_get_flush();
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessageMatches('/Only "array" or "string" is allowed/');

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -33,6 +33,7 @@ Bugs Fixed
 **********
 
 - **Autoloader:** Fixed a bug where ``Autoloader::unregister()`` (used during tests) silently failed to remove handlers from the SPL autoload stack, causing closures to accumulate permanently.
+- **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
When the command run through `command()` throws, output buffering is not closed, causing risky tests in phpunit.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
