### PR TITLE
docs: refactor AJAX request and clarify framework examples

### DIFF
--- a/user_guide_src/source/general/ajax.rst
+++ b/user_guide_src/source/general/ajax.rst
@@ -2,11 +2,11 @@
 AJAX Requests
 ##############
 
-The ``IncomingRequest::isAJAX()`` method uses the ``X-Requested-With`` header to define whether the request is XHR or normal. However, the most recent JavaScript implementations (i.e., fetch) no longer send this header along with the request, thus the use of ``IncomingRequest::isAJAX()`` becomes less reliable, because without this header it is not possible to define whether the request is or not XHR.
+The ``IncomingRequest::isAJAX()`` method uses the ``X-Requested-With`` header to define whether the request is XHR or normal. However, modern JavaScript APIs such as ``fetch`` no longer send this header by default, so ``IncomingRequest::isAJAX()`` becomes less reliable without additional configuration.
 
-To get around this problem, the most efficient solution (so far) is to manually define the request header, forcing the information to be sent to the server, which will then be able to identify that the request is XHR.
+To work around this problem, manually define the request header so the server can identify the request as XHR.
 
-Here's how to force the ``X-Requested-With`` header to be sent in the Fetch API and other JavaScript libraries.
+Here are common ways to send the ``X-Requested-With`` header in the Fetch API and other JavaScript libraries.
 
 .. contents::
     :local:
@@ -28,13 +28,42 @@ Fetch API
 Axios
 =====
 
-If you are using Axios, it also does not include the ``X-Requested-With`` header by default.
+Axios does not include the ``X-Requested-With`` header by default.
 You can add it globally as follows:
 
 .. code-block:: javascript
 
     axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
+
+If you prefer to avoid global defaults, create an Axios instance instead:
+
+.. code-block:: javascript
+
+    const api = axios.create({
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    });
+
+
+Vue.js
+-------
+
+Vue does not require a specific HTTP client. If your Vue app uses Axios, configure Axios once during application bootstrap or in a shared API module, and reuse that configuration throughout the app.
+
+React
+-----
+
+React also does not provide a built-in HTTP client. If your React app uses Axios, reuse the shared Axios configuration above, or set the header for an individual request when needed:
+
+.. code-block:: javascript
+
+    axios.get('your url', {
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    })
 
 jQuery
 ======
@@ -48,22 +77,6 @@ For libraries like jQuery for example, it is not necessary to make explicit the 
         headers: {'X-Requested-With': 'XMLHttpRequest'}
     });
 
-VueJS
-=====
-
-In VueJS you just need to add the following code to the ``created`` function, as long as you are using Axios for this type of request.
-
-.. code-block:: javascript
-
-    axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-
-React
-=====
-
-.. code-block:: javascript
-
-    axios.get("your url", {headers: {'Content-Type': 'application/json'}})
-
 htmx
 ====
 
@@ -74,3 +87,14 @@ You can use `ajax-header <https://github.com/bigskysoftware/htmx-extensions/blob
     <body hx-ext="ajax-header">
     ...
     </body>
+
+
+Or you can set the header manually with ``hx-headers``:
+
+.. code-block:: html
+
+    <button
+        hx-post="/your-url"
+        hx-headers='{"X-Requested-With": "XMLHttpRequest"}'>
+        Send Request
+    </button>


### PR DESCRIPTION
**Description**
This PR is a follow-up to #10069. It refactors the AJAX user guide to reduce duplication and make the guidance more consistent across libraries and frameworks.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
