### PR TITLE
fix: refactor inconsistent behavior on `CLI::write()` and `CLI::error()`

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -255,6 +255,7 @@ class CLI
         }
 
         static::fwrite(STDOUT, $field . (trim($field) !== '' ? ' ' : '') . $extraOutput . ': ');
+        static::$lastWrite = 'write';
 
         // Read the input from keyboard.
         $input = trim(static::$io->input());
@@ -458,7 +459,8 @@ class CLI
         }
 
         if (static::$lastWrite !== 'write') {
-            $text              = PHP_EOL . $text;
+            $text = PHP_EOL . $text;
+
             static::$lastWrite = 'write';
         }
 
@@ -473,11 +475,18 @@ class CLI
     public static function error(string $text, string $foreground = 'light_red', ?string $background = null)
     {
         // Check color support for STDERR
-        $stdout            = static::$isColored;
+        $stdout = static::$isColored;
+
         static::$isColored = static::hasColorSupport(STDERR);
 
         if ($foreground !== '' || (string) $background !== '') {
             $text = static::color($text, $foreground, $background);
+        }
+
+        if (static::$lastWrite !== 'write') {
+            $text = PHP_EOL . $text;
+
+            static::$lastWrite = 'write';
         }
 
         static::fwrite(STDERR, $text . PHP_EOL);

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -37,6 +37,7 @@ final class CLITest extends CIUnitTestCase
 
         Services::injectMock('superglobals', new Superglobals());
 
+        CLI::reset();
         CLI::init();
     }
 
@@ -393,16 +394,33 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::error('test');
 
-        // red expected cuz stderr
-        $expected = "\033[1;31mtest\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[1;31mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
+    }
+
+    public function testMixedWriteError(): void
+    {
+        CLI::write('test 1');
+        CLI::error('test 2');
+        CLI::write('test 3');
+
+        $this->assertSame(
+            <<<'EOT'
+
+                test 1
+                test 2
+                test 3
+
+                EOT,
+            preg_replace('/\e\[[^m]+m/u', '', $this->getStreamFilterBuffer()),
+        );
     }
 
     public function testErrorForeground(): void
     {
         CLI::error('test', 'purple');
 
-        $expected = "\033[0;35mtest\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;35mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 
@@ -410,7 +428,7 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::error('test', 'purple', 'green');
 
-        $expected = "\033[0;35m\033[42mtest\033[0m" . PHP_EOL;
+        $expected = PHP_EOL . "\033[0;35m\033[42mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 

--- a/tests/system/CLI/CommandsTest.php
+++ b/tests/system/CLI/CommandsTest.php
@@ -74,6 +74,7 @@ final class CommandsTest extends CIUnitTestCase
         $this->assertSame(EXIT_ERROR, $commands->run('app:inf', []));
         $this->assertSame(
             <<<'EOT'
+
                 Command "app:inf" not found.
 
                 Did you mean this?
@@ -91,6 +92,7 @@ final class CommandsTest extends CIUnitTestCase
         $this->assertSame(EXIT_ERROR, $commands->run('app:', []));
         $this->assertSame(
             <<<'EOT'
+
                 Command "app:" not found.
 
                 Did you mean one of these?

--- a/tests/system/Commands/Cache/ClearCacheTest.php
+++ b/tests/system/Commands/Cache/ClearCacheTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Cache;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\Handlers\FileHandler;
+use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
@@ -32,6 +33,7 @@ final class ClearCacheTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        CLI::reset();
         $this->resetServices();
 
         // Make sure we are testing with the correct handler (override injections)
@@ -42,6 +44,7 @@ final class ClearCacheTest extends CIUnitTestCase
     {
         parent::tearDown();
 
+        CLI::reset();
         $this->resetServices();
     }
 
@@ -50,7 +53,7 @@ final class ClearCacheTest extends CIUnitTestCase
         command('cache:clear junk');
 
         $this->assertSame(
-            "Cache driver \"junk\" is not a valid cache handler.\n",
+            "\nCache driver \"junk\" is not a valid cache handler.\n",
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }
@@ -79,7 +82,7 @@ final class ClearCacheTest extends CIUnitTestCase
         command('cache:clear');
 
         $this->assertSame(
-            "Error while clearing the cache.\n",
+            "\nError while clearing the cache.\n",
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }

--- a/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
@@ -33,6 +33,8 @@ final class ShowTableInfoMockIOTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        CLI::reset();
+
         putenv('NO_COLOR=1');
         CLI::init();
     }
@@ -40,6 +42,8 @@ final class ShowTableInfoMockIOTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+        CLI::reset();
 
         putenv('NO_COLOR');
         CLI::init();
@@ -58,17 +62,25 @@ final class ShowTableInfoMockIOTest extends CIUnitTestCase
 
         $result = $io->getOutput();
 
-        $expectedPattern = '/Which table do you want to see\? \[0, 1, 2, 3, 4, 5, 6, 7, 8, 9.*?\]: a
-The "Which table do you want to see\?" field must be one of: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9.*?./';
-        $this->assertMatchesRegularExpression($expectedPattern, $result);
-
-        $expected = 'Data of Table "db_migrations":';
-        $this->assertStringContainsString($expected, $result);
-
-        $expectedPattern = '/\| id[[:blank:]]+\| version[[:blank:]]+\| class[[:blank:]]+\| group[[:blank:]]+\| namespace[[:blank:]]+\| time[[:blank:]]+\| batch \|/';
-        $this->assertMatchesRegularExpression($expectedPattern, $result);
-
-        // Remove MockInputOutput.
-        CLI::resetInputOutput();
+        $this->assertMatchesRegularExpression(
+            '/Which table do you want to see\? \[[\d,\s]+\]\: a/',
+            $result,
+        );
+        $this->assertMatchesRegularExpression(
+            '/The "Which table do you want to see\?" field must be one of: [\d,\s]+./',
+            $result,
+        );
+        $this->assertMatchesRegularExpression(
+            '/Which table do you want to see\? \[[\d,\s]+\]\: 0/',
+            $result,
+        );
+        $this->assertMatchesRegularExpression(
+            '/Data of Table "db_migrations"\:/',
+            $result,
+        );
+        $this->assertMatchesRegularExpression(
+            '/\| id[[:blank:]]+\| version[[:blank:]]+\| class[[:blank:]]+\| group[[:blank:]]+\| namespace[[:blank:]]+\| time[[:blank:]]+\| batch \|/',
+            $result,
+        );
     }
 }

