### PR TITLE
feat: Add Query, Header and Cookie attributes for direct Controller injection

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -18,6 +18,10 @@ use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\LogicException;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
+use CodeIgniter\HTTP\Attributes\ParamSource\BaseParamSourceAttribute;
+use CodeIgniter\HTTP\Attributes\ParamSource\Cookie;
+use CodeIgniter\HTTP\Attributes\ParamSource\Header;
+use CodeIgniter\HTTP\Attributes\ParamSource\Query;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\Exceptions\FormRequestException;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
@@ -728,7 +732,32 @@ class CodeIgniter
         $resolved   = [];
         $routeIndex = 0;
 
+        $request = service('request');
+
         foreach ($reflection->getParameters() as $param) {
+            $attrs = $param->getAttributes();
+
+            if (count($attrs) > 0) {
+                foreach ($attrs as $attr) {
+                    $instance = $attr->newInstance();
+
+                    if (! $instance instanceof BaseParamSourceAttribute) {
+                        continue;
+                    }
+
+                    $key = $instance->getKey($param->getName());
+
+                    $resolved[] = match (true) {
+                        $instance instanceof Query  => $request->getGet($key),
+                        $instance instanceof Header => $request->getHeaderLine($key),
+                        $instance instanceof Cookie => $request->getCookie($key),
+                        default                     => throw new LogicException('Unsupported parameter attribute: ' . $instance::class),
+                    };
+
+                    continue 2;
+                }
+            }
+
             [$kind, $formRequestClass] = CallableParamClassifier::classify($param);
 
             switch ($kind) {

--- a/system/HTTP/Attributes/ParamSource/BaseParamSourceAttribute.php
+++ b/system/HTTP/Attributes/ParamSource/BaseParamSourceAttribute.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Attributes\ParamSource;
+
+abstract class BaseParamSourceAttribute
+{
+    public function __construct(private readonly ?string $key = null)
+    {
+    }
+
+    public function getKey(string $paramName): string
+    {
+        return $this->key ?? $paramName;
+    }
+}

--- a/system/HTTP/Attributes/ParamSource/Cookie.php
+++ b/system/HTTP/Attributes/ParamSource/Cookie.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Attributes\ParamSource;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Cookie extends BaseParamSourceAttribute
+{
+}

--- a/system/HTTP/Attributes/ParamSource/Header.php
+++ b/system/HTTP/Attributes/ParamSource/Header.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Attributes\ParamSource;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Header extends BaseParamSourceAttribute
+{
+}

--- a/system/HTTP/Attributes/ParamSource/Query.php
+++ b/system/HTTP/Attributes/ParamSource/Query.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Attributes\ParamSource;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Query extends BaseParamSourceAttribute
+{
+}


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This PR introduces attribute-driven parameter resolution for controller methods, allowing HTTP request data to be injected directly into method parameters using PHP 8 attributes.

It enhances CodeIgniter’s controller parameter resolution system while preserving existing routing, form request, and default parameter behaviors.

Controller method parameters can now be annotated with request-source attributes:
- `#[Query]` → Inject query string values
- `#[Header]` → Inject HTTP header values
- `#[Cookie]` → Inject cookie values

Example
```php
class MyController {
    public function index(
        int $id,
        #[Query('limit')] int $limit = 10,
        #[Header('X-Tenant-Id')] string $tenantId
    ) {
        // $limit and $tenant will be fetched from Query and Header respectively.
        // Passing of parameters to attribute is optional, if no $key is passed to attribute, it'll default to name of the parameter itself
    }
}
```

*Currently, its a draft PR for others to see implementation. I haven't added tests or updated userguide yet.*

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide