### PR TITLE
refactor: UX: `ClearLogs::execute()` error message is misleading after interactive `'n'`

### DIFF
--- a/system/Commands/Housekeeping/ClearLogs.php
+++ b/system/Commands/Housekeeping/ClearLogs.php
@@ -68,7 +68,9 @@ class ClearLogs extends BaseCommand
 
         if (! $force && CLI::prompt('Are you sure you want to delete the logs?', ['n', 'y']) === 'n') {
             CLI::error('Deleting logs aborted.');
-            CLI::error('If you want, use the "--force" option to force delete all log files.');
+
+            // @todo to re-add under non-interactive mode
+            // CLI::error('If you want, use the "--force" option to force delete all log files.');
 
             return EXIT_ERROR;
         }

--- a/tests/system/Commands/Housekeeping/ClearLogsTest.php
+++ b/tests/system/Commands/Housekeeping/ClearLogsTest.php
@@ -98,7 +98,6 @@ final class ClearLogsTest extends CIUnitTestCase
             <<<'EOT'
                 Are you sure you want to delete the logs? [n, y]: n
                 Deleting logs aborted.
-                If you want, use the "--force" option to force delete all log files.
 
                 EOT,
             preg_replace('/\e\[[^m]+m/', '', $io->getOutput()),
@@ -122,7 +121,6 @@ final class ClearLogsTest extends CIUnitTestCase
             <<<EOT
                 Are you sure you want to delete the logs? [n, y]:{$space}
                 Deleting logs aborted.
-                If you want, use the "--force" option to force delete all log files.
 
                 EOT,
             preg_replace('/\e\[[^m]+m/', '', $io->getOutput()),


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
In `logs:clear`, we require `--force` before the logs can be deleted. in an interactive session and `n` is provided in the prompt, deletion will be aborted but will display an additional line saying to pass `--force`. however, the user actually chooses not to pass `--force` so it is kind of annoying or misleading. it should only be added if we're in non-interactive mode.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
