### PR TITLE
refactor: simplify `FileLocator::listFiles()`

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -330,19 +330,7 @@ class FileLocator implements FileLocatorInterface
         helper('filesystem');
 
         foreach ($this->getNamespaces() as $namespace) {
-            $fullPath     = $namespace['path'] . $path;
-            $resolvedPath = realpath($fullPath);
-            $fullPath     = $resolvedPath !== false ? $resolvedPath : $fullPath;
-
-            if (! is_dir($fullPath)) {
-                continue;
-            }
-
-            $tempFiles = get_filenames($fullPath, true, false, false);
-
-            if ($tempFiles !== []) {
-                $files = array_merge($files, $tempFiles);
-            }
+            $files = array_merge($files, get_filenames($namespace['path'] . $path, true, false, false));
         }
 
         return $files;


### PR DESCRIPTION
**Description**

`FileLocator::listFiles()` resolved each namespace's `<path>` via `realpath()`, gated `get_filenames()` on `is_dir()`, and then guarded `array_merge` on a non-empty result. All three checks are redundant:

- `get_filenames()` (which uses `RecursiveDirectoryIterator` under the hood) already wraps its iterator in `try { ... } catch (Throwable) { return []; }` (see `system/Helpers/filesystem_helper.php`), so a missing or non-directory path simply yields an empty list.
- `array_merge($files, [])` is well-defined and returns a copy of `$files`, so the `if ($tempFiles !== [])` guard is a micro-optimization for a discovery-time path.

The loop body collapses to a single `array_merge` call.

Side benefit: dropping the `realpath`/`is_dir` gate also avoids a class of latent flakes where PHP's stat / realpath caches hold stale negative entries for a namespace's subdirectory on Linux PHP (which caches `is_dir` negatives and `realpath()` failures, unlike macOS PHP). PR #10141 papered over one such failure in `CommandsTest` with `clearstatcache(true)`; with this change, that workaround is no longer load-bearing.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide