### PR TITLE
fix: `Entity::normalizeValue()` must handle `UnitEnum` before `toArray()`

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -465,6 +465,8 @@ class Entity implements JsonSerializable
                 ];
             } elseif ($data instanceof JsonSerializable) {
                 $objectData = $data->jsonSerialize();
+            } elseif (method_exists($data, 'toArray')) {
+                $objectData = $data->toArray();
             } elseif ($data instanceof Traversable) {
                 $objectData = iterator_to_array($data);
             } elseif ($data instanceof DateTimeInterface) {
@@ -472,8 +474,6 @@ class Entity implements JsonSerializable
                     '__class'    => $data::class,
                     '__datetime' => $data->format(DATE_RFC3339_EXTENDED),
                 ];
-            } elseif (method_exists($data, 'toArray')) {
-                $objectData = $data->toArray();
             } else {
                 $objectData = get_object_vars($data);
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -458,10 +458,13 @@ class Entity implements JsonSerializable
             // Check for Entity instance (use raw values, recursive)
             if ($data instanceof self) {
                 $objectData = $data->toRawArray(false, true);
+            } elseif ($data instanceof UnitEnum) {
+                return [
+                    '__class' => $data::class,
+                    '__enum'  => $data instanceof BackedEnum ? $data->value : $data->name,
+                ];
             } elseif ($data instanceof JsonSerializable) {
                 $objectData = $data->jsonSerialize();
-            } elseif (method_exists($data, 'toArray')) {
-                $objectData = $data->toArray();
             } elseif ($data instanceof Traversable) {
                 $objectData = iterator_to_array($data);
             } elseif ($data instanceof DateTimeInterface) {
@@ -469,11 +472,8 @@ class Entity implements JsonSerializable
                     '__class'    => $data::class,
                     '__datetime' => $data->format(DATE_RFC3339_EXTENDED),
                 ];
-            } elseif ($data instanceof UnitEnum) {
-                return [
-                    '__class' => $data::class,
-                    '__enum'  => $data instanceof BackedEnum ? $data->value : $data->name,
-                ];
+            } elseif (method_exists($data, 'toArray')) {
+                $objectData = $data->toArray();
             } else {
                 $objectData = get_object_vars($data);
 

--- a/tests/_support/Entity/ArrayObjectWithToArray.php
+++ b/tests/_support/Entity/ArrayObjectWithToArray.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Entity;
+
+use ArrayObject;
+
+/**
+ * @extends ArrayObject<string, string>
+ */
+final class ArrayObjectWithToArray extends ArrayObject
+{
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return ['array' => 'same'];
+    }
+}

--- a/tests/_support/Enum/JsonSerializableStateUnitEnum.php
+++ b/tests/_support/Enum/JsonSerializableStateUnitEnum.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Enum;
+
+use JsonSerializable;
+
+enum JsonSerializableStateUnitEnum implements JsonSerializable
+{
+    case DRAFT;
+    case PUBLISHED;
+
+    public function jsonSerialize(): mixed
+    {
+        return ['json' => $this->name];
+    }
+}

--- a/tests/_support/Enum/StateEnum.php
+++ b/tests/_support/Enum/StateEnum.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Enum;
+
+enum StateEnum: string
+{
+    case DRAFT     = 'draft';
+    case PUBLISHED = 'published';
+
+    public function toArray(): array
+    {
+        return self::cases();
+    }
+}

--- a/tests/_support/Enum/StateUnitEnum.php
+++ b/tests/_support/Enum/StateUnitEnum.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Enum;
+
+enum StateUnitEnum
+{
+    case DRAFT;
+    case PUBLISHED;
+
+    public function toArray(): array
+    {
+        return self::cases();
+    }
+}

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -34,8 +34,10 @@ use Tests\Support\Entity\Cast\CastBase64;
 use Tests\Support\Entity\Cast\CastPassParameters;
 use Tests\Support\Entity\Cast\NotExtendsBaseCast;
 use Tests\Support\Enum\ColorEnum;
+use Tests\Support\Enum\JsonSerializableStateUnitEnum;
 use Tests\Support\Enum\RoleEnum;
 use Tests\Support\Enum\StateEnum;
+use Tests\Support\Enum\StateUnitEnum;
 use Tests\Support\Enum\StatusEnum;
 use Tests\Support\SomeEntity;
 
@@ -1049,13 +1051,39 @@ final class EntityTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/10136
      */
-    public function testInjectRawDataWithEnumThatHasToArrayMethod(): void
+    public function testInjectRawDataWithBackedEnumThatHasToArrayMethod(): void
     {
         $entity = new class () extends Entity {};
 
         $entity->injectRawData(['state' => StateEnum::DRAFT]);
 
         $this->assertSame(StateEnum::DRAFT, $entity->toRawArray()['state']);
+        $this->assertFalse($entity->hasChanged('state'));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/10136
+     */
+    public function testInjectRawDataWithUnitEnumThatHasToArrayMethod(): void
+    {
+        $entity = new class () extends Entity {};
+
+        $entity->injectRawData(['state' => StateUnitEnum::DRAFT]);
+
+        $this->assertSame(StateUnitEnum::DRAFT, $entity->toRawArray()['state']);
+        $this->assertFalse($entity->hasChanged('state'));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/10136
+     */
+    public function testInjectRawDataWithUnitEnumThatImplementsJsonSerializable(): void
+    {
+        $entity = new class () extends Entity {};
+
+        $entity->injectRawData(['state' => JsonSerializableStateUnitEnum::DRAFT]);
+
+        $this->assertSame(JsonSerializableStateUnitEnum::DRAFT, $entity->toRawArray()['state']);
         $this->assertFalse($entity->hasChanged('state'));
     }
 
@@ -1989,6 +2017,41 @@ final class EntityTest extends CIUnitTestCase
         $this->assertTrue($entity->hasChanged('data'));
     }
 
+    public function testHasChangedPrefersJsonSerializableOverToArray(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'data' => null,
+            ];
+        };
+
+        $entity->data = new class ('original') implements JsonSerializable {
+            public function __construct(private string $value)
+            {
+            }
+
+            public function jsonSerialize(): mixed
+            {
+                return ['json' => $this->value];
+            }
+
+            public function setValue(string $value): void
+            {
+                $this->value = $value;
+            }
+
+            public function toArray(): array
+            {
+                return ['array' => 'same'];
+            }
+        };
+        $entity->syncOriginal();
+
+        $entity->data->setValue('modified');
+
+        $this->assertTrue($entity->hasChanged('data'));
+    }
+
     public function testHasChangedDoesNotDetectUnchangedObject(): void
     {
         $entity = new class () extends Entity {
@@ -2290,6 +2353,48 @@ final class EntityTest extends CIUnitTestCase
         $entity->custom = $obj2;
 
         $this->assertTrue($entity->hasChanged('custom'));
+    }
+
+    public function testHasChangedPrefersToArrayOverTraversable(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'items' => null,
+            ];
+        };
+
+        $entity->items = new class (['iterator' => 'original']) extends ArrayObject {
+            public function toArray(): array
+            {
+                return ['array' => 'same'];
+            }
+        };
+        $entity->syncOriginal();
+
+        $entity->items->exchangeArray(['iterator' => 'modified']);
+
+        $this->assertFalse($entity->hasChanged('items'));
+    }
+
+    public function testHasChangedPrefersToArrayOverDateTimeInterface(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'date' => null,
+            ];
+        };
+
+        $entity->date = new class ('2024-01-01 00:00:00') extends DateTime {
+            public function toArray(): array
+            {
+                return ['date' => 'same'];
+            }
+        };
+        $entity->syncOriginal();
+
+        $entity->date->modify('+1 day');
+
+        $this->assertFalse($entity->hasChanged('date'));
     }
 
     public function testHasChangedScalarOptimizationWithNullValues(): void

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -2368,9 +2368,7 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
 
-        /**
-         * @extends ArrayObject<string, string>
-         */
+        /** @extends ArrayObject<string, string> */
         $items = new class (['iterator' => 'original']) extends ArrayObject {
             /**
              * @return array<string, string>

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -2368,6 +2368,9 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
 
+        /**
+         * @extends ArrayObject<string, string>
+         */
         $items = new class (['iterator' => 'original']) extends ArrayObject {
             /**
              * @return array<string, string>

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -2025,7 +2025,7 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
 
-        $entity->data = new class ('original') implements JsonSerializable {
+        $data = new class ('original') implements JsonSerializable {
             public function __construct(private string $value)
             {
             }
@@ -2040,14 +2040,19 @@ final class EntityTest extends CIUnitTestCase
                 $this->value = $value;
             }
 
+            /**
+             * @return array<string, string>
+             */
             public function toArray(): array
             {
                 return ['array' => 'same'];
             }
         };
+
+        $entity->data = $data;
         $entity->syncOriginal();
 
-        $entity->data->setValue('modified');
+        $data->setValue('modified');
 
         $this->assertTrue($entity->hasChanged('data'));
     }
@@ -2363,15 +2368,20 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
 
-        $entity->items = new class (['iterator' => 'original']) extends ArrayObject {
+        $items = new class (['iterator' => 'original']) extends ArrayObject {
+            /**
+             * @return array<string, string>
+             */
             public function toArray(): array
             {
                 return ['array' => 'same'];
             }
         };
+
+        $entity->items = $items;
         $entity->syncOriginal();
 
-        $entity->items->exchangeArray(['iterator' => 'modified']);
+        $items->exchangeArray(['iterator' => 'modified']);
 
         $this->assertFalse($entity->hasChanged('items'));
     }
@@ -2384,15 +2394,20 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
 
-        $entity->date = new class ('2024-01-01 00:00:00') extends DateTime {
+        $date = new class ('2024-01-01 00:00:00') extends DateTime {
+            /**
+             * @return array<string, string>
+             */
             public function toArray(): array
             {
                 return ['date' => 'same'];
             }
         };
+
+        $entity->date = $date;
         $entity->syncOriginal();
 
-        $entity->date->modify('+1 day');
+        $date->modify('+1 day');
 
         $this->assertFalse($entity->hasChanged('date'));
     }

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -35,6 +35,7 @@ use Tests\Support\Entity\Cast\CastPassParameters;
 use Tests\Support\Entity\Cast\NotExtendsBaseCast;
 use Tests\Support\Enum\ColorEnum;
 use Tests\Support\Enum\RoleEnum;
+use Tests\Support\Enum\StateEnum;
 use Tests\Support\Enum\StatusEnum;
 use Tests\Support\SomeEntity;
 
@@ -1043,6 +1044,19 @@ final class EntityTest extends CIUnitTestCase
         // Should return the enum object when accessed
         $this->assertInstanceOf(ColorEnum::class, $entity->color);
         $this->assertSame(ColorEnum::RED, $entity->color);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/10136
+     */
+    public function testInjectRawDataWithEnumThatHasToArrayMethod(): void
+    {
+        $entity = new class () extends Entity {};
+
+        $entity->injectRawData(['state' => StateEnum::DRAFT]);
+
+        $this->assertSame(StateEnum::DRAFT, $entity->toRawArray()['state']);
+        $this->assertFalse($entity->hasChanged('state'));
     }
 
     public function testAsArray(): void

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use ReflectionException;
 use stdClass;
+use Tests\Support\Entity\ArrayObjectWithToArray;
 use Tests\Support\Entity\Cast\CastBase64;
 use Tests\Support\Entity\Cast\CastPassParameters;
 use Tests\Support\Entity\Cast\NotExtendsBaseCast;
@@ -2368,16 +2369,7 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
 
-        /** @extends ArrayObject<string, string> */
-        $items = new class (['iterator' => 'original']) extends ArrayObject {
-            /**
-             * @return array<string, string>
-             */
-            public function toArray(): array
-            {
-                return ['array' => 'same'];
-            }
-        };
+        $items = new ArrayObjectWithToArray(['iterator' => 'original']);
 
         $entity->items = $items;
         $entity->syncOriginal();

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -45,6 +45,7 @@ Bugs Fixed
 - **Database:** Fixed a bug where ``BaseConnection::listTables()`` could return a sparse array when using cached table names after a table was dropped.
 - **Database:** Fixed a bug where the PostgreSQL driver's ``increment()`` and ``decrement()`` methods were not working for numeric columns.
 - **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
+- **Entity:** Fixed a bug where ``Entity::normalizeValue()`` did not handle ``UnitEnum`` before checking for ``toArray()``, causing enums implementing ``toArray()`` to be incorrectly normalized as generic objects instead of enums.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Language:** Fixed a bug where ``Language::getLine()`` returned the literal dot-notation key instead of the nested array value when the requested key resolved to an intermediate array three or more levels deep.
 - **Toolbar:** Fixed a bug where the Logs collector raised an undefined property error when using a third-party PSR-3 logger.


### PR DESCRIPTION
**Description**

Moves the `UnitEnum` instanceof check before `JsonSerializable` and `method_exists($data, 'toArray')` in Entity::normalizeValue(), so that enums implementing toArray() are always normalized as enums rather than as generic objects.

Fixes codeigniter4/CodeIgniter4#10136




* fix test: correct toRawArray() assertion for injected enum

toRawArray() returns raw $this->attributes, so an injected enum object stays as an enum object — not the backing string value. The real regression is that hasChanged() must return false (normalizeValue() handles UnitEnum before toArray()).

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
