### PR TITLE
feat: add transaction lifecycle callbacks

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -359,6 +359,20 @@ abstract class BaseConnection implements ConnectionInterface
     protected bool $transException = false;
 
     /**
+     * Callbacks to run after the outermost transaction commits.
+     *
+     * @var list<callable(): void>
+     */
+    protected array $transCommitCallbacks = [];
+
+    /**
+     * Callbacks to run after the outermost transaction rolls back.
+     *
+     * @var list<callable(): void>
+     */
+    protected array $transRollbackCallbacks = [];
+
+    /**
      * Array of table aliases.
      *
      * @var list<string>
@@ -985,13 +999,15 @@ abstract class BaseConnection implements ConnectionInterface
 
         // The query() function will set this flag to FALSE in the event that a query failed
         if ($this->transStatus === false || $this->transFailure === true) {
-            $this->transRollback();
-
-            // If we are NOT running in strict mode, we will reset
-            // the _trans_status flag so that subsequent groups of
-            // transactions will be permitted.
-            if ($this->transStrict === false) {
-                $this->transStatus = true;
+            try {
+                $this->transRollback();
+            } finally {
+                // If we are NOT running in strict mode, we will reset
+                // the _trans_status flag so that subsequent groups of
+                // transactions will be permitted.
+                if ($this->transStrict === false) {
+                    $this->transStatus = true;
+                }
             }
 
             return false;
@@ -1006,6 +1022,48 @@ abstract class BaseConnection implements ConnectionInterface
     public function transStatus(): bool
     {
         return $this->transStatus;
+    }
+
+    /**
+     * Register a callback to run after the outermost transaction commits.
+     *
+     * If no transaction is active, the callback runs immediately.
+     *
+     * @param callable(): void $callback
+     *
+     * @return $this
+     */
+    public function afterCommit(callable $callback): static
+    {
+        if ($this->transDepth === 0) {
+            $callback();
+
+            return $this;
+        }
+
+        $this->transCommitCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to run after the outermost transaction rolls back.
+     *
+     * If no transaction is active, the callback is not run.
+     *
+     * @param callable(): void $callback
+     *
+     * @return $this
+     */
+    public function afterRollback(callable $callback): static
+    {
+        if ($this->transDepth === 0) {
+            return $this;
+        }
+
+        $this->transRollbackCallbacks[] = $callback;
+
+        return $this;
     }
 
     /**
@@ -1055,6 +1113,11 @@ abstract class BaseConnection implements ConnectionInterface
         if ($this->transDepth > 1 || $this->_transCommit()) {
             $this->transDepth--;
 
+            if ($this->transDepth === 0) {
+                $this->transRollbackCallbacks = [];
+                $this->runTransCommitCallbacks();
+            }
+
             return true;
         }
 
@@ -1073,6 +1136,11 @@ abstract class BaseConnection implements ConnectionInterface
         // When transactions are nested we only begin/commit/rollback the outermost ones
         if ($this->transDepth > 1 || $this->_transRollback()) {
             $this->transDepth--;
+
+            if ($this->transDepth === 0) {
+                $this->transCommitCallbacks = [];
+                $this->runTransRollbackCallbacks();
+            }
 
             return true;
         }
@@ -1099,6 +1167,32 @@ abstract class BaseConnection implements ConnectionInterface
     {
         if ($this->transDepth !== 0) {
             $this->transStatus = false;
+        }
+    }
+
+    /**
+     * Run and clear callbacks registered for a successful transaction commit.
+     */
+    protected function runTransCommitCallbacks(): void
+    {
+        $callbacks                  = $this->transCommitCallbacks;
+        $this->transCommitCallbacks = [];
+
+        foreach ($callbacks as $callback) {
+            $callback();
+        }
+    }
+
+    /**
+     * Run and clear callbacks registered for a transaction rollback.
+     */
+    protected function runTransRollbackCallbacks(): void
+    {
+        $callbacks                    = $this->transRollbackCallbacks;
+        $this->transRollbackCallbacks = [];
+
+        foreach ($callbacks as $callback) {
+            $callback();
         }
     }
 

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use Config\Database as DbConfig;
+use Throwable;
 
 /**
  * @see \CodeIgniter\Database\ConfigTest
@@ -184,7 +185,12 @@ class Config extends BaseConfig
                 log_message('error', "Uncommitted transaction detected in database group '{$group}'. Transactions must be completed before request ends.");
 
                 while ($connection->transDepth > 0) {
-                    $connection->transRollback();
+                    try {
+                        $connection->transRollback();
+                    } catch (Throwable $e) {
+                        log_message('critical', $e->getMessage());
+                        break;
+                    }
                 }
             }
 

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -116,6 +116,24 @@ interface ConnectionInterface
     public function simpleQuery(string $sql);
 
     /**
+     * Register a callback to run after the outermost transaction commits.
+     *
+     * @param callable(): void $callback
+     *
+     * @return $this
+     */
+    public function afterCommit(callable $callback): static;
+
+    /**
+     * Register a callback to run after the outermost transaction rolls back.
+     *
+     * @param callable(): void $callback
+     *
+     * @return $this
+     */
+    public function afterRollback(callable $callback): static;
+
+    /**
      * Returns an instance of the query builder for this connection.
      *
      * @param array|string $tableName Table name.

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -558,6 +558,72 @@ final class BaseConnectionTest extends CIUnitTestCase
         $this->assertNull($result);
     }
 
+    public function testAfterCommitCallbacksRemainQueuedWhenDriverCommitFails(): void
+    {
+        $callbacks = [];
+
+        $db = new class ($this->options) extends MockConnection {
+            public int $commitAttempts = 0;
+
+            protected function _transCommit(): bool
+            {
+                $this->commitAttempts++;
+
+                return $this->commitAttempts > 1;
+            }
+        };
+
+        $this->assertTrue($db->transBegin());
+        $db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'committed';
+        });
+
+        $this->assertFalse($db->transCommit());
+        $this->assertSame([], $callbacks);
+        $this->assertSame(1, $db->transDepth);
+
+        $this->assertTrue($db->transCommit());
+        $this->assertSame(['committed'], $callbacks);
+        $this->assertSame(0, $db->transDepth);
+
+        $this->assertTrue($db->transBegin());
+        $this->assertTrue($db->transCommit());
+        $this->assertSame(['committed'], $callbacks);
+    }
+
+    public function testAfterRollbackCallbacksRemainQueuedWhenDriverRollbackFails(): void
+    {
+        $callbacks = [];
+
+        $db = new class ($this->options) extends MockConnection {
+            public int $rollbackAttempts = 0;
+
+            protected function _transRollback(): bool
+            {
+                $this->rollbackAttempts++;
+
+                return $this->rollbackAttempts > 1;
+            }
+        };
+
+        $this->assertTrue($db->transBegin());
+        $db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'rolled back';
+        });
+
+        $this->assertFalse($db->transRollback());
+        $this->assertSame([], $callbacks);
+        $this->assertSame(1, $db->transDepth);
+
+        $this->assertTrue($db->transRollback());
+        $this->assertSame(['rolled back'], $callbacks);
+        $this->assertSame(0, $db->transDepth);
+
+        $this->assertTrue($db->transBegin());
+        $this->assertTrue($db->transRollback());
+        $this->assertSame(['rolled back'], $callbacks);
+    }
+
     public function testCallFunctionDoesNotDoublePrefixAlreadyPrefixedName(): void
     {
         $db = new class ($this->options) extends MockConnection {

--- a/tests/system/Database/Live/TransactionCallbacksTest.php
+++ b/tests/system/Database/Live/TransactionCallbacksTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @internal
+ *
+ * @no-final
+ */
+#[Group('DatabaseLive')]
+class TransactionCallbacksTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    protected function setUp(): void
+    {
+        // Reset connection instance.
+        $this->db = Database::connect($this->DBGroup, false);
+
+        parent::setUp();
+    }
+
+    public function testAfterCommitRunsImmediatelyWhenNoTransactionIsActive(): void
+    {
+        $callbacks = [];
+
+        $result = $this->db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'ran';
+        });
+
+        $this->assertSame($this->db, $result);
+        $this->assertSame(['ran'], $callbacks);
+    }
+
+    public function testAfterCommitRunsAfterSuccessfulTransactionCommit(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart();
+        $this->db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'committed';
+        });
+
+        $this->assertSame([], $callbacks);
+
+        $this->db->transComplete();
+
+        $this->assertSame(['committed'], $callbacks);
+    }
+
+    public function testAfterCommitDoesNotRunAfterTransactionRollsBack(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart(true);
+        $this->db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'committed';
+        });
+
+        $this->db->transComplete();
+
+        $this->assertSame([], $callbacks);
+    }
+
+    public function testAfterCommitRunsAfterOutermostTransactionCommit(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart();
+        $this->db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'outer';
+        });
+
+        $this->db->transStart();
+        $this->db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'inner';
+        });
+        $this->db->transComplete();
+
+        $this->assertSame([], $callbacks);
+
+        $this->db->transComplete();
+
+        $this->assertSame(['outer', 'inner'], $callbacks);
+    }
+
+    public function testAfterCommitCallbackExceptionBubblesAfterTransactionCommit(): void
+    {
+        $builder = $this->db->table('job');
+
+        $this->db->transStart();
+        $builder->insert([
+            'name'        => 'Committed Job',
+            'description' => 'The transaction should still commit.',
+        ]);
+        $this->db->afterCommit(static function (): void {
+            throw new RuntimeException('Commit callback failed.');
+        });
+
+        try {
+            $this->db->transComplete();
+            $this->fail('Expected commit callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Commit callback failed.', $e->getMessage());
+        }
+
+        $this->seeInDatabase('job', ['name' => 'Committed Job']);
+    }
+
+    public function testAfterRollbackDoesNotRunWhenNoTransactionIsActive(): void
+    {
+        $callbacks = [];
+
+        $result = $this->db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'rolled back';
+        });
+
+        $this->assertSame($this->db, $result);
+        $this->assertSame([], $callbacks);
+    }
+
+    public function testAfterRollbackRunsAfterTransactionRollsBack(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart(true);
+        $this->db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'rolled back';
+        });
+
+        $this->assertSame([], $callbacks);
+
+        $this->db->transComplete();
+
+        $this->assertSame(['rolled back'], $callbacks);
+    }
+
+    public function testAfterRollbackDoesNotRunAfterSuccessfulTransactionCommit(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart();
+        $this->db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'rolled back';
+        });
+
+        $this->db->transComplete();
+
+        $this->assertSame([], $callbacks);
+    }
+
+    public function testAfterRollbackRunsAfterOutermostTransactionRollsBack(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart();
+        $this->db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'outer';
+        });
+
+        $this->db->transStart();
+        $this->db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'inner';
+        });
+        $this->db->transComplete();
+
+        $this->assertSame([], $callbacks);
+
+        $this->db->transRollback();
+
+        $this->assertSame(['outer', 'inner'], $callbacks);
+    }
+
+    public function testAfterRollbackCallbackExceptionBubblesAfterTransactionRollback(): void
+    {
+        $builder = $this->db->table('job');
+
+        $this->db->transStart(true);
+        $builder->insert([
+            'name'        => 'Rolled Back Job',
+            'description' => 'The transaction should still roll back.',
+        ]);
+        $this->db->afterRollback(static function (): void {
+            throw new RuntimeException('Rollback callback failed.');
+        });
+
+        try {
+            $this->db->transComplete();
+            $this->fail('Expected rollback callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Rollback callback failed.', $e->getMessage());
+        }
+
+        $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
+    }
+
+    public function testAfterRollbackCallbackExceptionDoesNotPreventNonStrictStatusReset(): void
+    {
+        $this->db->transStrict(false);
+        $this->db->transStart(true);
+        $this->db->afterRollback(static function (): void {
+            throw new RuntimeException('Rollback callback failed.');
+        });
+
+        try {
+            $this->db->transComplete();
+            $this->fail('Expected rollback callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Rollback callback failed.', $e->getMessage());
+        }
+
+        $this->assertTrue($this->db->transStatus());
+    }
+
+    public function testAfterRollbackRunsAfterAutomaticRollbackOnQueryFailure(): void
+    {
+        $callbacks = [];
+        $builder   = $this->db->transException(true)->table('job');
+
+        try {
+            $this->db->transStart();
+            $this->db->afterRollback(static function () use (&$callbacks): void {
+                $callbacks[] = 'rolled back';
+            });
+            $builder->insert([
+                'name'        => 'Rolled Back Job',
+                'description' => 'The transaction should roll back.',
+            ]);
+            $builder->insert([
+                'id'          => 1,
+                'name'        => 'Duplicate Job',
+                'description' => 'This should fail.',
+            ]);
+        } catch (DatabaseException) {
+            // The framework already rolled back while handling the query failure.
+        }
+
+        $this->assertSame(['rolled back'], $callbacks);
+        $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
+    }
+}

