### PR TITLE
test: fix flaky CommandsTest override-discovery tests under random order

### DIFF
--- a/tests/system/CLI/CommandsTest.php
+++ b/tests/system/CLI/CommandsTest.php
@@ -68,6 +68,7 @@ final class CommandsTest extends CIUnitTestCase
         }
 
         copy($path, APPPATH . 'Commands/' . basename($path));
+        clearstatcache(true);
     }
 
     private function deleteCommand(string $path): void
@@ -75,6 +76,8 @@ final class CommandsTest extends CIUnitTestCase
         if (is_file(APPPATH . 'Commands/' . basename($path))) {
             unlink(APPPATH . 'Commands/' . basename($path));
         }
+
+        clearstatcache(true);
     }
 
     public function testRunOnUnknownCommand(): void


### PR DESCRIPTION
**Description**

`CommandsTest::testDiscoveredLegacyCommandsCanBeOverridden` (and its modern counterpart) fail intermittently under `--order-by=random` on GHA. Reproducer: `vendor/bin/phpunit tests/system/CLI --order-by=random --random-order-seed=1777101167`, which produces:

```
1) CodeIgniter\CLI\CommandsTest::testDiscoveredLegacyCommandsCanBeOverridden
Failed asserting that '
CodeIgniter Version: 4.8.0-dev
' [ASCII](length: 32) contains "This is App\Commands\AppInfo" [ASCII](length: 28).

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/CLI/CommandsTest.php:451
```

The override tests copy a fixture into `app/Commands/` and expect discovery to pick it up. `app/Commands/` is not tracked in git, so on a fresh checkout it does not exist until the test creates it.

PHP keys its stat cache by exact path string and only invalidates the exact path argument passed to `mkdir`/`copy`/`unlink`. The test's `copyCommand` calls `mkdir(APPPATH . 'Commands')` (no trailing slash), but `FileLocator::listFiles()` later checks `is_dir(APPPATH . 'Commands/')` (with trailing slash). When an earlier CLI test in the random order primes the cache with the trailing-slash form while the directory does not yet exist, the stat-cache entry survives the `mkdir`. Discovery then skips the `App` namespace and the original fixture command wins the `app:info` slot, so the override assertion fails.

Calling `clearstatcache(true)` after the filesystem mutations clears both the stat cache and the realpath cache, so subsequent discovery sees the fresh state. Scoped to the test fixture; production behavior matches PHP's documented cache rules and is not changed here.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide