### PR TITLE
refactor: rename `-h` option of `routes` command as `--handler`

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -73,8 +73,8 @@ class Routes extends BaseCommand
      * @var array<string, string>
      */
     protected $options = [
-        '-h'     => 'Sort by Handler.',
-        '--host' => 'Specify hostname in request URI.',
+        '--handler' => 'Sort by Handler.',
+        '--host'    => 'Specify hostname in request URI.',
     ];
 
     /**
@@ -82,8 +82,17 @@ class Routes extends BaseCommand
      */
     public function run(array $params)
     {
-        $sortByHandler = array_key_exists('h', $params);
-        $host          = $params['host'] ?? null;
+        $sortByHandler = array_key_exists('handler', $params);
+
+        if (! $sortByHandler && array_key_exists('h', $params)) {
+            // Support -h as a shortcut but print a warning that it is not the intended use of -h.
+            CLI::write('Warning: -h will be used as shortcut for --help in v4.8.0. Please use --handler to sort by handler.', 'yellow');
+            CLI::newLine();
+
+            $sortByHandler = true;
+        }
+
+        $host = $params['host'] ?? null;
 
         // Set HTTP_HOST
         if ($host !== null) {

--- a/tests/system/Commands/Utilities/RoutesTest.php
+++ b/tests/system/Commands/Utilities/RoutesTest.php
@@ -56,7 +56,7 @@ final class RoutesTest extends CIUnitTestCase
 
     public function testRoutesCommand(): void
     {
-        Services::injectMock('routes', null);
+        Services::resetSingle('routes');
 
         command('routes');
 
@@ -92,9 +92,9 @@ final class RoutesTest extends CIUnitTestCase
 
     public function testRoutesCommandSortByHandler(): void
     {
-        Services::injectMock('routes', null);
+        Services::resetSingle('routes');
 
-        command('routes -h');
+        command('routes --handler');
 
         $expected = <<<'EOL'
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
@@ -117,9 +117,41 @@ final class RoutesTest extends CIUnitTestCase
         $this->assertStringContainsString($expected, $this->getBuffer());
     }
 
+    /**
+     * @todo To remove this test and the backward compatibility for -h in v4.8.0.
+     */
+    public function testRoutesCommandSortByHandlerUsingShortcutForBc(): void
+    {
+        Services::resetSingle('routes');
+
+        command('routes -h');
+
+        $expected = <<<'EOL'
+            Warning: -h will be used as shortcut for --help in v4.8.0. Please use --handler to sort by handler.
+
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            | Method  | Route   | Name          | Handler ↓                              | Before Filters | After Filters |
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            | GET     | closure | »             | (Closure)                              |                |               |
+            | GET     | /       | »             | \App\Controllers\Home::index           |                |               |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | PATCH   | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            EOL;
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
+
     public function testRoutesCommandHostHostname(): void
     {
-        Services::injectMock('routes', null);
+        Services::resetSingle('routes');
 
         command('routes --host blog.example.com');
 
@@ -148,7 +180,7 @@ final class RoutesTest extends CIUnitTestCase
 
     public function testRoutesCommandHostSubdomain(): void
     {
-        Services::injectMock('routes', null);
+        Services::resetSingle('routes');
 
         command('routes --host sub.example.com');
 
@@ -181,8 +213,7 @@ final class RoutesTest extends CIUnitTestCase
 
         $routes->setAutoRoute(true);
         config('Feature')->autoRoutesImproved = true;
-        $namespace                            = 'Tests\Support\Controllers';
-        $routes->setDefaultNamespace($namespace);
+        $routes->setDefaultNamespace('Tests\Support\Controllers');
 
         command('routes');
 
@@ -214,7 +245,8 @@ final class RoutesTest extends CIUnitTestCase
         $routes = $this->getCleanRoutes();
         $routes->loadRoutes();
 
-        $featureConfig                     = config(Feature::class);
+        $featureConfig = config(Feature::class);
+
         $featureConfig->autoRoutesImproved = false;
         $routes->setAutoRoute(true);
 

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -24,6 +24,10 @@ Message Changes
 Changes
 *******
 
+- **Commands:** The ``-h`` option for the ``routes`` command is renamed to ``--handler`` to avoid conflict with the common use of ``-h`` as a shortcut for ``--help``.
+    The old ``-h`` option will continue to work until v4.8.0, at which point it will be removed and repurposed as a shortcut for ``--help``.
+    A warning message is displayed when using the old ``-h`` option to encourage users to switch to the new ``--handler`` option.
+
 ************
 Deprecations
 ************

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,4 +1,4 @@
-# total 82 errors
+# total 78 errors
 
 parameters:
     ignoreErrors:
@@ -46,11 +46,6 @@ parameters:
             message: '#^Parameter \#2 \$to of method CodeIgniter\\Router\\RouteCollection\:\:add\(\) expects array\|\(Closure\(mixed \.\.\.\)\: \(CodeIgniter\\HTTP\\ResponseInterface\|string\|void\)\)\|string, Closure\(mixed\)\: void given\.$#'
             count: 1
             path: ../../tests/system/CodeIgniterTest.php
-
-        -
-            message: '#^Parameter \#2 \$mock of static method CodeIgniter\\Config\\BaseService\:\:injectMock\(\) expects object, null given\.$#'
-            count: 4
-            path: ../../tests/system/Commands/Utilities/RoutesTest.php
 
         -
             message: '#^Parameter \#1 \$expected of method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) expects class\-string\<Config\\TestRegistrar\>, string given\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2059 errors
+# total 2055 errors
 
 includes:
     - argument.type.neon


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
The `-h` shortcut is more commonly known as the shortcut for the `--help` option, so I found it surprising that it was used as the name for the sort by handler option. This PR changes the option name to `--handler` (or `--sort-by-handler` for clarity?). For backward compatibility, use the `-h` option will still work but a soft warning will be printed in the terminal screen.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