--- a/tests/system/Database/Live/TransactionCallbacksTest.php
+++ b/tests/system/Database/Live/TransactionCallbacksTest.php
@@ -23,11 +23,9 @@ use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**
  * @internal
- *
- * @no-final
  */
 #[Group('DatabaseLive')]
-class TransactionCallbacksTest extends CIUnitTestCase
+final class TransactionCallbacksTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 

--- a/tests/system/Database/Live/TransactionCallbacksTest.php
+++ b/tests/system/Database/Live/TransactionCallbacksTest.php
@@ -70,6 +70,22 @@ class TransactionCallbacksTest extends CIUnitTestCase
         $this->assertSame(['committed'], $callbacks);
     }
 
+    public function testAfterCommitRunsAfterManualTransactionCommit(): void
+    {
+        $callbacks = [];
+
+        $this->db->transBegin();
+        $this->db->afterCommit(static function () use (&$callbacks): void {
+            $callbacks[] = 'committed';
+        });
+
+        $this->assertSame([], $callbacks);
+
+        $this->db->transCommit();
+
+        $this->assertSame(['committed'], $callbacks);
+    }
+
     public function testAfterCommitDoesNotRunAfterTransactionRollsBack(): void
     {
         $callbacks = [];
@@ -153,6 +169,22 @@ class TransactionCallbacksTest extends CIUnitTestCase
         $this->assertSame([], $callbacks);
 
         $this->db->transComplete();
+
+        $this->assertSame(['rolled back'], $callbacks);
+    }
+
+    public function testAfterRollbackRunsAfterManualTransactionRollback(): void
+    {
+        $callbacks = [];
+
+        $this->db->transBegin();
+        $this->db->afterRollback(static function () use (&$callbacks): void {
+            $callbacks[] = 'rolled back';
+        });
+
+        $this->assertSame([], $callbacks);
+
+        $this->db->transRollback();
 
         $this->assertSame(['rolled back'], $callbacks);
     }

