### PR TITLE
fix: suppress stty stderr leak in `CLI::generateDimensions()` when stdin is not a TTY

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -778,7 +778,7 @@ class CLI
                         static::$width  = (int) $matches[2];
                     }
                 }
-            } elseif (($size = exec('stty size')) && preg_match('/(\d+)\s+(\d+)/', $size, $matches)) {
+            } elseif (($size = exec('stty size 2>/dev/null')) && preg_match('/(\d+)\s+(\d+)/', $size, $matches)) {
                 static::$height = (int) $matches[1];
                 static::$width  = (int) $matches[2];
             } else {

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -21,6 +21,7 @@ use CodeIgniter\Test\PhpStreamWrapper;
 use CodeIgniter\Test\StreamFilterTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use ReflectionProperty;
 
 /**
@@ -592,6 +593,33 @@ final class CLITest extends CIUnitTestCase
         $width->setValue(null, null);
 
         $this->assertIsInt(CLI::getWidth());
+    }
+
+    #[RequiresOperatingSystem('Darwin|Linux')]
+    public function testGenerateDimensionsDoesNotLeakSttyErrorToStderr(): void
+    {
+        $code = <<<'PHP'
+            require __DIR__ . '/system/Test/bootstrap.php';
+            CodeIgniter\CLI\CLI::generateDimensions();
+            PHP;
+
+        $cmd = sprintf('%s -r %s < /dev/null', PHP_BINARY, escapeshellarg($code));
+
+        $proc = proc_open(
+            $cmd,
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            ROOTPATH,
+        );
+        $this->assertIsResource($proc);
+
+        stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($proc);
+
+        $this->assertSame('', $stderr);
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -37,6 +37,7 @@ Bugs Fixed
 **********
 
 - **Autoloader:** Fixed a bug where ``Autoloader::unregister()`` (used during tests) silently failed to remove handlers from the SPL autoload stack, causing closures to accumulate permanently.
+- **CLI:** Fixed a bug where ``CLI::generateDimensions()`` leaked ``stty`` error output (e.g., ``stty: 'standard input': Inappropriate ioctl for device``) to stderr when stdin was not a TTY.
 - **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
When stdin isn't a TTY (PHPUnit, CI, piped output), stty writes `Inappropriate ioctl for device` to stderr — PHP's `exec()` only captures stdout, so that message leaked to the console. Redirecting stderr fixes it without affecting the fallback logic, since `exec()` still returns empty stdout and falls through to `tput`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
