### PR TITLE
fix: reset Kint CSP state in worker mode

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -208,6 +208,29 @@ class CodeIgniter
         // Reset timing
         $this->startTime = null;
         $this->totalTime = 0;
+
+        $this->resetKintForWorkerMode();
+    }
+
+    /**
+     * Resets Kint request-specific state for worker mode.
+     */
+    private function resetKintForWorkerMode(): void
+    {
+        if (! CI_DEBUG || ! class_exists(Kint::class, false)) {
+            return;
+        }
+
+        $csp = service('csp');
+        if ($csp->enabled()) {
+            RichRenderer::$js_nonce  = $csp->getScriptNonce();
+            RichRenderer::$css_nonce = $csp->getStyleNonce();
+        } else {
+            RichRenderer::$js_nonce  = null;
+            RichRenderer::$css_nonce = null;
+        }
+
+        RichRenderer::$needs_pre_render = true;
     }
 
     /**

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -30,6 +30,7 @@ use Config\Cache;
 use Config\Filters as FiltersConfig;
 use Config\Modules;
 use Config\Routing;
+use Kint\Renderer\RichRenderer;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -1273,6 +1274,15 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testResetForWorkerMode(): void
     {
+        $this->resetServices();
+
+        $appConfig             = config(App::class);
+        $appConfig->CSPEnabled = true;
+
+        RichRenderer::$js_nonce         = 'stale-script-nonce';
+        RichRenderer::$css_nonce        = 'stale-style-nonce';
+        RichRenderer::$needs_pre_render = false;
+
         $config      = new App();
         $codeigniter = new MockCodeIgniter($config);
 
@@ -1292,5 +1302,11 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertNull($this->getPrivateProperty($codeigniter, 'controller'));
         $this->assertNull($this->getPrivateProperty($codeigniter, 'method'));
         $this->assertNull($this->getPrivateProperty($codeigniter, 'output'));
+
+        $csp = service('csp');
+
+        $this->assertSame($csp->getScriptNonce(), RichRenderer::$js_nonce);
+        $this->assertSame($csp->getStyleNonce(), RichRenderer::$css_nonce);
+        $this->assertTrue(RichRenderer::$needs_pre_render);
     }
 }

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -40,6 +40,7 @@ Bugs Fixed
 - **CLI:** Fixed a bug where ``CLI::generateDimensions()`` leaked ``stty`` error output (e.g., ``stty: 'standard input': Inappropriate ioctl for device``) to stderr when stdin was not a TTY.
 - **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
+- **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
 
 See the repo's


### PR DESCRIPTION
This fixes stale Kint renderer state in worker mode.

Kint stores CSP nonces and rich renderer pre-render state in static properties. In normal PHP execution those statics are discarded after each request, but in worker mode they persist across requests. This can cause Debug Toolbar/Kint inline assets to use stale CSP nonces and trigger browser CSP violations.

This change resets Kint's request-specific renderer state from `CodeIgniter::resetForWorkerMode()` without reinitializing Kint or adding new public API.

- Refreshes Kint script/style CSP nonces per worker request
- Clears stale Kint nonces when CSP is disabled
- Restores `RichRenderer::$needs_pre_render` for the next request
- Adds regression coverage for worker reset behavior
- Adds a changelog entry

Fixes #10138

<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
