### PR TITLE
refactor: commands - move the null exit code deprecation earlier

### DIFF
--- a/system/Boot.php
+++ b/system/Boot.php
@@ -428,17 +428,6 @@ class Boot
 
     protected static function runCommand(Console $console): int
     {
-        $exitCode = $console->initialize()->run();
-
-        if (! is_int($exitCode)) {
-            @trigger_error(sprintf(
-                'Since v4.8.0, commands must return an integer exit code. Last command "%s" exited with %s. Defaulting to EXIT_SUCCESS.',
-                $console->getCommand(),
-                get_debug_type($exitCode),
-            ), E_USER_DEPRECATED);
-            $exitCode = EXIT_SUCCESS;
-        }
-
-        return $exitCode;
+        return $console->initialize()->run();
     }
 }

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -101,7 +101,7 @@ abstract class BaseCommand
      *
      * @param array<int|string, string|null> $params
      *
-     * @return int|void
+     * @return int|null
      */
     abstract public function run(array $params);
 
@@ -110,7 +110,7 @@ abstract class BaseCommand
      *
      * @param array<int|string, string|null> $params
      *
-     * @return int|void
+     * @return int|null
      *
      * @throws ReflectionException
      */

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -69,11 +69,20 @@ class Commands
 
         Events::trigger('pre_command');
 
-        $exit = $class->run($params);
+        $exitCode = $class->run($params);
 
         Events::trigger('post_command');
 
-        return $exit;
+        if (! is_int($exitCode)) {
+            @trigger_error(sprintf(
+                'Since v4.8.0, commands must return an integer exit code. Last command "%s" exited with %s. Defaulting to EXIT_SUCCESS.',
+                $command,
+                get_debug_type($exitCode),
+            ), E_USER_DEPRECATED);
+            $exitCode = EXIT_SUCCESS;
+        }
+
+        return $exitCode;
     }
 
     /**

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -39,7 +39,7 @@ class Console
      *
      * @param list<string> $tokens
      *
-     * @return int|null Exit code or null for legacy commands that don't return an exit code.
+     * @return int Exit code
      */
     public function run(array $tokens = [])
     {

--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -63,7 +63,7 @@ class InfoCache extends BaseCommand
         if ($config->handler !== 'file') {
             CLI::error('This command only supports the file cache handler.');
 
-            return;
+            return EXIT_ERROR;
         }
 
         $cache  = CacheFactory::getHandler($config);
@@ -87,5 +87,7 @@ class InfoCache extends BaseCommand
         ];
 
         CLI::table($tbody, $thead);
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -115,7 +115,7 @@ class CreateDatabase extends BaseCommand
                         CLI::error("Database \"{$dbName}\" already exists.", 'light_gray', 'red');
                         CLI::newLine();
 
-                        return;
+                        return EXIT_ERROR;
                     }
 
                     unset($dbName);
@@ -130,7 +130,7 @@ class CreateDatabase extends BaseCommand
                     CLI::error('Database creation failed.', 'light_gray', 'red');
                     CLI::newLine();
 
-                    return;
+                    return EXIT_ERROR;
                     // @codeCoverageIgnoreEnd
                 }
             } elseif (! Database::forge()->createDatabase($name)) {
@@ -138,14 +138,18 @@ class CreateDatabase extends BaseCommand
                 CLI::error('Database creation failed.', 'light_gray', 'red');
                 CLI::newLine();
 
-                return;
+                return EXIT_ERROR;
                 // @codeCoverageIgnoreEnd
             }
 
             CLI::write("Database \"{$name}\" successfully created.", 'green');
             CLI::newLine();
+
+            return EXIT_SUCCESS;
         } catch (Throwable $e) {
             $this->showError($e);
+
+            return EXIT_ERROR;
         } finally {
             Factories::reset('config');
             Database::connect(null, false);

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -99,9 +99,12 @@ class Migrate extends BaseCommand
 
             CLI::write(lang('Migrations.migrated'), 'green');
 
+            return EXIT_SUCCESS;
             // @codeCoverageIgnoreStart
         } catch (Throwable $e) {
             $this->showError($e);
+
+            return EXIT_ERROR;
             // @codeCoverageIgnoreEnd
         }
     }

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -79,16 +79,15 @@ class MigrateRefresh extends BaseCommand
             $force = array_key_exists('f', $params) || CLI::getOption('f');
 
             if (! $force && CLI::prompt(lang('Migrations.refreshConfirm'), ['y', 'n']) === 'n') {
-                return;
+                return EXIT_ERROR;
             }
 
             $params['f'] = null;
             // @codeCoverageIgnoreEnd
         }
 
-        $this->withSignalsBlocked(function () use ($params): void {
-            $this->call('migrate:rollback', $params);
-            $this->call('migrate', $params);
-        });
+        return $this->withSignalsBlocked(
+            fn (): int => $this->call('migrate:rollback', $params) | $this->call('migrate', $params),
+        );
     }
 }

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -77,7 +77,7 @@ class MigrateRollback extends BaseCommand
             $force = array_key_exists('f', $params) || CLI::getOption('f');
 
             if (! $force && CLI::prompt(lang('Migrations.rollBackConfirm'), ['y', 'n']) === 'n') {
-                return null;
+                return EXIT_ERROR;
             }
             // @codeCoverageIgnoreEnd
         }
@@ -101,11 +101,19 @@ class MigrateRollback extends BaseCommand
 
             CLI::write(lang('Migrations.rollingBack') . ' ' . $batch, 'yellow');
 
-            $this->withSignalsBlocked(static function () use ($runner, $batch): void {
+            $exit = $this->withSignalsBlocked(static function () use ($runner, $batch): int {
                 if (! $runner->regress($batch)) {
                     CLI::error(lang('Migrations.generalFault'), 'light_gray', 'red'); // @codeCoverageIgnore
+
+                    return EXIT_ERROR;
                 }
+
+                return EXIT_SUCCESS;
             });
+
+            if ($exit !== EXIT_SUCCESS) {
+                return $exit;
+            }
 
             $messages = $runner->getCliMessages();
 
@@ -115,12 +123,13 @@ class MigrateRollback extends BaseCommand
 
             CLI::write('Done rolling back migrations.', 'green');
 
+            return EXIT_SUCCESS;
             // @codeCoverageIgnoreStart
         } catch (Throwable $e) {
             $this->showError($e);
+
+            return EXIT_ERROR;
             // @codeCoverageIgnoreEnd
         }
-
-        return null;
     }
 }

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -150,7 +150,7 @@ class MigrateStatus extends BaseCommand
             CLI::error(lang('Migrations.noneFound'), 'light_gray', 'red');
             CLI::newLine();
 
-            return;
+            return EXIT_ERROR;
             // @codeCoverageIgnoreEnd
         }
 
@@ -164,5 +164,7 @@ class MigrateStatus extends BaseCommand
         ];
 
         CLI::table($status, $headers);
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Database/Seed.php
+++ b/system/Commands/Database/Seed.php
@@ -77,8 +77,12 @@ class Seed extends BaseCommand
 
         try {
             $seeder->call($seedName);
+
+            return EXIT_SUCCESS;
         } catch (Throwable $e) {
             $this->showError($e);
+
+            return EXIT_ERROR;
         }
     }
 }

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -89,7 +89,7 @@ class GenerateKey extends BaseCommand
             CLI::write($encodedKey, 'yellow');
             CLI::newLine();
 
-            return EXIT_ERROR;
+            return EXIT_SUCCESS;
         }
 
         if (! $this->setNewEncryptionKey($encodedKey, $params)) {

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -89,14 +89,14 @@ class GenerateKey extends BaseCommand
             CLI::write($encodedKey, 'yellow');
             CLI::newLine();
 
-            return;
+            return EXIT_ERROR;
         }
 
         if (! $this->setNewEncryptionKey($encodedKey, $params)) {
             CLI::write('Error in setting new encryption key to .env file.', 'light_gray', 'red');
             CLI::newLine();
 
-            return;
+            return EXIT_ERROR;
         }
 
         // force DotEnv to reload the new env vars
@@ -107,6 +107,8 @@ class GenerateKey extends BaseCommand
 
         CLI::write('Application\'s new encryption key was successfully set.', 'green');
         CLI::newLine();
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/CellGenerator.php
+++ b/system/Commands/Generators/CellGenerator.php
@@ -102,6 +102,6 @@ class CellGenerator extends BaseCommand
 
         $this->generateView($namespace . $viewName, $params);
 
