### PR TITLE
fix: ensure calling `env` command with options only would not throw

### DIFF
--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -85,7 +85,7 @@ final class Environment extends BaseCommand
      */
     public function run(array $params)
     {
-        if ($params === []) {
+        if (! isset($params[0])) {
             CLI::write(sprintf('Your environment is currently set as %s.', CLI::color(service('superglobals')->server('CI_ENVIRONMENT', ENVIRONMENT), 'green')));
             CLI::newLine();
 

--- a/tests/system/Commands/Utilities/EnvironmentCommandTest.php
+++ b/tests/system/Commands/Utilities/EnvironmentCommandTest.php
@@ -64,6 +64,13 @@ final class EnvironmentCommandTest extends CIUnitTestCase
         $this->assertStringContainsString(ENVIRONMENT, $this->getStreamFilterBuffer());
     }
 
+    public function testUsingCommandWithOptionsOnlyGivesCurrentEnvironment(): void
+    {
+        command('env --foo');
+        $this->assertStringContainsString('testing', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString(ENVIRONMENT, $this->getStreamFilterBuffer());
+    }
+
     public function testProvidingTestingAsEnvGivesErrorMessage(): void
     {
         command('env testing');

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -33,6 +33,7 @@ Bugs Fixed
 **********
 
 - **Autoloader:** Fixed a bug where ``Autoloader::unregister()`` (used during tests) silently failed to remove handlers from the SPL autoload stack, causing closures to accumulate permanently.
+- **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
When the `env` command is called without an argument but only with options other than `--help` and `--no-header`, the command will throw a `TypeError`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