--- a/tests/system/Commands/Generators/TestGeneratorTest.php
+++ b/tests/system/Commands/Generators/TestGeneratorTest.php
@@ -33,9 +33,6 @@ final class TestGeneratorTest extends CIUnitTestCase
         parent::setUp();
 
         $this->resetStreamFilterBuffer();
-
-        putenv('NO_COLOR=1');
-        CLI::init();
     }
 
     protected function tearDown(): void
@@ -44,14 +41,16 @@ final class TestGeneratorTest extends CIUnitTestCase
 
         $this->clearTestFiles();
         $this->resetStreamFilterBuffer();
+    }
 
-        putenv('NO_COLOR');
-        CLI::init();
+    private function getUndecoratedBuffer(): string
+    {
+        return preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer());
     }
 
     private function clearTestFiles(): void
     {
-        preg_match('/File created: (.*)/', $this->getStreamFilterBuffer(), $result);
+        preg_match('/File created: (.*)/', $this->getUndecoratedBuffer(), $result);
 
         $file = str_replace('ROOTPATH' . DIRECTORY_SEPARATOR, ROOTPATH, $result[1] ?? '');
         if (is_file($file)) {
@@ -71,7 +70,7 @@ final class TestGeneratorTest extends CIUnitTestCase
 
         $expectedTestFile = str_replace('/', DIRECTORY_SEPARATOR, sprintf('%stests/%s.php', ROOTPATH, $expectedClass));
         $expectedMessage  = sprintf('File created: %s', str_replace(ROOTPATH, 'ROOTPATH' . DIRECTORY_SEPARATOR, $expectedTestFile));
-        $this->assertStringContainsString($expectedMessage, $this->getStreamFilterBuffer());
+        $this->assertStringContainsString($expectedMessage, $this->getUndecoratedBuffer());
         $this->assertFileExists($expectedTestFile);
     }
 
@@ -93,6 +92,7 @@ final class TestGeneratorTest extends CIUnitTestCase
     public function testGenerateTestWithEmptyClassName(): void
     {
         $expectedFile = ROOTPATH . 'tests/FooTest.php';
+        CLI::reset();
 
         try {
             $io = new MockInputOutput();
@@ -106,7 +106,7 @@ final class TestGeneratorTest extends CIUnitTestCase
             $expectedOutput .= 'The "Test class name" field is required.' . PHP_EOL;
             $expectedOutput .= 'Test class name : Foo' . PHP_EOL . PHP_EOL;
             $expectedOutput .= 'File created: ROOTPATH/tests/FooTest.php' . PHP_EOL . PHP_EOL;
-            $this->assertSame($expectedOutput, $io->getOutput());
+            $this->assertSame($expectedOutput, preg_replace('/\e\[[^m]+m/', '', $io->getOutput()));
             $this->assertFileExists($expectedFile);
         } finally {
             if (is_file($expectedFile)) {

--- a/tests/system/Commands/Housekeeping/ClearDebugbarTest.php
+++ b/tests/system/Commands/Housekeeping/ClearDebugbarTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Housekeeping;
 
+use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use PHPUnit\Framework\Attributes\Group;
@@ -35,6 +36,8 @@ final class ClearDebugbarTest extends CIUnitTestCase
         command('debugbar:clear');
         $this->resetStreamFilterBuffer();
 
+        CLI::reset();
+
         $this->time = time();
         $this->createDummyDebugbarJson();
     }
@@ -43,6 +46,8 @@ final class ClearDebugbarTest extends CIUnitTestCase
     {
         command('debugbar:clear');
         $this->resetStreamFilterBuffer();
+
+        CLI::reset();
 
         parent::tearDown();
     }
@@ -70,7 +75,7 @@ final class ClearDebugbarTest extends CIUnitTestCase
         $this->assertFileDoesNotExist(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
         $this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . 'index.html');
         $this->assertSame(
-            "Debugbar cleared.\n",
+            "\nDebugbar cleared.\n",
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }
@@ -111,7 +116,7 @@ final class ClearDebugbarTest extends CIUnitTestCase
 
         $this->assertFileExists($path);
         $this->assertSame(
-            "Error deleting the debugbar JSON files.\n",
+            "\nError deleting the debugbar JSON files.\n",
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }

--- a/tests/system/Commands/Housekeeping/ClearLogsTest.php
+++ b/tests/system/Commands/Housekeeping/ClearLogsTest.php
@@ -41,6 +41,8 @@ final class ClearLogsTest extends CIUnitTestCase
         command('logs:clear --force');
         $this->resetStreamFilterBuffer();
 
+        CLI::reset();
+
         $this->createDummyLogFiles();
     }
 
@@ -78,7 +80,7 @@ final class ClearLogsTest extends CIUnitTestCase
 
         $this->assertFileDoesNotExist(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
         $this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . 'index.html');
-        $this->assertSame("Logs cleared.\n", preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()));
+        $this->assertSame("\nLogs cleared.\n", preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()));
     }
 
     public function testClearLogsAbortsClearWithoutForce(): void