-        return 0;
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Generators/CommandGenerator.php
+++ b/system/Commands/Generators/CommandGenerator.php
@@ -86,6 +86,8 @@ class CommandGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.command';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/ConfigGenerator.php
+++ b/system/Commands/Generators/ConfigGenerator.php
@@ -82,6 +82,8 @@ class ConfigGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.config';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/ControllerGenerator.php
+++ b/system/Commands/Generators/ControllerGenerator.php
@@ -88,6 +88,8 @@ class ControllerGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.controller';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/EntityGenerator.php
+++ b/system/Commands/Generators/EntityGenerator.php
@@ -82,5 +82,7 @@ class EntityGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.entity';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Generators/FilterGenerator.php
+++ b/system/Commands/Generators/FilterGenerator.php
@@ -82,5 +82,7 @@ class FilterGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.filter';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -93,6 +93,8 @@ class MigrationGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.migration';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/ModelGenerator.php
+++ b/system/Commands/Generators/ModelGenerator.php
@@ -86,6 +86,8 @@ class ModelGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.model';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/ScaffoldGenerator.php
+++ b/system/Commands/Generators/ScaffoldGenerator.php
@@ -115,9 +115,13 @@ class ScaffoldGenerator extends BaseCommand
         $class = $params[0] ?? CLI::getSegment(2);
 
         // Call those commands!
-        $this->call('make:controller', array_merge([$class], $controllerOpts, $options));
-        $this->call('make:model', array_merge([$class], $modelOpts, $options));
-        $this->call('make:migration', array_merge([$class], $options));
-        $this->call('make:seeder', array_merge([$class], $options));
+        $exit1 = $this->call('make:controller', array_merge([$class], $controllerOpts, $options));
+        $exit2 = $this->call('make:model', array_merge([$class], $modelOpts, $options));
+        $exit3 = $this->call('make:migration', array_merge([$class], $options));
+        $exit4 = $this->call('make:seeder', array_merge([$class], $options));
+
+        assert(is_int($exit1) && is_int($exit2) && is_int($exit3) && is_int($exit4));
+
+        return $exit1 | $exit2 | $exit3 | $exit4;
     }
 }

--- a/system/Commands/Generators/SeederGenerator.php
+++ b/system/Commands/Generators/SeederGenerator.php
@@ -82,5 +82,7 @@ class SeederGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.seeder';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -89,6 +89,8 @@ class TestGenerator extends BaseCommand
         $autoload->addNamespace('Tests', ROOTPATH . 'tests');
 
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/TransformerGenerator.php
+++ b/system/Commands/Generators/TransformerGenerator.php
@@ -82,6 +82,8 @@ class TransformerGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.transformer';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/system/Commands/Generators/ValidationGenerator.php
+++ b/system/Commands/Generators/ValidationGenerator.php
@@ -82,5 +82,7 @@ class ValidationGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.validation';
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Generators/Views/command.tpl.php
+++ b/system/Commands/Generators/Views/command.tpl.php
@@ -68,9 +68,11 @@ class {class} extends BaseCommand
         $this->directory = 'Commands';
         $this->template  = 'command.tpl.php';
 
-        $this->execute($params);
+        $this->generateClass($params);
 <?php else: ?>
-        //
+        // your command logic here
 <?php endif ?>
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -78,10 +78,12 @@ class Help extends BaseCommand
         $commands = $this->commands->getCommands();
 
         if (! $this->commands->verifyCommand($command, $commands)) {
-            return;
+            return EXIT_ERROR;
         }
 
         $class = new $commands[$command]['class']($this->logger, $this->commands);
         $class->showHelp();
+
+        return EXIT_SUCCESS;
     }
 }

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -113,7 +113,9 @@ class Serve extends BaseCommand
         if ($status !== EXIT_SUCCESS && $this->portOffset < $this->tries) {
             $this->portOffset++;
 
-            $this->run($params);
+            return $this->run($params);
         }
+
+        return $status;
     }
 }

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -89,7 +89,7 @@ final class Environment extends BaseCommand
             CLI::write(sprintf('Your environment is currently set as %s.', CLI::color(service('superglobals')->server('CI_ENVIRONMENT', ENVIRONMENT), 'green')));
             CLI::newLine();
 
-            return EXIT_ERROR;
+            return EXIT_SUCCESS;
         }
 
         $env = strtolower(array_shift($params));

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -89,6 +89,8 @@ class Namespaces extends BaseCommand
         ];
 
         CLI::table($tbody, $thead);
+
+        return EXIT_SUCCESS;
     }
 
     private function outputAllNamespaces(array $params): array

--- a/system/Commands/Utilities/Publish.php
+++ b/system/Commands/Utilities/Publish.php
@@ -86,8 +86,10 @@ class Publish extends BaseCommand
                 CLI::write(lang('Publisher.publishMissingNamespace', [$directory, $namespace]));
             }
 
