### PR TITLE
fix: preserve null values in Validation::getValidated()

### DIFF
--- a/system/Validation/DotArrayFilter.php
+++ b/system/Validation/DotArrayFilter.php
@@ -62,8 +62,9 @@ final class DotArrayFilter
         // Get the current index
         $currentIndex = array_shift($indexes);
 
-        // If the current index doesn't exist and is not a wildcard, return an empty array
-        if (! isset($array[$currentIndex]) && $currentIndex !== '*') {
+        // If the current index doesn't exist and is not a wildcard, return an empty array.
+        // Use array_key_exists() so explicit null values are preserved.
+        if ($currentIndex !== '*' && ! array_key_exists($currentIndex, $array)) {
             return [];
         }
 
@@ -88,9 +89,9 @@ final class DotArrayFilter
             return $result;
         }
 
-        // If this is the last index, return the value
+        // If this is the last index, return the value as-is, including null.
         if ($indexes === []) {
-            return [$currentIndex => $array[$currentIndex] ?? []];
+            return [$currentIndex => $array[$currentIndex]];
         }
 
         // If the current value is an array, recursively filter it

--- a/tests/system/Validation/DotArrayFilterTest.php
+++ b/tests/system/Validation/DotArrayFilterTest.php
@@ -197,4 +197,15 @@ final class DotArrayFilterTest extends CIUnitTestCase
 
         $this->assertSame($data, $result);
     }
+
+    public function testRunPreservesNullValue(): void
+    {
+        $data = [
+            'foo' => null,
+        ];
+
+        $result = DotArrayFilter::run(['foo'], $data);
+
+        $this->assertSame(['foo' => null], $result);
+    }
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -901,6 +901,49 @@ class ValidationTest extends CIUnitTestCase
         service('superglobals')->unsetServer('CONTENT_TYPE');
     }
 
+    /**
+     * @param array<string, string> $rules
+     * @param array<string, mixed>  $expectedValidated
+     */
+    #[DataProvider('provideGetValidatedWithNullValue')]
+    public function testGetValidatedWithNullValue(
+        array $rules,
+        bool $expectedResult,
+        array $expectedValidated,
+    ): void {
+        $data = [
+            'role' => null,
+        ];
+
+        $result = $this->validation->setRules($rules)->run($data);
+
+        $this->assertSame($expectedResult, $result);
+        $this->assertSame($expectedValidated, $this->validation->getValidated());
+        $this->assertSame($expectedResult ? [] : ['role'], array_keys($this->validation->getErrors()));
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     0: array<string, string>,
+     *     1: bool,
+     *     2: array<string, mixed>
+     * }>
+     */
+    public static function provideGetValidatedWithNullValue(): iterable
+    {
+        yield 'permit_empty preserves null' => [
+            ['role' => 'permit_empty|string'],
+            true,
+            ['role' => null],
+        ];
+
+        yield 'string fails on null' => [
+            ['role' => 'string'],
+            false,
+            [],
+        ];
+    }
+
     public function testJsonInputInvalid(): void
     {
         $this->expectException(HTTPException::class);

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -34,6 +34,7 @@ Bugs Fixed
 
 - **Autoloader:** Fixed a bug where ``Autoloader::unregister()`` (used during tests) silently failed to remove handlers from the SPL autoload stack, causing closures to accumulate permanently.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
+- **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a validation bug where `Validation::getValidated()` could drop fields whose validated value was explicitly `null`.

The issue came from `DotArrayFilter`, which treated `null` like a missing key when building the validated data array. With this change, explicit `null` values are preserved, so validated output stays consistent with the original validated input, including cases such as `permit_empty`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