@@ -94,11 +96,12 @@ final class ClearLogsTest extends CIUnitTestCase
         $this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
         $this->assertSame(
             <<<'EOT'
+                Are you sure you want to delete the logs? [n, y]: n
                 Deleting logs aborted.
                 If you want, use the "--force" option to force delete all log files.
 
                 EOT,
-            preg_replace('/\e\[[^m]+m/', '', $io->getOutput(2) . $io->getOutput(3)),
+            preg_replace('/\e\[[^m]+m/', '', $io->getOutput()),
         );
     }
 
@@ -110,16 +113,19 @@ final class ClearLogsTest extends CIUnitTestCase
         $io->setInputs(['']);
         CLI::setInputOutput($io);
 
+        $space = ' ';
+
         command('logs:clear');
 
         $this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
         $this->assertSame(
-            <<<'EOT'
+            <<<EOT
+                Are you sure you want to delete the logs? [n, y]:{$space}
                 Deleting logs aborted.
                 If you want, use the "--force" option to force delete all log files.
 
                 EOT,
-            preg_replace('/\e\[[^m]+m/', '', $io->getOutput(2) . $io->getOutput(3)),
+            preg_replace('/\e\[[^m]+m/', '', $io->getOutput()),
         );
     }
 
@@ -134,7 +140,14 @@ final class ClearLogsTest extends CIUnitTestCase
         command('logs:clear');
 
         $this->assertFileDoesNotExist(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
-        $this->assertSame("Logs cleared.\n", preg_replace('/\e\[[^m]+m/', '', $io->getOutput(2)));
+        $this->assertSame(
+            <<<'EOT'
+                Are you sure you want to delete the logs? [n, y]: y
+                Logs cleared.
+
+                EOT,
+            preg_replace('/\e\[[^m]+m/', '', $io->getOutput()),
+        );
     }
 
     #[RequiresOperatingSystem('Darwin|Linux')]
@@ -173,6 +186,9 @@ final class ClearLogsTest extends CIUnitTestCase
         }
 
         $this->assertFileExists($path);
-        $this->assertSame("Error in deleting the logs files.\n", preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()));
+        $this->assertSame(
+            "\nError in deleting the logs files.\n",
+            preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
+        );
     }
 }

--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Commands\Utilities;
 
 use Closure;
+use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\App;
@@ -31,34 +32,38 @@ final class ConfigCheckTest extends CIUnitTestCase
 
     public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         App::$override = false;
 
         putenv('NO_COLOR=1');
         CliRenderer::$cli_colors = false;
-
-        parent::setUpBeforeClass();
     }
 
     public static function tearDownAfterClass(): void
     {
+        parent::tearDownAfterClass();
+
         App::$override = true;
 
         putenv('NO_COLOR');
         CliRenderer::$cli_colors = true;
-
-        parent::tearDownAfterClass();
     }
 
     protected function setUp(): void
     {
-        $this->resetServices();
         parent::setUp();
+
+        $this->resetServices();
+        CLI::reset();
     }
 
     protected function tearDown(): void
     {
-        $this->resetServices();
         parent::tearDown();
+
+        $this->resetServices();
+        CLI::reset();
     }
 
     public function testCommandConfigCheckWithNoArgumentPassed(): void
@@ -67,13 +72,14 @@ final class ConfigCheckTest extends CIUnitTestCase
 
         $this->assertSame(
             <<<'EOF'
+
                 You must specify a Config classname.
                   Usage: config:check <classname>
                 Example: config:check App
                          config:check 'CodeIgniter\Shield\Config\Auth'
 
                 EOF,
-            str_replace("\n\n", "\n", $this->getStreamFilterBuffer()),
+            $this->getStreamFilterBuffer(),
         );
     }
 
@@ -82,7 +88,7 @@ final class ConfigCheckTest extends CIUnitTestCase
         command('config:check Nonexistent');
 
         $this->assertSame(
-            "No such Config class: Nonexistent\n",
+            "\nNo such Config class: Nonexistent\n",
             $this->getStreamFilterBuffer(),
         );
     }
@@ -98,7 +104,7 @@ final class ConfigCheckTest extends CIUnitTestCase
         command('config:check App');
 
         $this->assertSame(
-            $command(config('App')) . "\n",
+            "\n" . $command(config('App')) . "\n",
             preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer()),
         );
     }
@@ -110,19 +116,14 @@ final class ConfigCheckTest extends CIUnitTestCase
             new ConfigCheck(service('logger'), service('commands')),
             'getVarDump',
         );
-        $clean = static fn (string $input): string => trim(preg_replace(
-            '/(\033\[[0-9;]+m)|(\035\[[0-9;]+m)/u',
-            '',
-            $input,
-        ));
 
         try {
             Kint::$enabled_mode = false;
             command('config:check App');
 
             $this->assertSame(
-                $clean($command(config('App'))),
-                $clean(preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer())),
+                "\n" . $command(config('App')),
+                preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer()),
             );
         } finally {
             Kint::$enabled_mode = true;


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
There is currently an inconsistency in how `CLI::write()` behaves when printed first vs the same scenario for `CLI::error()`. To demonstrate, using this script:
```php
<?php

require __DIR__ . '/system/Test/bootstrap.php';

use CodeIgniter\CLI\CLI;

if (rand(0, 1) === 0) {
    CLI::error('This is an error message.');
    CLI::error('This is an error message.');
} else {
    CLI::write('This is a success message.');
    CLI::write('This is a success message.');
}

```

This gives:
<img width="234" height="137" alt="image" src="https://github.com/user-attachments/assets/52ecc3c0-5320-476a-9db5-a92619259746" />

I am proposing that whichever method is used on a first print, it will print a new line first. 
<img width="241" height="148" alt="image" src="https://github.com/user-attachments/assets/184eadfc-3b8d-48d4-8f91-0c7dc33364b9" />

Moreover, if they are sandwiched together, like:
```php
<?php

require __DIR__ . '/system/Test/bootstrap.php';

use CodeIgniter\CLI\CLI;

if (rand(0, 1) === 0) {
    CLI::error('This is an error message.');
    CLI::write('This is a success message.');
    CLI::error('This is an error message.');
} else {
    CLI::write('This is a success message.');
    CLI::error('This is an error message.');
    CLI::write('This is a success message.');
}

```

I am proposing the behavior to be this:
<img width="229" height="246" alt="image" src="https://github.com/user-attachments/assets/24eb0702-7dfd-44da-b326-d51d2829af78" />

instead of:
<img width="230" height="181" alt="image" src="https://github.com/user-attachments/assets/e694f10e-dae9-4b55-b32d-c6216d4cfa1b" />

I am also open to the idea of having `error` behave as `write`, so that for sandwiched use, they are not spaced out.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