-            return;
+            return EXIT_ERROR;
         }
+
+        $exit = EXIT_SUCCESS;
 
         foreach ($publishers as $publisher) {
             if ($publisher->publish()) {
@@ -96,18 +98,24 @@ class Publish extends BaseCommand
                     count($publisher->getPublished()),
                     $publisher->getDestination(),
                 ]), 'green');
-            } else {
-                CLI::error(lang('Publisher.publishFailure', [
-                    $publisher::class,
-                    $publisher->getDestination(),
-                ]), 'light_gray', 'red');
 
-                foreach ($publisher->getErrors() as $file => $exception) {
-                    CLI::write($file);
-                    CLI::error($exception->getMessage());
-                    CLI::newLine();
-                }
+                continue;
             }
+
+            CLI::error(lang('Publisher.publishFailure', [
+                $publisher::class,
+                $publisher->getDestination(),
+            ]), 'light_gray', 'red');
+
+            foreach ($publisher->getErrors() as $file => $exception) {
+                CLI::write($file);
+                CLI::error($exception->getMessage());
+                CLI::newLine();
+            }
+
+            $exit = EXIT_ERROR;
         }
+
+        return $exit;
     }
 }

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -202,10 +202,10 @@ class Routes extends BaseCommand
 
         CLI::table($tbody, $thead);
 
-        $this->showRequiredFilters();
+        return $this->showRequiredFilters();
     }
 
-    private function showRequiredFilters(): void
+    private function showRequiredFilters(): int
     {
         $filterCollector = new FilterCollector();
 
@@ -226,5 +226,7 @@ class Routes extends BaseCommand
         }
 
         CLI::write(' Required After Filters: ' . implode(', ', $filters));
+
+        return EXIT_SUCCESS;
     }
 }

--- a/tests/_support/Commands/AppInfo.php
+++ b/tests/_support/Commands/AppInfo.php
@@ -32,26 +32,24 @@ final class AppInfo extends BaseCommand
     {
         CLI::write(sprintf('CodeIgniter Version: %s', CodeIgniter::CI_VERSION));
 
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     public function bomb(): int
     {
         try {
             CLI::color('test', 'white', 'Background');
+
+            return EXIT_SUCCESS;
         } catch (RuntimeException $e) {
             $this->showError($e);
 
-            return 1;
+            return EXIT_ERROR;
         }
-
-        return 0;
     }
 
     public function helpMe(): int
     {
-        $this->call('help');
-
-        return 0;
+        return $this->call('help');
     }
 }

--- a/tests/_support/Commands/InvalidCommand.php
+++ b/tests/_support/Commands/InvalidCommand.php
@@ -29,8 +29,10 @@ class InvalidCommand extends BaseCommand
         throw new ReflectionException();
     }
 
-    public function run(array $params): void
+    public function run(array $params): int
     {
         CLI::write('CI Version: ' . CLI::color(CodeIgniter::CI_VERSION, 'red'));
+
+        return EXIT_SUCCESS;
     }
 }

--- a/tests/_support/Commands/LanguageCommand.php
+++ b/tests/_support/Commands/LanguageCommand.php
@@ -29,7 +29,7 @@ class LanguageCommand extends BaseCommand
         '--sort' => 'Turn on/off the sortImports flag.',
     ];
 
-    public function run(array $params): void
+    public function run(array $params): int
     {
         $this->setHasClassName(false);
         $params[0] = 'Foobar';
@@ -42,6 +42,8 @@ class LanguageCommand extends BaseCommand
         $this->setSortImports($sort);
 
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 
     protected function prepare(string $class): string

--- a/tests/_support/Commands/Unsuffixable.php
+++ b/tests/_support/Commands/Unsuffixable.php
@@ -67,7 +67,7 @@ class Unsuffixable extends BaseCommand
     /**
      * Actually execute a command.
      */
-    public function run(array $params): void
+    public function run(array $params): int
     {
         $this->component = 'Command';
         $this->directory = 'Commands';
@@ -75,5 +75,7 @@ class Unsuffixable extends BaseCommand
 
         $this->setEnabledSuffixing(false);
         $this->generateClass($params);
+
+        return EXIT_SUCCESS;
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Follow up to #10080 

Moves the deprecation notice to the command runner (`Commands`) instead of in `Boot` where it will be only accessed by running spark commands directly in terminal. Uses in the `command()` function are not affected by the current deprecation. Thus, this PR fixes that.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
