### PR TITLE
docs: fix indentation on `4.7.2` and `4.7.3` changelogs

### DIFF
--- a/user_guide_src/source/changelogs/v4.7.2.rst
+++ b/user_guide_src/source/changelogs/v4.7.2.rst
@@ -15,8 +15,8 @@ Bugs Fixed
 **********
 
 - **Security:** Fixed a bug where the CSRF filter could corrupt JSON request bodies after successful
-    verification when the CSRF token was provided via the ``X-CSRF-TOKEN`` header.
-    This caused ``IncomingRequest::getJSON()`` to fail on valid ``application/json`` requests.
+  verification when the CSRF token was provided via the ``X-CSRF-TOKEN`` header.
+  This caused ``IncomingRequest::getJSON()`` to fail on valid ``application/json`` requests.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -25,8 +25,8 @@ Changes
 *******
 
 - **Commands:** The ``-h`` option for the ``routes`` command is renamed to ``--sort-by-handler`` to avoid conflict with the common use of ``-h`` as a shortcut for ``--help``.
-    The old ``-h`` option will continue to work until v4.8.0, at which point it will be removed and repurposed as a shortcut for ``--help``.
-    A warning message is displayed when using the old ``-h`` option to encourage users to switch to the new ``--sort-by-handler`` option.
+  The old ``-h`` option will continue to work until v4.8.0, at which point it will be removed and repurposed as a shortcut for ``--help``.
+  A warning message is displayed when using the old ``-h`` option to encourage users to switch to the new ``--sort-by-handler`` option.
 
 ************
 Deprecations


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
The 4-space indentation causes the rendered HTML to treat them as blocks instead of continuation of the previous lines.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
