### PR TITLE
fix: Rename `phpunit.xml.dist`

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -11,7 +11,7 @@ on:
       - 'tests/**.php'
       - 'spark'
       - composer.json
-      - phpunit.xml.dist
+      - phpunit.dist.xml
       - .github/workflows/test-phpunit.yml
       - .github/workflows/reusable-phpunit-test.yml
 
@@ -25,7 +25,7 @@ on:
       - 'tests/**.php'
       - 'spark'
       - composer.json
-      - phpunit.xml.dist
+      - phpunit.dist.xml
       - .github/workflows/test-phpunit.yml
       - .github/workflows/reusable-phpunit-test.yml
 

--- a/.github/workflows/test-random-execution.yml
+++ b/.github/workflows/test-random-execution.yml
@@ -9,7 +9,7 @@ on:
       - '.github/scripts/run-random-tests.sh'
       - '.github/scripts/random-tests-config.txt'
       - '.github/workflows/test-random-execution.yml'
-      - 'phpunit.xml.dist'
+      - 'phpunit.dist.xml'
       - 'system/**.php'
       - 'tests/**.php'
 
@@ -21,7 +21,7 @@ on:
       - '.github/scripts/run-random-tests.sh'
       - '.github/scripts/random-tests-config.txt'
       - '.github/workflows/test-random-execution.yml'
-      - 'phpunit.xml.dist'
+      - 'phpunit.dist.xml'
       - 'system/**.php'
       - 'tests/**.php'
 

--- a/admin/starter/builds
+++ b/admin/starter/builds
@@ -94,7 +94,7 @@ if (is_file($file)) {
 
 $files = [
     __DIR__ . DIRECTORY_SEPARATOR . 'app/Config/Paths.php',
-    __DIR__ . DIRECTORY_SEPARATOR . 'phpunit.xml.dist',
+    __DIR__ . DIRECTORY_SEPARATOR . 'phpunit.dist.xml',
     __DIR__ . DIRECTORY_SEPARATOR . 'phpunit.xml',
 ];
 

--- a/admin/starter/tests/README.md
+++ b/admin/starter/tests/README.md
@@ -80,11 +80,11 @@ The HTML files can be viewed by opening **tests/coverage/index.html** in your fa
 
 ## PHPUnit XML Configuration
 
-The repository has a ``phpunit.xml.dist`` file in the project root that's used for
+The repository has a ``phpunit.dist.xml`` file in the project root that's used for
 PHPUnit configuration. This is used to provide a default configuration if you
 do not have your own configuration file in the project root.
 
-The normal practice would be to copy ``phpunit.xml.dist`` to ``phpunit.xml``
+The normal practice would be to copy ``phpunit.dist.xml`` to ``phpunit.xml``
 (which is git ignored), and to tailor it as you see fit.
 For instance, you might wish to exclude database tests, or automatically generate
 HTML code coverage reports.

--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -27,7 +27,7 @@ final class HealthTest extends CIUnitTestCase
 
         if ($env) {
             // BaseURL in .env is a valid URL?
-            // phpunit.xml.dist sets app.baseURL in $_SERVER
+            // phpunit.dist.xml sets app.baseURL in $_SERVER
             // So if you set app.baseURL in .env, it takes precedence
             $config = new App();
             $this->assertTrue(
@@ -37,7 +37,7 @@ final class HealthTest extends CIUnitTestCase
         }
 
         // Get the baseURL in app/Config/App.php
-        // You can't use Config\App, because phpunit.xml.dist sets app.baseURL
+        // You can't use Config\App, because phpunit.dist.xml sets app.baseURL
         $reader = new ConfigReader();
 
         // BaseURL in app/Config/App.php is a valid URL?

--- a/tests/README.md
+++ b/tests/README.md
@@ -172,11 +172,11 @@ as a comprehensive collection of HTML files that show the status of every line o
 
 ## PHPUnit XML Configuration
 
-The repository has a ``phpunit.xml.dist`` file in the project root that's used for
+The repository has a ``phpunit.dist.xml`` file in the project root that's used for
 PHPUnit configuration. This is used to provide a default configuration if you
 do not have your own configuration file in the project root.
 
-The normal practice would be to copy ``phpunit.xml.dist`` to ``phpunit.xml``
+The normal practice would be to copy ``phpunit.dist.xml`` to ``phpunit.xml``
 (which is git ignored), and to tailor it as you see fit.
 For instance, you might wish to exclude database tests, or automatically generate
 HTML code coverage reports.


### PR DESCRIPTION
**Description**
Fixes #10102 
I used the search to replace the missing places.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