--- a/tests/system/Database/Live/WorkerModeTest.php
+++ b/tests/system/Database/Live/WorkerModeTest.php
@@ -18,6 +18,7 @@ use CodeIgniter\Database\Config;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
 
 /**
  * @internal
@@ -46,6 +47,22 @@ final class WorkerModeTest extends CIUnitTestCase
 
         $this->assertSame(0, $conn->transDepth);
         $this->assertNotFalse($this->getPrivateProperty($conn, 'connID'));
+    }
+
+    public function testCleanupForWorkerModeLogsRollbackCallbackException(): void
+    {
+        $conn = Config::connect();
+        $this->assertInstanceOf(BaseConnection::class, $conn);
+
+        $conn->transStart();
+        $conn->afterRollback(static function (): void {
+            throw new RuntimeException('Rollback callback failed.');
+        });
+
+        Config::cleanupForWorkerMode();
+
+        $this->assertSame(0, $conn->transDepth);
+        $this->assertLogged('critical', 'Rollback callback failed.');
     }
 
     public function testReconnectForWorkerMode(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,9 +43,9 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()`` and ``afterRollback()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()`` and ``afterRollback()`` methods.
 
 Method Signature Changes
 ========================

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -195,6 +195,7 @@ Testing
 Database
 ========
 
+- Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -195,7 +195,7 @@ Testing
 Database
 ========
 
-- Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back.
+- Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -45,6 +45,7 @@ update your implementations to include the new methods or method changes to ensu
 
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()`` and ``afterRollback()`` methods.
 
 Method Signature Changes
 ========================

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -111,6 +111,38 @@ If you want an exception to be thrown when a query error occurs, you can use
 If a query error occurs, all the queries will be rolled backed, and a
 ``DatabaseException`` will be thrown.
 
+Running Code after Commit or Rollback
+=====================================
+
+.. versionadded:: 4.8.0
+
+You may register callbacks to run only after the outermost transaction has
+successfully committed by using the ``afterCommit()`` method, or after the
+outermost transaction has rolled back by using the ``afterRollback()`` method:
+
+.. literalinclude:: transactions/010.php
+
+Callbacks registered during an active transaction are delayed until the
+outermost transaction commits or rolls back.
+
+If the transaction commits, ``afterCommit()`` callbacks run and
+``afterRollback()`` callbacks are discarded. If the transaction rolls back,
+``afterRollback()`` callbacks run and ``afterCommit()`` callbacks are discarded.
+If no transaction is active, ``afterCommit()`` callbacks run immediately, while
+``afterRollback()`` callbacks are not run.
+
+This is useful for side effects that should only happen after committed data is
+visible, such as dispatching a queued job or sending a notification, and for
+cleanup that should only happen after a real rollback.
+
+Callbacks run after the database transaction has already committed or rolled
+back. If a callback throws an exception, that exception bubbles to the caller,
+but the transaction outcome is not changed.
+
+Rollback callbacks also run when CodeIgniter automatically rolls back an active
+transaction while handling a transaction failure or cleaning up an unfinished
+transaction.
+
 Disabling Transactions
 ======================
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -111,6 +111,8 @@ If you want an exception to be thrown when a query error occurs, you can use
 If a query error occurs, all the queries will be rolled backed, and a
 ``DatabaseException`` will be thrown.
 
+.. _transactions-transaction-callbacks:
+
 Running Code after Commit or Rollback
 =====================================
 
@@ -131,6 +133,16 @@ If the transaction commits, ``afterCommit()`` callbacks run and
 If no transaction is active, ``afterCommit()`` callbacks run immediately, while
 ``afterRollback()`` callbacks are not run.
 
+For example:
+
+.. literalinclude:: transactions/011.php
+
+.. note:: When ``afterCommit()`` is called outside an active transaction, it runs
+    immediately. This includes calls from Model ``beforeInsert`` or
+    ``beforeUpdate`` events when the calling code has not already started a
+    transaction, so the callback may run before the Model's insert or update
+    query is executed.
+
 This is useful for side effects that should only happen after committed data is
 visible, such as dispatching a queued job or sending a notification, and for
 cleanup that should only happen after a real rollback.
@@ -138,6 +150,10 @@ cleanup that should only happen after a real rollback.
 Callbacks run after the database transaction has already committed or rolled
 back. If a callback throws an exception, that exception bubbles to the caller,
 but the transaction outcome is not changed.
+
+.. warning:: When multiple callbacks are registered for the same transaction
+    outcome, they run in registration order. If one callback throws an exception,
+    the subsequent callbacks are not run.
 
 Rollback callbacks also run when CodeIgniter automatically rolls back an active
 transaction while handling a transaction failure or cleaning up an unfinished

--- a/user_guide_src/source/database/transactions/010.php
+++ b/user_guide_src/source/database/transactions/010.php
@@ -1,0 +1,14 @@
+<?php
+
+$this->db->transStart();
+$this->db->query('AN SQL QUERY...');
+
+$this->db->afterCommit(static function (): void {
+    // Dispatch a queued job or run another side effect after commit.
+});
+
+$this->db->afterRollback(static function (): void {
+    // Run cleanup that should only happen after rollback.
+});
+
+$this->db->transComplete();

--- a/user_guide_src/source/database/transactions/011.php
+++ b/user_guide_src/source/database/transactions/011.php
@@ -1,0 +1,5 @@
+<?php
+
+$this->db->afterCommit(static function (): void {
+    // Runs immediately because there is no active transaction.
+});

--- a/user_guide_src/source/database/transactions/011.php
+++ b/user_guide_src/source/database/transactions/011.php
@@ -1,5 +1,9 @@
 <?php
 
 $this->db->afterCommit(static function (): void {
-    // Runs immediately because there is no active transaction.
+    // Runs immediately because no transaction has started yet.
 });
+
+$this->db->transStart();
+$this->db->query('AN SQL QUERY...');
+$this->db->transComplete();


### PR DESCRIPTION
**Introduction**

Hello! I’d like to propose a small database-layer primitive for transaction-aware side effects.

This came up as a concrete need in one of my CodeIgniter 4 projects, where jobs, notifications, events, cache invalidation, and cleanup should happen only after a transaction has actually committed or rolled back.

I kept the implementation intentionally narrow: no queue integration, event dispatcher behavior, outbox abstraction, or configuration surface. Since I am new to contributing here, please treat this as an initial proposal, and apologies in advance if this has already been discussed, rejected, or does not fit the current roadmap.

**Description**

This PR adds database transaction lifecycle callbacks to database connections:

- `afterCommit()` runs callbacks after the outermost transaction successfully commits.
- `afterRollback()` runs callbacks after the outermost transaction rolls back.
- Callbacks registered for the opposite outcome are discarded.
- `afterCommit()` runs immediately when no transaction is active.
- `afterRollback()` is a no-op when no transaction is active.
- Callback exceptions bubble to the caller after the database transaction has already reached its final state.

**Motivation**

Application code can currently perform side effects inside a transaction, but that can be unsafe when the transaction later rolls back. For example, an application may dispatch a queued job, send a notification, publish an event, clear a cache entry, or trigger an external integration before the data it depends on is actually committed.

This can lead to race conditions or inconsistent behavior, such as:

- A queued job runs before the committed row is visible.
- A notification is sent for data that later rolls back.
- A cache entry is invalidated even though the write did not persist.
- Cleanup code runs even though the transaction eventually commits.

By adding transaction lifecycle callbacks to the database layer, applications and future framework libraries can safely defer these side effects until after the outermost transaction commits or rolls back.

**Use Cases**

Common use cases include:

- Dispatching a queued job only after the database write it depends on has committed.
- Sending a notification only after a transaction succeeds.
- Publishing an application/domain event after committed data is visible.
- Invalidating or warming cache entries after a successful commit.
- Running cleanup logic only after a real rollback.
- Supporting future framework features that need transaction-aware side effects.

**Behavior Notes**

Callbacks are tied to the outermost transaction. Nested transaction callbacks do not run until the outermost transaction commits or rolls back.

Only callbacks for the final transaction outcome run: commit discards rollback callbacks, and rollback discards commit callbacks.

If a callback throws, the exception bubbles to the caller after the database transaction has already committed or rolled back, so the callback exception does not change the database outcome.

**Testing**

Added live database tests covering commit callbacks, rollback callbacks, nested transactions, callback exceptions, and automatic rollback behavior.

**Checklist**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
