### PR TITLE
feat: add atomic locks for cache-backed concurrency control

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -99,6 +99,10 @@ deptrac:
       collectors:
         - type: classNameRegex
           value: '/^CodeIgniter\\Language\\.*$/'
+    - name: Lock
+      collectors:
+        - type: classNameRegex
+          value: '/^CodeIgniter\\Lock\\.*$/'
     - name: Log
       collectors:
         - type: classNameRegex
@@ -170,6 +174,7 @@ deptrac:
       - URI
     Cache:
       - I18n
+      - Lock
     Controller:
       - HTTP
       - Validation
@@ -207,6 +212,8 @@ deptrac:
     Images:
       - Files
       - I18n
+    Lock:
+      - Cache
     Model:
       - Database
       - DataCaster

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -174,7 +174,6 @@ deptrac:
       - URI
     Cache:
       - I18n
-      - Lock
     Controller:
       - HTTP
       - Validation

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\Exceptions\CacheException;
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use Throwable;
 

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -15,6 +15,8 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStores\FileLockStore;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use Throwable;
@@ -24,7 +26,7 @@ use Throwable;
  *
  * @see \CodeIgniter\Cache\Handlers\FileHandlerTest
  */
-class FileHandler extends BaseHandler implements LockStoreInterface
+class FileHandler extends BaseHandler implements LockStoreProvider
 {
     /**
      * Maximum key length.
@@ -47,6 +49,8 @@ class FileHandler extends BaseHandler implements LockStoreInterface
      * @see https://www.php.net/manual/en/function.chmod.php
      */
     protected $mode;
+
+    private ?LockStoreInterface $lockStore = null;
 
     /**
      * Note: Use `CacheFactory::getHandler()` to instantiate.
@@ -156,78 +160,6 @@ class FileHandler extends BaseHandler implements LockStoreInterface
         return $this->increment($key, -$offset);
     }
 
-    public function acquireLock(string $key, string $owner, int $ttl): bool
-    {
-        return $this->withLockFile($key, static function ($handle) use ($owner, $ttl): bool {
-            $data = self::readLockData($handle);
-            $now  = Time::now()->getTimestamp();
-
-            if ($data !== null && $data['expires'] > $now) {
-                return false;
-            }
-
-            return self::writeLockData($handle, $owner, $now + $ttl);
-        });
-    }
-
-    public function releaseLock(string $key, string $owner): bool
-    {
-        return $this->withLockFile($key, static function ($handle) use ($owner): bool {
-            $data = self::readLockData($handle);
-
-            if ($data === null || $data['owner'] !== $owner) {
-                return false;
-            }
-
-            return self::clearLockFile($handle);
-        });
-    }
-
-    public function forceReleaseLock(string $key): bool
-    {
-        return ! is_file($this->path . static::validateKey($key, $this->prefix))
-            || $this->withLockFile($key, static fn ($handle): bool => self::clearLockFile($handle), false);
-    }
-
-    public function refreshLock(string $key, string $owner, int $ttl): bool
-    {
-        return $this->withLockFile($key, static function ($handle) use ($owner, $ttl): bool {
-            $data = self::readLockData($handle);
-            $now  = Time::now()->getTimestamp();
-
-            if ($data === null || $data['owner'] !== $owner || $data['expires'] <= $now) {
-                return false;
-            }
-
-            return self::writeLockData($handle, $owner, $now + $ttl);
-        });
-    }
-
-    public function getLockOwner(string $key): ?string
-    {
-        $owner = null;
-
-        $this->withLockFile($key, static function ($handle) use (&$owner): bool {
-            $data = self::readLockData($handle);
-
-            if ($data === null) {
-                return true;
-            }
-
-            if ($data['expires'] <= Time::now()->getTimestamp()) {
-                self::clearLockFile($handle);
-
-                return true;
-            }
-
-            $owner = $data['owner'];
-
-            return true;
-        }, false);
-
-        return $owner;
-    }
-
     public function clean(): bool
     {
         return delete_files($this->path, false, true);
@@ -256,6 +188,11 @@ class FileHandler extends BaseHandler implements LockStoreInterface
     public function isSupported(): bool
     {
         return is_writable($this->path);
+    }
+
+    public function lockStore(): LockStoreInterface
+    {
+        return $this->lockStore ??= new FileLockStore($this->path, $this->mode, $this->prefix);
     }
 
     /**
@@ -301,93 +238,5 @@ class FileHandler extends BaseHandler implements LockStoreInterface
         }
 
         return $data;
-    }
-
-    /**
-     * @param callable(resource): bool $callback
-     */
-    private function withLockFile(string $key, callable $callback, bool $create = true): bool
-    {
-        $key    = static::validateKey($key, $this->prefix);
-        $handle = @fopen($this->path . $key, $create ? 'c+b' : 'r+b');
-
-        if ($handle === false) {
-            return false;
-        }
-
-        try {
-            if (! flock($handle, LOCK_EX)) {
-                return false;
-            }
-
-            return $callback($handle);
-        } finally {
-            flock($handle, LOCK_UN);
-            fclose($handle);
-
-            if (is_file($this->path . $key)) {
-                try {
-                    chmod($this->path . $key, $this->mode);
-                } catch (Throwable $e) {
-                    log_message('debug', 'Failed to set mode on cache lock file: ' . $e);
-                }
-            }
-        }
-    }
-
-    /**
-     * @param resource $handle
-     *
-     * @return array{owner: string, expires: int}|null
-     */
-    private static function readLockData($handle): ?array
-    {
-        rewind($handle);
-
-        $content = stream_get_contents($handle);
-
-        if ($content === false || $content === '') {
-            return null;
-        }
-
-        try {
-            $data = unserialize($content);
-        } catch (Throwable) {
-            return null;
-        }
-
-        if (! is_array($data) || ! isset($data['owner'], $data['expires']) || ! is_string($data['owner']) || ! is_int($data['expires'])) {
-            return null;
-        }
-
-        return $data;
-    }
-
-    /**
-     * @param resource $handle
-     */
-    private static function writeLockData($handle, string $owner, int $expires): bool
-    {
-        rewind($handle);
-
-        if (! ftruncate($handle, 0)) {
-            return false;
-        }
-
-        if (fwrite($handle, serialize(['owner' => $owner, 'expires' => $expires])) === false) {
-            return false;
-        }
-
-        return fflush($handle);
-    }
-
-    /**
-     * @param resource $handle
-     */
-    private static function clearLockFile($handle): bool
-    {
-        rewind($handle);
-
-        return ftruncate($handle, 0) && fflush($handle);
     }
 }

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use Throwable;
 
@@ -23,7 +24,7 @@ use Throwable;
  *
  * @see \CodeIgniter\Cache\Handlers\FileHandlerTest
  */
-class FileHandler extends BaseHandler
+class FileHandler extends BaseHandler implements LockStoreInterface
 {
     /**
      * Maximum key length.
@@ -155,6 +156,78 @@ class FileHandler extends BaseHandler
         return $this->increment($key, -$offset);
     }
 
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        return $this->withLockFile($key, static function ($handle) use ($owner, $ttl): bool {
+            $data = self::readLockData($handle);
+            $now  = Time::now()->getTimestamp();
+
+            if ($data !== null && $data['expires'] > $now) {
+                return false;
+            }
+
+            return self::writeLockData($handle, $owner, $now + $ttl);
+        });
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        return $this->withLockFile($key, static function ($handle) use ($owner): bool {
+            $data = self::readLockData($handle);
+
+            if ($data === null || $data['owner'] !== $owner) {
+                return false;
+            }
+
+            return self::clearLockFile($handle);
+        });
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        return ! is_file($this->path . static::validateKey($key, $this->prefix))
+            || $this->withLockFile($key, static fn ($handle): bool => self::clearLockFile($handle), false);
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        return $this->withLockFile($key, static function ($handle) use ($owner, $ttl): bool {
+            $data = self::readLockData($handle);
+            $now  = Time::now()->getTimestamp();
+
+            if ($data === null || $data['owner'] !== $owner || $data['expires'] <= $now) {
+                return false;
+            }
+
+            return self::writeLockData($handle, $owner, $now + $ttl);
+        });
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $owner = null;
+
+        $this->withLockFile($key, static function ($handle) use (&$owner): bool {
+            $data = self::readLockData($handle);
+
+            if ($data === null) {
+                return true;
+            }
+
+            if ($data['expires'] <= Time::now()->getTimestamp()) {
+                self::clearLockFile($handle);
+
+                return true;
+            }
+
+            $owner = $data['owner'];
+
+            return true;
+        }, false);
+
+        return $owner;
+    }
+
     public function clean(): bool
     {
         return delete_files($this->path, false, true);
@@ -228,5 +301,93 @@ class FileHandler extends BaseHandler
         }
 
         return $data;
+    }
+
+    /**
+     * @param callable(resource): bool $callback
+     */
+    private function withLockFile(string $key, callable $callback, bool $create = true): bool
+    {
+        $key    = static::validateKey($key, $this->prefix);
+        $handle = @fopen($this->path . $key, $create ? 'c+b' : 'r+b');
+
+        if ($handle === false) {
+            return false;
+        }
+
+        try {
+            if (! flock($handle, LOCK_EX)) {
+                return false;
+            }
+
+            return $callback($handle);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+
+            if (is_file($this->path . $key)) {
+                try {
+                    chmod($this->path . $key, $this->mode);
+                } catch (Throwable $e) {
+                    log_message('debug', 'Failed to set mode on cache lock file: ' . $e);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param resource $handle
+     *
+     * @return array{owner: string, expires: int}|null
+     */
+    private static function readLockData($handle): ?array
+    {
+        rewind($handle);
+
+        $content = stream_get_contents($handle);
+
+        if ($content === false || $content === '') {
+            return null;
+        }
+
+        try {
+            $data = unserialize($content);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! is_array($data) || ! isset($data['owner'], $data['expires']) || ! is_string($data['owner']) || ! is_int($data['expires'])) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private static function writeLockData($handle, string $owner, int $expires): bool
+    {
+        rewind($handle);
+
+        if (! ftruncate($handle, 0)) {
+            return false;
+        }
+
+        if (fwrite($handle, serialize(['owner' => $owner, 'expires' => $expires])) === false) {
+            return false;
+        }
+
+        return fflush($handle);
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private static function clearLockFile($handle): bool
+    {
+        rewind($handle);
+
+        return ftruncate($handle, 0) && fflush($handle);
     }
 }

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -15,7 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\Cache\LockStores\FileLockStore;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -26,7 +26,7 @@ use Throwable;
  *
  * @see \CodeIgniter\Cache\Handlers\FileHandlerTest
  */
-class FileHandler extends BaseHandler implements LockStoreProvider
+class FileHandler extends BaseHandler implements LockStoreProviderInterface
 {
     /**
      * Maximum key length.
@@ -50,7 +50,7 @@ class FileHandler extends BaseHandler implements LockStoreProvider
      */
     protected $mode;
 
-    private ?LockStoreInterface $lockStore = null;
+    private readonly LockStoreInterface $lockStore;
 
     /**
      * Note: Use `CacheFactory::getHandler()` to instantiate.
@@ -73,6 +73,8 @@ class FileHandler extends BaseHandler implements LockStoreProvider
 
         $this->mode   = $options['mode'];
         $this->prefix = $config->prefix;
+
+        $this->lockStore = new FileLockStore($this->path, $this->mode, $this->prefix);
 
         helper('filesystem');
     }
@@ -192,7 +194,7 @@ class FileHandler extends BaseHandler implements LockStoreProvider
 
     public function lockStore(): LockStoreInterface
     {
-        return $this->lockStore ??= new FileLockStore($this->path, $this->mode, $this->prefix);
+        return $this->lockStore;
     }
 
     /**

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use Exception;
 use Predis\Client;
@@ -26,7 +27,7 @@ use Predis\Response\Status;
  *
  * @see \CodeIgniter\Cache\Handlers\PredisHandlerTest
  */
-class PredisHandler extends BaseHandler
+class PredisHandler extends BaseHandler implements LockStoreInterface
 {
     /**
      * Default config
@@ -165,6 +166,60 @@ class PredisHandler extends BaseHandler
         $key = static::validateKey($key);
 
         return $this->redis->hincrby($key, 'data', -$offset);
+    }
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        $key    = static::validateKey($key);
+        $result = $this->redis->set($key, $owner, 'EX', $ttl, 'NX');
+
+        return $result instanceof Status && $result->getPayload() === 'OK';
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        $key = static::validateKey($key);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            end
+
+            return 0
+            LUA;
+
+        return $this->redis->eval($script, 1, $key, $owner) === 1;
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        $key     = static::validateKey($key);
+        $deleted = $this->redis->del($key);
+
+        return is_int($deleted) && $deleted >= 0;
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = static::validateKey($key);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("expire", KEYS[1], ARGV[2])
+            end
+
+            return 0
+            LUA;
+
+        return $this->redis->eval($script, 1, $key, $owner, (string) $ttl) === 1;
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $key   = static::validateKey($key);
+        $owner = $this->redis->get($key);
+
+        return is_string($owner) ? $owner : null;
     }
 
     public function clean(): bool

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use Exception;
 use Predis\Client;

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStores\PredisLockStore;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -27,7 +29,7 @@ use Predis\Response\Status;
  *
  * @see \CodeIgniter\Cache\Handlers\PredisHandlerTest
  */
-class PredisHandler extends BaseHandler implements LockStoreInterface
+class PredisHandler extends BaseHandler implements LockStoreProvider
 {
     /**
      * Default config
@@ -59,6 +61,8 @@ class PredisHandler extends BaseHandler implements LockStoreInterface
      */
     protected $redis;
 
+    private ?LockStoreInterface $lockStore = null;
+
     /**
      * Note: Use `CacheFactory::getHandler()` to instantiate.
      */
@@ -72,7 +76,8 @@ class PredisHandler extends BaseHandler implements LockStoreInterface
     public function initialize(): void
     {
         try {
-            $this->redis = new Client($this->config, ['prefix' => $this->prefix]);
+            $this->redis     = new Client($this->config, ['prefix' => $this->prefix]);
+            $this->lockStore = null;
             $this->redis->time();
         } catch (Exception $e) {
             throw new CriticalError('Cache: Predis connection refused (' . $e->getMessage() . ').', $e->getCode(), $e);
@@ -168,60 +173,6 @@ class PredisHandler extends BaseHandler implements LockStoreInterface
         return $this->redis->hincrby($key, 'data', -$offset);
     }
 
-    public function acquireLock(string $key, string $owner, int $ttl): bool
-    {
-        $key    = static::validateKey($key);
-        $result = $this->redis->set($key, $owner, 'EX', $ttl, 'NX');
-
-        return $result instanceof Status && $result->getPayload() === 'OK';
-    }
-
-    public function releaseLock(string $key, string $owner): bool
-    {
-        $key = static::validateKey($key);
-
-        $script = <<<'LUA'
-            if redis.call("get", KEYS[1]) == ARGV[1] then
-                return redis.call("del", KEYS[1])
-            end
-
-            return 0
-            LUA;
-
-        return $this->redis->eval($script, 1, $key, $owner) === 1;
-    }
-
-    public function forceReleaseLock(string $key): bool
-    {
-        $key     = static::validateKey($key);
-        $deleted = $this->redis->del($key);
-
-        return is_int($deleted) && $deleted >= 0;
-    }
-
-    public function refreshLock(string $key, string $owner, int $ttl): bool
-    {
-        $key = static::validateKey($key);
-
-        $script = <<<'LUA'
-            if redis.call("get", KEYS[1]) == ARGV[1] then
-                return redis.call("expire", KEYS[1], ARGV[2])
-            end
-
-            return 0
-            LUA;
-
-        return $this->redis->eval($script, 1, $key, $owner, (string) $ttl) === 1;
-    }
-
-    public function getLockOwner(string $key): ?string
-    {
-        $key   = static::validateKey($key);
-        $owner = $this->redis->get($key);
-
-        return is_string($owner) ? $owner : null;
-    }
-
     public function clean(): bool
     {
         return $this->redis->flushdb()->getPayload() === 'OK';
@@ -255,6 +206,11 @@ class PredisHandler extends BaseHandler implements LockStoreInterface
     public function isSupported(): bool
     {
         return class_exists(Client::class);
+    }
+
+    public function lockStore(): LockStoreInterface
+    {
+        return $this->lockStore ??= new PredisLockStore($this->redis);
     }
 
     public function ping(): bool

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\Cache\LockStores\PredisLockStore;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
@@ -29,7 +29,7 @@ use Predis\Response\Status;
  *
  * @see \CodeIgniter\Cache\Handlers\PredisHandlerTest
  */
-class PredisHandler extends BaseHandler implements LockStoreProvider
+class PredisHandler extends BaseHandler implements LockStoreProviderInterface
 {
     /**
      * Default config
@@ -210,6 +210,7 @@ class PredisHandler extends BaseHandler implements LockStoreProvider
 
     public function lockStore(): LockStoreInterface
     {
+        // Predis applies the configured prefix at the client level.
         return $this->lockStore ??= new PredisLockStore($this->redis);
     }
 

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStores\RedisLockStore;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -25,7 +27,7 @@ use RedisException;
  *
  * @see \CodeIgniter\Cache\Handlers\RedisHandlerTest
  */
-class RedisHandler extends BaseHandler implements LockStoreInterface
+class RedisHandler extends BaseHandler implements LockStoreProvider
 {
     /**
      * Default config
@@ -55,6 +57,8 @@ class RedisHandler extends BaseHandler implements LockStoreInterface
      */
     protected $redis;
 
+    private ?LockStoreInterface $lockStore = null;
+
     /**
      * Note: Use `CacheFactory::getHandler()` to instantiate.
      */
@@ -69,7 +73,8 @@ class RedisHandler extends BaseHandler implements LockStoreInterface
     {
         $config = $this->config;
 
-        $this->redis = new Redis();
+        $this->redis     = new Redis();
+        $this->lockStore = null;
 
         try {
             $funcConnection = isset($config['persistent']) && $config['persistent'] ? 'pconnect' : 'connect';
@@ -186,59 +191,6 @@ class RedisHandler extends BaseHandler implements LockStoreInterface
         return $this->increment($key, -$offset);
     }
 
-    public function acquireLock(string $key, string $owner, int $ttl): bool
-    {
-        $key = static::validateKey($key, $this->prefix);
-
-        return (bool) $this->redis->set($key, $owner, ['nx', 'ex' => $ttl]);
-    }
-
-    public function releaseLock(string $key, string $owner): bool
-    {
-        $key = static::validateKey($key, $this->prefix);
-
-        $script = <<<'LUA'
-            if redis.call("get", KEYS[1]) == ARGV[1] then
-                return redis.call("del", KEYS[1])
-            end
-
-            return 0
-            LUA;
-
-        return (int) $this->redis->eval($script, [$key, $owner], 1) === 1;
-    }
-
-    public function forceReleaseLock(string $key): bool
-    {
-        $key     = static::validateKey($key, $this->prefix);
-        $deleted = $this->redis->del($key);
-
-        return is_int($deleted) && $deleted >= 0;
-    }
-
-    public function refreshLock(string $key, string $owner, int $ttl): bool
-    {
-        $key = static::validateKey($key, $this->prefix);
-
-        $script = <<<'LUA'
-            if redis.call("get", KEYS[1]) == ARGV[1] then
-                return redis.call("expire", KEYS[1], ARGV[2])
-            end
-
-            return 0
-            LUA;
-
-        return (int) $this->redis->eval($script, [$key, $owner, $ttl], 1) === 1;
-    }
-
-    public function getLockOwner(string $key): ?string
-    {
-        $key   = static::validateKey($key, $this->prefix);
-        $owner = $this->redis->get($key);
-
-        return is_string($owner) ? $owner : null;
-    }
-
     public function clean(): bool
     {
         return $this->redis->flushDB();
@@ -271,6 +223,13 @@ class RedisHandler extends BaseHandler implements LockStoreInterface
     public function isSupported(): bool
     {
         return extension_loaded('redis');
+    }
+
+    public function lockStore(): LockStoreInterface
+    {
+        assert($this->redis instanceof Redis);
+
+        return $this->lockStore ??= new RedisLockStore($this->redis, $this->prefix);
     }
 
     public function ping(): bool

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use Redis;
 use RedisException;

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use Redis;
 use RedisException;
@@ -24,7 +25,7 @@ use RedisException;
  *
  * @see \CodeIgniter\Cache\Handlers\RedisHandlerTest
  */
-class RedisHandler extends BaseHandler
+class RedisHandler extends BaseHandler implements LockStoreInterface
 {
     /**
      * Default config
@@ -183,6 +184,59 @@ class RedisHandler extends BaseHandler
     public function decrement(string $key, int $offset = 1): int
     {
         return $this->increment($key, -$offset);
+    }
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = static::validateKey($key, $this->prefix);
+
+        return (bool) $this->redis->set($key, $owner, ['nx', 'ex' => $ttl]);
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        $key = static::validateKey($key, $this->prefix);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            end
+
+            return 0
+            LUA;
+
+        return (int) $this->redis->eval($script, [$key, $owner], 1) === 1;
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        $key     = static::validateKey($key, $this->prefix);
+        $deleted = $this->redis->del($key);
+
+        return is_int($deleted) && $deleted >= 0;
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = static::validateKey($key, $this->prefix);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("expire", KEYS[1], ARGV[2])
+            end
+
+            return 0
+            LUA;
+
+        return (int) $this->redis->eval($script, [$key, $owner, $ttl], 1) === 1;
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $key   = static::validateKey($key, $this->prefix);
+        $owner = $this->redis->get($key);
+
+        return is_string($owner) ? $owner : null;
     }
 
     public function clean(): bool

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\Cache\LockStores\RedisLockStore;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
@@ -27,7 +27,7 @@ use RedisException;
  *
  * @see \CodeIgniter\Cache\Handlers\RedisHandlerTest
  */
-class RedisHandler extends BaseHandler implements LockStoreProvider
+class RedisHandler extends BaseHandler implements LockStoreProviderInterface
 {
     /**
      * Default config

--- a/system/Cache/LockStoreInterface.php
+++ b/system/Cache/LockStoreInterface.php
@@ -15,13 +15,28 @@ namespace CodeIgniter\Cache;
 
 interface LockStoreInterface
 {
+    /**
+     * Attempts to acquire a lock for the given owner and TTL.
+     */
     public function acquireLock(string $key, string $owner, int $ttl): bool;
 
+    /**
+     * Releases the lock only when it is currently held by the given owner.
+     */
     public function releaseLock(string $key, string $owner): bool;
 
+    /**
+     * Releases the lock without checking ownership.
+     */
     public function forceReleaseLock(string $key): bool;
 
+    /**
+     * Extends the lock TTL only when it is currently held by the given owner.
+     */
     public function refreshLock(string $key, string $owner, int $ttl): bool;
 
+    /**
+     * Returns the current owner token, or null when the lock is not held.
+     */
     public function getLockOwner(string $key): ?string;
 }

--- a/system/Cache/LockStoreInterface.php
+++ b/system/Cache/LockStoreInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Lock;
+namespace CodeIgniter\Cache;
 
 interface LockStoreInterface
 {

--- a/system/Cache/LockStoreProvider.php
+++ b/system/Cache/LockStoreProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache;
+
+interface LockStoreProvider
+{
+    public function lockStore(): LockStoreInterface;
+}

--- a/system/Cache/LockStoreProviderInterface.php
+++ b/system/Cache/LockStoreProviderInterface.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache;
 
-interface LockStoreProvider
+interface LockStoreProviderInterface
 {
+    /**
+     * Returns the atomic lock store for this cache handler.
+     */
     public function lockStore(): LockStoreInterface;
 }

--- a/system/Cache/LockStores/FileLockStore.php
+++ b/system/Cache/LockStores/FileLockStore.php
@@ -146,7 +146,7 @@ class FileLockStore implements LockStoreInterface
         }
 
         try {
-            $data = unserialize($content);
+            $data = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
         } catch (Throwable) {
             return null;
         }
@@ -169,7 +169,13 @@ class FileLockStore implements LockStoreInterface
             return false;
         }
 
-        if (fwrite($handle, serialize(['owner' => $owner, 'expires' => $expires])) === false) {
+        try {
+            $content = json_encode(['owner' => $owner, 'expires' => $expires], JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return false;
+        }
+
+        if (fwrite($handle, $content) === false) {
             return false;
         }
 

--- a/system/Cache/LockStores/FileLockStore.php
+++ b/system/Cache/LockStores/FileLockStore.php
@@ -56,8 +56,7 @@ class FileLockStore implements LockStoreInterface
 
     public function forceReleaseLock(string $key): bool
     {
-        return ! is_file($this->path . FileHandler::validateKey($key, $this->prefix))
-            || $this->withLockFile($key, static fn ($handle): bool => self::clearLockFile($handle), false);
+        return $this->withLockFile($key, static fn ($handle): bool => self::clearLockFile($handle));
     }
 
     public function refreshLock(string $key, string $owner, int $ttl): bool

--- a/system/Cache/LockStores/FileLockStore.php
+++ b/system/Cache/LockStores/FileLockStore.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\LockStores;
+
+use CodeIgniter\Cache\Handlers\FileHandler;
+use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\I18n\Time;
+use Throwable;
+
+class FileLockStore implements LockStoreInterface
+{
+    public function __construct(
+        private readonly string $path,
+        private readonly int $mode,
+        private readonly string $prefix = '',
+    ) {
+    }
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        return $this->withLockFile($key, static function ($handle) use ($owner, $ttl): bool {
+            $data = self::readLockData($handle);
+            $now  = Time::now()->getTimestamp();
+
+            if ($data !== null && $data['expires'] > $now) {
+                return false;
+            }
+
+            return self::writeLockData($handle, $owner, $now + $ttl);
+        });
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        return $this->withLockFile($key, static function ($handle) use ($owner): bool {
+            $data = self::readLockData($handle);
+
+            if ($data === null || $data['owner'] !== $owner) {
+                return false;
+            }
+
+            return self::clearLockFile($handle);
+        });
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        return ! is_file($this->path . FileHandler::validateKey($key, $this->prefix))
+            || $this->withLockFile($key, static fn ($handle): bool => self::clearLockFile($handle), false);
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        return $this->withLockFile($key, static function ($handle) use ($owner, $ttl): bool {
+            $data = self::readLockData($handle);
+            $now  = Time::now()->getTimestamp();
+
+            if ($data === null || $data['owner'] !== $owner || $data['expires'] <= $now) {
+                return false;
+            }
+
+            return self::writeLockData($handle, $owner, $now + $ttl);
+        });
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $owner = null;
+
+        $this->withLockFile($key, static function ($handle) use (&$owner): bool {
+            $data = self::readLockData($handle);
+
+            if ($data === null) {
+                return true;
+            }
+
+            if ($data['expires'] <= Time::now()->getTimestamp()) {
+                self::clearLockFile($handle);
+
+                return true;
+            }
+
+            $owner = $data['owner'];
+
+            return true;
+        }, false);
+
+        return $owner;
+    }
+
+    /**
+     * @param callable(resource): bool $callback
+     */
+    private function withLockFile(string $key, callable $callback, bool $create = true): bool
+    {
+        $key    = FileHandler::validateKey($key, $this->prefix);
+        $handle = @fopen($this->path . $key, $create ? 'c+b' : 'r+b');
+
+        if ($handle === false) {
+            return false;
+        }
+
+        try {
+            if (! flock($handle, LOCK_EX)) {
+                return false;
+            }
+
+            return $callback($handle);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+
+            if (is_file($this->path . $key)) {
+                try {
+                    chmod($this->path . $key, $this->mode);
+                } catch (Throwable $e) {
+                    log_message('debug', 'Failed to set mode on cache lock file: ' . $e);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param resource $handle
+     *
+     * @return array{owner: string, expires: int}|null
+     */
+    private static function readLockData($handle): ?array
+    {
+        rewind($handle);
+
+        $content = stream_get_contents($handle);
+
+        if ($content === false || $content === '') {
+            return null;
+        }
+
+        try {
+            $data = unserialize($content);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! is_array($data) || ! isset($data['owner'], $data['expires']) || ! is_string($data['owner']) || ! is_int($data['expires'])) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private static function writeLockData($handle, string $owner, int $expires): bool
+    {
+        rewind($handle);
+
+        if (! ftruncate($handle, 0)) {
+            return false;
+        }
+
+        if (fwrite($handle, serialize(['owner' => $owner, 'expires' => $expires])) === false) {
+            return false;
+        }
+
+        return fflush($handle);
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private static function clearLockFile($handle): bool
+    {
+        rewind($handle);
+
+        return ftruncate($handle, 0) && fflush($handle);
+    }
+}

--- a/system/Cache/LockStores/PredisLockStore.php
+++ b/system/Cache/LockStores/PredisLockStore.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\LockStores;
+
+use CodeIgniter\Cache\Handlers\PredisHandler;
+use CodeIgniter\Cache\LockStoreInterface;
+use Predis\Client;
+use Predis\Response\Status;
+
+class PredisLockStore implements LockStoreInterface
+{
+    public function __construct(private readonly Client $redis)
+    {
+    }
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        $key    = PredisHandler::validateKey($key);
+        $result = $this->redis->set($key, $owner, 'EX', $ttl, 'NX');
+
+        return $result instanceof Status && $result->getPayload() === 'OK';
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        $key = PredisHandler::validateKey($key);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            end
+
+            return 0
+            LUA;
+
+        return $this->redis->eval($script, 1, $key, $owner) === 1;
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        $key     = PredisHandler::validateKey($key);
+        $deleted = $this->redis->del($key);
+
+        return is_int($deleted) && $deleted >= 0;
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = PredisHandler::validateKey($key);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("expire", KEYS[1], ARGV[2])
+            end
+
+            return 0
+            LUA;
+
+        return $this->redis->eval($script, 1, $key, $owner, (string) $ttl) === 1;
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $key   = PredisHandler::validateKey($key);
+        $owner = $this->redis->get($key);
+
+        return is_string($owner) ? $owner : null;
+    }
+}

--- a/system/Cache/LockStores/RedisLockStore.php
+++ b/system/Cache/LockStores/RedisLockStore.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\LockStores;
+
+use CodeIgniter\Cache\Handlers\RedisHandler;
+use CodeIgniter\Cache\LockStoreInterface;
+use Redis;
+
+class RedisLockStore implements LockStoreInterface
+{
+    public function __construct(
+        private readonly Redis $redis,
+        private readonly string $prefix = '',
+    ) {
+    }
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = RedisHandler::validateKey($key, $this->prefix);
+
+        return (bool) $this->redis->set($key, $owner, ['nx', 'ex' => $ttl]);
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        $key = RedisHandler::validateKey($key, $this->prefix);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            end
+
+            return 0
+            LUA;
+
+        return (int) $this->redis->eval($script, [$key, $owner], 1) === 1;
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        $key     = RedisHandler::validateKey($key, $this->prefix);
+        $deleted = $this->redis->del($key);
+
+        return is_int($deleted) && $deleted >= 0;
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = RedisHandler::validateKey($key, $this->prefix);
+
+        $script = <<<'LUA'
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("expire", KEYS[1], ARGV[2])
+            end
+
+            return 0
+            LUA;
+
+        return (int) $this->redis->eval($script, [$key, $owner, $ttl], 1) === 1;
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $key   = RedisHandler::validateKey($key, $this->prefix);
+        $owner = $this->redis->get($key);
+
+        return is_string($owner) ? $owner : null;
+    }
+}

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -47,6 +47,7 @@ use CodeIgniter\HTTP\SiteURIFactory;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\Language\Language;
+use CodeIgniter\Lock\LockManager;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Router\RouteCollection;
@@ -121,6 +122,7 @@ use Config\WorkerMode;
  * @method static IncomingRequest            incomingrequest(?App $config = null, bool $getShared = true)
  * @method static Iterator                   iterator($getShared = true)
  * @method static Language                   language($locale = null, $getShared = true)
+ * @method static LockManager                locks(?CacheInterface $cache = null, bool $getShared = true)
  * @method static Logger                     logger($getShared = true)
  * @method static MigrationRunner            migrations(Migrations $config = null, ConnectionInterface $db = null, $getShared = true)
  * @method static Negotiate                  negotiator(RequestInterface $request = null, $getShared = true)

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -134,10 +134,8 @@ class Services extends BaseService
 
     /**
      * The locks service provides atomic locks backed by supported cache handlers.
-     *
-     * @return LockManager
      */
-    public static function locks(?CacheInterface $cache = null, bool $getShared = true)
+    public static function locks(?CacheInterface $cache = null, bool $getShared = true): LockManager
     {
         if ($getShared) {
             return static::getSharedInstance('locks', $cache);

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -139,15 +139,13 @@ class Services extends BaseService
      */
     public static function locks(?CacheInterface $cache = null, bool $getShared = true)
     {
-        if ($cache instanceof CacheInterface) {
-            return new LockManager($cache);
-        }
-
         if ($getShared) {
-            return static::getSharedInstance('locks', null);
+            return static::getSharedInstance('locks', $cache);
         }
 
-        return new LockManager(AppServices::get('cache'));
+        $cache ??= AppServices::get('cache');
+
+        return new LockManager($cache);
     }
 
     /**

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -47,6 +47,7 @@ use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\Language\Language;
+use CodeIgniter\Lock\LockManager;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Router\RouteCollection;
@@ -129,6 +130,24 @@ class Services extends BaseService
         $config ??= config(Cache::class);
 
         return CacheFactory::getHandler($config);
+    }
+
+    /**
+     * The locks service provides atomic locks backed by supported cache handlers.
+     *
+     * @return LockManager
+     */
+    public static function locks(?CacheInterface $cache = null, bool $getShared = true)
+    {
+        if ($cache instanceof CacheInterface) {
+            return new LockManager($cache);
+        }
+
+        if ($getShared) {
+            return static::getSharedInstance('locks', null);
+        }
+
+        return new LockManager(AppServices::get('cache'));
     }
 
     /**

--- a/system/Language/en/Lock.php
+++ b/system/Language/en/Lock.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+// Lock language settings
+return [
+    'unsupportedStore' => 'The cache handler "{0}" does not support locks.',
+];

--- a/system/Lock/Exceptions/LockException.php
+++ b/system/Lock/Exceptions/LockException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Lock\Exceptions;
+
+use CodeIgniter\Exceptions\FrameworkException;
+
+class LockException extends FrameworkException
+{
+    public static function forUnsupportedStore(string $class): self
+    {
+        return new self(sprintf('The cache handler "%s" does not support locks.', $class));
+    }
+}

--- a/system/Lock/Exceptions/LockException.php
+++ b/system/Lock/Exceptions/LockException.php
@@ -19,6 +19,6 @@ class LockException extends FrameworkException
 {
     public static function forUnsupportedStore(string $class): self
     {
-        return new self(sprintf('The cache handler "%s" does not support locks.', $class));
+        return new self(lang('Lock.unsupportedStore', [$class]));
     }
 }

--- a/system/Lock/Lock.php
+++ b/system/Lock/Lock.php
@@ -66,7 +66,7 @@ class Lock implements LockInterface
         $acquired = $waitSeconds > 0 ? $this->block($waitSeconds) : $this->acquire();
 
         if (! $acquired) {
-            return null;
+            return false;
         }
 
         try {

--- a/system/Lock/Lock.php
+++ b/system/Lock/Lock.php
@@ -17,13 +17,15 @@ use Closure;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 
-class Lock implements LockInterface
+final readonly class Lock implements LockInterface
 {
+    private const BLOCK_RETRY_MICROSECONDS = 100_000;
+
     public function __construct(
-        private readonly LockStoreInterface $store,
-        private readonly string $key,
-        private readonly int $ttl,
-        private readonly string $owner,
+        private LockStoreInterface $store,
+        private string $key,
+        private int $ttl,
+        private string $owner,
     ) {
         if ($ttl < 1) {
             throw new InvalidArgumentException('Lock TTL must be a positive integer.');
@@ -52,7 +54,7 @@ class Lock implements LockInterface
                 return true;
             }
 
-            usleep(100_000);
+            usleep(self::BLOCK_RETRY_MICROSECONDS);
         } while (microtime(true) < $expiresAt);
 
         return false;

--- a/system/Lock/Lock.php
+++ b/system/Lock/Lock.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Lock;
+
+use Closure;
+use CodeIgniter\Exceptions\InvalidArgumentException;
+
+class Lock implements LockInterface
+{
+    public function __construct(
+        private readonly LockStoreInterface $store,
+        private readonly string $key,
+        private readonly int $ttl,
+        private readonly string $owner,
+    ) {
+        if ($ttl < 1) {
+            throw new InvalidArgumentException('Lock TTL must be a positive integer.');
+        }
+
+        if ($owner === '') {
+            throw new InvalidArgumentException('Lock owner cannot be empty.');
+        }
+    }
+
+    public function acquire(): bool
+    {
+        return $this->store->acquireLock($this->key, $this->owner, $this->ttl);
+    }
+
+    public function block(int $seconds): bool
+    {
+        if ($seconds < 1) {
+            return $this->acquire();
+        }
+
+        $expiresAt = microtime(true) + $seconds;
+
+        do {
+            if ($this->acquire()) {
+                return true;
+            }
+
+            usleep(100_000);
+        } while (microtime(true) < $expiresAt);
+
+        return false;
+    }
+
+    /**
+     * @param Closure(): mixed $callback
+     */
+    public function run(Closure $callback, int $waitSeconds = 0): mixed
+    {
+        $acquired = $waitSeconds > 0 ? $this->block($waitSeconds) : $this->acquire();
+
+        if (! $acquired) {
+            return null;
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $this->release();
+        }
+    }
+
+    public function release(): bool
+    {
+        return $this->store->releaseLock($this->key, $this->owner);
+    }
+
+    public function forceRelease(): bool
+    {
+        return $this->store->forceReleaseLock($this->key);
+    }
+
+    public function refresh(?int $ttl = null): bool
+    {
+        $ttl ??= $this->ttl;
+
+        if ($ttl < 1) {
+            throw new InvalidArgumentException('Lock TTL must be a positive integer.');
+        }
+
+        return $this->store->refreshLock($this->key, $this->owner, $ttl);
+    }
+
+    public function isAcquired(): bool
+    {
+        return $this->store->getLockOwner($this->key) === $this->owner;
+    }
+
+    public function owner(): string
+    {
+        return $this->owner;
+    }
+}

--- a/system/Lock/Lock.php
+++ b/system/Lock/Lock.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Lock;
 
 use Closure;
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 
 class Lock implements LockInterface

--- a/system/Lock/LockInterface.php
+++ b/system/Lock/LockInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Lock;
+
+use Closure;
+
+interface LockInterface
+{
+    public function acquire(): bool;
+
+    public function block(int $seconds): bool;
+
+    /**
+     * @param Closure(): mixed $callback
+     */
+    public function run(Closure $callback, int $waitSeconds = 0): mixed;
+
+    public function release(): bool;
+
+    public function forceRelease(): bool;
+
+    public function refresh(?int $ttl = null): bool;
+
+    public function isAcquired(): bool;
+
+    public function owner(): string;
+}

--- a/system/Lock/LockInterface.php
+++ b/system/Lock/LockInterface.php
@@ -17,22 +17,45 @@ use Closure;
 
 interface LockInterface
 {
+    /**
+     * Attempts to acquire the lock immediately.
+     */
     public function acquire(): bool;
 
+    /**
+     * Attempts to acquire the lock, waiting up to the given number of seconds.
+     */
     public function block(int $seconds): bool;
 
     /**
+     * Runs the callback while the lock is held.
+     *
      * @param Closure(): mixed $callback
      */
     public function run(Closure $callback, int $waitSeconds = 0): mixed;
 
+    /**
+     * Releases the lock only if this instance still owns it.
+     */
     public function release(): bool;
 
+    /**
+     * Releases the lock without checking ownership.
+     */
     public function forceRelease(): bool;
 
+    /**
+     * Extends the lock TTL only if this instance still owns it.
+     */
     public function refresh(?int $ttl = null): bool;
 
+    /**
+     * Checks whether this instance still owns the lock.
+     */
     public function isAcquired(): bool;
 
+    /**
+     * Returns this instance's owner token.
+     */
     public function owner(): string;
 }

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -15,19 +15,19 @@ namespace CodeIgniter\Lock;
 
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Lock\Exceptions\LockException;
 
-class LockManager
+final readonly class LockManager
 {
     private const KEY_PREFIX = 'lock_';
 
-    private readonly LockStoreInterface $store;
+    private LockStoreInterface $store;
 
     public function __construct(CacheInterface $cache)
     {
-        if (! $cache instanceof LockStoreProvider) {
+        if (! $cache instanceof LockStoreProviderInterface) {
             throw LockException::forUnsupportedStore($cache::class);
         }
 

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Lock;
 
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Lock\Exceptions\LockException;
 
@@ -22,8 +23,15 @@ class LockManager
 {
     private const KEY_PREFIX = 'lock_';
 
-    public function __construct(private readonly CacheInterface $cache)
+    private readonly LockStoreInterface $store;
+
+    public function __construct(CacheInterface $cache)
     {
+        if (! $cache instanceof LockStoreProvider) {
+            throw LockException::forUnsupportedStore($cache::class);
+        }
+
+        $this->store = $cache->lockStore();
     }
 
     public function create(string $name, int $ttl = 300, ?string $owner = null): LockInterface
@@ -32,24 +40,12 @@ class LockManager
             throw new InvalidArgumentException('Lock name cannot be empty.');
         }
 
-        $store = $this->store();
-        $key   = $this->key($name);
-
-        return new Lock($store, $key, $ttl, $owner ?? bin2hex(random_bytes(16)));
+        return new Lock($this->store, $this->key($name), $ttl, $owner ?? bin2hex(random_bytes(16)));
     }
 
     public function restore(string $name, string $owner, int $ttl = 300): LockInterface
     {
         return $this->create($name, $ttl, $owner);
-    }
-
-    private function store(): LockStoreInterface
-    {
-        if (! $this->cache instanceof LockStoreInterface) {
-            throw LockException::forUnsupportedStore($this->cache::class);
-        }
-
-        return $this->cache;
     }
 
     private function key(string $name): string

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Lock;
 
 use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Lock\Exceptions\LockException;
 

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -25,6 +25,11 @@ final readonly class LockManager
 
     private LockStoreInterface $store;
 
+    /**
+     * @param CacheInterface $cache Cache handler that must also implement LockStoreProviderInterface.
+     *
+     * @throws LockException When the cache handler does not support locks.
+     */
     public function __construct(CacheInterface $cache)
     {
         if (! $cache instanceof LockStoreProviderInterface) {
@@ -50,6 +55,6 @@ final readonly class LockManager
 
     private function key(string $name): string
     {
-        return self::KEY_PREFIX . hash('sha256', $name);
+        return self::KEY_PREFIX . hash('xxh128', $name);
     }
 }

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Lock;
+
+use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\Exceptions\InvalidArgumentException;
+use CodeIgniter\Lock\Exceptions\LockException;
+
+class LockManager
+{
+    private const KEY_PREFIX = 'lock_';
+
+    public function __construct(private readonly CacheInterface $cache)
+    {
+    }
+
+    public function create(string $name, int $ttl = 300, ?string $owner = null): LockInterface
+    {
+        if ($name === '') {
+            throw new InvalidArgumentException('Lock name cannot be empty.');
+        }
+
+        $store = $this->store();
+        $key   = $this->key($name);
+
+        return new Lock($store, $key, $ttl, $owner ?? bin2hex(random_bytes(16)));
+    }
+
+    public function restore(string $name, string $owner, int $ttl = 300): LockInterface
+    {
+        return $this->create($name, $ttl, $owner);
+    }
+
+    private function store(): LockStoreInterface
+    {
+        if (! $this->cache instanceof LockStoreInterface) {
+            throw LockException::forUnsupportedStore($this->cache::class);
+        }
+
+        return $this->cache;
+    }
+
+    private function key(string $name): string
+    {
+        return self::KEY_PREFIX . hash('sha256', $name);
+    }
+}

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -26,7 +26,7 @@ final readonly class LockManager
     private LockStoreInterface $store;
 
     /**
-     * @param CacheInterface $cache Cache handler that must also implement LockStoreProviderInterface.
+     * @param CacheInterface&LockStoreProviderInterface $cache Cache handler that supports lock stores.
      *
      * @throws LockException When the cache handler does not support locks.
      */

--- a/system/Lock/LockStoreInterface.php
+++ b/system/Lock/LockStoreInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Lock;
+
+interface LockStoreInterface
+{
+    public function acquireLock(string $key, string $owner, int $ttl): bool;
+
+    public function releaseLock(string $key, string $owner): bool;
+
+    public function forceReleaseLock(string $key): bool;
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool;
+
+    public function getLockOwner(string $key): ?string;
+}

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -17,11 +17,11 @@ use Closure;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\Handlers\BaseHandler;
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Assert;
 
-class MockCache extends BaseHandler implements CacheInterface, LockStoreProvider
+class MockCache extends BaseHandler implements CacheInterface, LockStoreProviderInterface
 {
     /**
      * Mock cache storage.

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -16,10 +16,12 @@ namespace CodeIgniter\Test\Mock;
 use Closure;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\Handlers\BaseHandler;
+use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Assert;
 
-class MockCache extends BaseHandler implements CacheInterface
+class MockCache extends BaseHandler implements CacheInterface, LockStoreProvider
 {
     /**
      * Mock cache storage.
@@ -41,6 +43,8 @@ class MockCache extends BaseHandler implements CacheInterface
      * @var bool
      */
     protected $bypass = false;
+
+    private ?MockLockStore $lockStore = null;
 
     /**
      * Takes care of any handler-specific setup that must be done.
@@ -180,6 +184,7 @@ class MockCache extends BaseHandler implements CacheInterface
     {
         $this->cache       = [];
         $this->expirations = [];
+        $this->lockStore?->clean();
 
         return true;
     }
@@ -225,6 +230,11 @@ class MockCache extends BaseHandler implements CacheInterface
     public function isSupported(): bool
     {
         return true;
+    }
+
+    public function lockStore(): LockStoreInterface
+    {
+        return $this->lockStore ??= new MockLockStore();
     }
 
     // --------------------------------------------------------------------

--- a/system/Test/Mock/MockLockStore.php
+++ b/system/Test/Mock/MockLockStore.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Test\Mock;
+
+use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\I18n\Time;
+
+class MockLockStore implements LockStoreInterface
+{
+    /**
+     * @var array<string, array{owner: string, expires: int}>
+     */
+    private array $locks = [];
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        if ($this->getLockOwner($key) !== null) {
+            return false;
+        }
+
+        $this->locks[$key] = [
+            'owner'   => $owner,
+            'expires' => Time::now()->getTimestamp() + $ttl,
+        ];
+
+        return true;
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        if ($this->getLockOwner($key) !== $owner) {
+            return false;
+        }
+
+        unset($this->locks[$key]);
+
+        return true;
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        unset($this->locks[$key]);
+
+        return true;
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        if ($this->getLockOwner($key) !== $owner) {
+            return false;
+        }
+
+        $this->locks[$key]['expires'] = Time::now()->getTimestamp() + $ttl;
+
+        return true;
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        if (! isset($this->locks[$key])) {
+            return null;
+        }
+
+        if ($this->locks[$key]['expires'] <= Time::now()->getTimestamp()) {
+            unset($this->locks[$key]);
+
+            return null;
+        }
+
+        return $this->locks[$key]['owner'];
+    }
+
+    public function clean(): void
+    {
+        $this->locks = [];
+    }
+}

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -51,6 +51,10 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
+        if (! isset($this->handler)) {
+            return;
+        }
+
         foreach (self::getKeyArray() as $key) {
             $this->handler->delete($key);
         }

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -45,10 +46,18 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 
         $this->config  = new Cache();
         $this->handler = CacheFactory::getHandler($this->config, 'predis');
+
+        if ($this->handler::class !== PredisHandler::class) {
+            $this->markTestSkipped('Predis connection not available.');
+        }
     }
 
     protected function tearDown(): void
     {
+        if (! isset($this->handler)) {
+            return;
+        }
+
         foreach (self::getKeyArray() as $key) {
             $this->handler->delete($key);
         }
@@ -102,6 +111,21 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));
+    }
+
+    public function testLockOperations(): void
+    {
+        $handler = $this->handler;
+
+        $this->assertInstanceOf(LockStoreInterface::class, $handler);
+        $this->assertTrue($handler->acquireLock(self::$key1, 'owner1', 60));
+        $this->assertFalse($handler->acquireLock(self::$key1, 'owner2', 60));
+        $this->assertSame('owner1', $handler->getLockOwner(self::$key1));
+        $this->assertFalse($handler->releaseLock(self::$key1, 'owner2'));
+        $this->assertTrue($handler->refreshLock(self::$key1, 'owner1', 120));
+        $this->assertTrue($handler->releaseLock(self::$key1, 'owner1'));
+        $this->assertNull($handler->getLockOwner(self::$key1));
+        $this->assertTrue($handler->forceReleaseLock(self::$key1));
     }
 
     public function testSavePermanent(): void

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -117,15 +118,19 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handler;
 
-        $this->assertInstanceOf(LockStoreInterface::class, $handler);
-        $this->assertTrue($handler->acquireLock(self::$key1, 'owner1', 60));
-        $this->assertFalse($handler->acquireLock(self::$key1, 'owner2', 60));
-        $this->assertSame('owner1', $handler->getLockOwner(self::$key1));
-        $this->assertFalse($handler->releaseLock(self::$key1, 'owner2'));
-        $this->assertTrue($handler->refreshLock(self::$key1, 'owner1', 120));
-        $this->assertTrue($handler->releaseLock(self::$key1, 'owner1'));
-        $this->assertNull($handler->getLockOwner(self::$key1));
-        $this->assertTrue($handler->forceReleaseLock(self::$key1));
+        $this->assertInstanceOf(LockStoreProvider::class, $handler);
+
+        $store = $handler->lockStore();
+
+        $this->assertInstanceOf(LockStoreInterface::class, $store);
+        $this->assertTrue($store->acquireLock(self::$key1, 'owner1', 60));
+        $this->assertFalse($store->acquireLock(self::$key1, 'owner2', 60));
+        $this->assertSame('owner1', $store->getLockOwner(self::$key1));
+        $this->assertFalse($store->releaseLock(self::$key1, 'owner2'));
+        $this->assertTrue($store->refreshLock(self::$key1, 'owner1', 120));
+        $this->assertTrue($store->releaseLock(self::$key1, 'owner1'));
+        $this->assertNull($store->getLockOwner(self::$key1));
+        $this->assertTrue($store->forceReleaseLock(self::$key1));
     }
 
     public function testSavePermanent(): void
@@ -223,11 +228,18 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 
     public function testReconnect(): void
     {
-        $this->handler->save(self::$key1, 'value');
-        $this->assertSame('value', $this->handler->get(self::$key1));
+        $handler = $this->handler;
 
-        $this->assertTrue($this->handler->reconnect());
+        $this->assertInstanceOf(LockStoreProvider::class, $handler);
 
-        $this->assertSame('value', $this->handler->get(self::$key1));
+        $lockStore = $handler->lockStore();
+
+        $handler->save(self::$key1, 'value');
+        $this->assertSame('value', $handler->get(self::$key1));
+
+        $this->assertTrue($handler->reconnect());
+
+        $this->assertSame('value', $handler->get(self::$key1));
+        $this->assertNotSame($lockStore, $handler->lockStore());
     }
 }

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -15,7 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -118,7 +118,7 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handler;
 
-        $this->assertInstanceOf(LockStoreProvider::class, $handler);
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
 
         $store = $handler->lockStore();
 
@@ -230,7 +230,7 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handler;
 
-        $this->assertInstanceOf(LockStoreProvider::class, $handler);
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
 
         $lockStore = $handler->lockStore();
 

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -15,7 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
-use CodeIgniter\Cache\LockStoreProvider;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -119,7 +119,7 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handler;
 
-        $this->assertInstanceOf(LockStoreProvider::class, $handler);
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
 
         $store = $handler->lockStore();
 
@@ -268,7 +268,7 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handler;
 
-        $this->assertInstanceOf(LockStoreProvider::class, $handler);
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
 
         $lockStore = $handler->lockStore();
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProvider;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
@@ -118,15 +119,19 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handler;
 
-        $this->assertInstanceOf(LockStoreInterface::class, $handler);
-        $this->assertTrue($handler->acquireLock(self::$key1, 'owner1', 60));
-        $this->assertFalse($handler->acquireLock(self::$key1, 'owner2', 60));
-        $this->assertSame('owner1', $handler->getLockOwner(self::$key1));
-        $this->assertFalse($handler->releaseLock(self::$key1, 'owner2'));
-        $this->assertTrue($handler->refreshLock(self::$key1, 'owner1', 120));
-        $this->assertTrue($handler->releaseLock(self::$key1, 'owner1'));
-        $this->assertNull($handler->getLockOwner(self::$key1));
-        $this->assertTrue($handler->forceReleaseLock(self::$key1));
+        $this->assertInstanceOf(LockStoreProvider::class, $handler);
+
+        $store = $handler->lockStore();
+
+        $this->assertInstanceOf(LockStoreInterface::class, $store);
+        $this->assertTrue($store->acquireLock(self::$key1, 'owner1', 60));
+        $this->assertFalse($store->acquireLock(self::$key1, 'owner2', 60));
+        $this->assertSame('owner1', $store->getLockOwner(self::$key1));
+        $this->assertFalse($store->releaseLock(self::$key1, 'owner2'));
+        $this->assertTrue($store->refreshLock(self::$key1, 'owner1', 120));
+        $this->assertTrue($store->releaseLock(self::$key1, 'owner1'));
+        $this->assertNull($store->getLockOwner(self::$key1));
+        $this->assertTrue($store->forceReleaseLock(self::$key1));
     }
 
     public function testSavePermanent(): void
@@ -261,11 +266,18 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 
     public function testReconnect(): void
     {
-        $this->handler->save(self::$key1, 'value');
-        $this->assertSame('value', $this->handler->get(self::$key1));
+        $handler = $this->handler;
 
-        $this->assertTrue($this->handler->reconnect());
+        $this->assertInstanceOf(LockStoreProvider::class, $handler);
 
-        $this->assertSame('value', $this->handler->get(self::$key1));
+        $lockStore = $handler->lockStore();
+
+        $handler->save(self::$key1, 'value');
+        $this->assertSame('value', $handler->get(self::$key1));
+
+        $this->assertTrue($handler->reconnect());
+
+        $this->assertSame('value', $handler->get(self::$key1));
+        $this->assertNotSame($lockStore, $handler->lockStore());
     }
 }

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -54,6 +55,10 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
+        if (! isset($this->handler)) {
+            return;
+        }
+
         foreach (self::getKeyArray() as $key) {
             $this->handler->delete($key);
         }
@@ -107,6 +112,21 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));
+    }
+
+    public function testLockOperations(): void
+    {
+        $handler = $this->handler;
+
+        $this->assertInstanceOf(LockStoreInterface::class, $handler);
+        $this->assertTrue($handler->acquireLock(self::$key1, 'owner1', 60));
+        $this->assertFalse($handler->acquireLock(self::$key1, 'owner2', 60));
+        $this->assertSame('owner1', $handler->getLockOwner(self::$key1));
+        $this->assertFalse($handler->releaseLock(self::$key1, 'owner2'));
+        $this->assertTrue($handler->refreshLock(self::$key1, 'owner1', 120));
+        $this->assertTrue($handler->releaseLock(self::$key1, 'owner1'));
+        $this->assertNull($handler->getLockOwner(self::$key1));
+        $this->assertTrue($handler->forceReleaseLock(self::$key1));
     }
 
     public function testSavePermanent(): void

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Lock\LockStoreInterface;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -111,8 +111,20 @@ final class ServicesTest extends CIUnitTestCase
 
     public function testNewLocks(): void
     {
-        $actual = Services::locks();
-        $this->assertInstanceOf(LockManager::class, $actual);
+        $config                    = new Cache();
+        $config->file['storePath'] = WRITEPATH . 'cache/ServicesLockTest';
+
+        if (! is_dir($config->file['storePath'])) {
+            mkdir($config->file['storePath'], 0777, true);
+        }
+
+        try {
+            $actual = Services::locks(Services::cache($config, false));
+            $this->assertInstanceOf(LockManager::class, $actual);
+        } finally {
+            delete_files($config->file['storePath'], false, true);
+            rmdir($config->file['storePath']);
+        }
     }
 
     public function testNewUnsharedLocksWithCustomCache(): void

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -32,6 +32,7 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Images\ImageHandlerInterface;
 use CodeIgniter\Language\Language;
+use CodeIgniter\Lock\LockManager;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Router\Router;
@@ -46,6 +47,7 @@ use CodeIgniter\Typography\Typography;
 use CodeIgniter\Validation\Validation;
 use CodeIgniter\View\Cell;
 use CodeIgniter\View\Parser;
+use Config\Cache;
 use Config\Database as DatabaseConfig;
 use Config\Exceptions;
 use Config\Security as SecurityConfig;
@@ -105,6 +107,32 @@ final class ServicesTest extends CIUnitTestCase
     {
         $actual = Services::locator();
         $this->assertInstanceOf(FileLocator::class, $actual);
+    }
+
+    public function testNewLocks(): void
+    {
+        $actual = Services::locks();
+        $this->assertInstanceOf(LockManager::class, $actual);
+    }
+
+    public function testLocksWithCustomCacheIsNotShared(): void
+    {
+        $config                    = new Cache();
+        $config->file['storePath'] = WRITEPATH . 'cache/ServicesLockTest';
+
+        if (! is_dir($config->file['storePath'])) {
+            mkdir($config->file['storePath'], 0777, true);
+        }
+
+        try {
+            $custom = Services::cache($config, false);
+
+            $this->assertInstanceOf(LockManager::class, Services::locks($custom));
+            $this->assertNotSame(Services::locks($custom), Services::locks());
+        } finally {
+            delete_files($config->file['storePath'], false, true);
+            rmdir($config->file['storePath']);
+        }
     }
 
     public function testNewUnsharedFileLocator(): void

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -115,7 +115,7 @@ final class ServicesTest extends CIUnitTestCase
         $this->assertInstanceOf(LockManager::class, $actual);
     }
 
-    public function testLocksWithCustomCacheIsNotShared(): void
+    public function testNewUnsharedLocksWithCustomCache(): void
     {
         $config                    = new Cache();
         $config->file['storePath'] = WRITEPATH . 'cache/ServicesLockTest';
@@ -127,8 +127,8 @@ final class ServicesTest extends CIUnitTestCase
         try {
             $custom = Services::cache($config, false);
 
-            $this->assertInstanceOf(LockManager::class, Services::locks($custom));
-            $this->assertNotSame(Services::locks($custom), Services::locks());
+            $this->assertInstanceOf(LockManager::class, Services::locks($custom, false));
+            $this->assertNotSame(Services::locks($custom, false), Services::locks($custom, false));
         } finally {
             delete_files($config->file['storePath'], false, true);
             rmdir($config->file['storePath']);

--- a/tests/system/Lock/LockTest.php
+++ b/tests/system/Lock/LockTest.php
@@ -191,12 +191,10 @@ final class LockTest extends CIUnitTestCase
 
     public function testUnsupportedCacheHandlerThrows(): void
     {
-        $locks = new LockManager(CacheFactory::getHandler($this->config, 'dummy'));
-
         $this->expectException(LockException::class);
         $this->expectExceptionMessage('does not support locks');
 
-        $locks->create('reports.daily-export');
+        new LockManager(CacheFactory::getHandler($this->config, 'dummy'));
     }
 
     private function lockFile(string $name): string

--- a/tests/system/Lock/LockTest.php
+++ b/tests/system/Lock/LockTest.php
@@ -194,6 +194,7 @@ final class LockTest extends CIUnitTestCase
         $this->expectException(LockException::class);
         $this->expectExceptionMessage('does not support locks');
 
+        // @phpstan-ignore argument.type
         new LockManager(CacheFactory::getHandler($this->config, 'dummy'));
     }
 

--- a/tests/system/Lock/LockTest.php
+++ b/tests/system/Lock/LockTest.php
@@ -199,6 +199,6 @@ final class LockTest extends CIUnitTestCase
 
     private function lockFile(string $name): string
     {
-        return rtrim($this->config->file['storePath'], '\\/') . '/lock_' . hash('sha256', $name);
+        return rtrim($this->config->file['storePath'], '\\/') . '/lock_' . hash('xxh128', $name);
     }
 }

--- a/tests/system/Lock/LockTest.php
+++ b/tests/system/Lock/LockTest.php
@@ -157,13 +157,13 @@ final class LockTest extends CIUnitTestCase
         $this->assertTrue($this->locks->create('notifications.send', 60)->acquire());
     }
 
-    public function testRunReturnsNullWhenLockCannotBeAcquired(): void
+    public function testRunReturnsFalseWhenLockCannotBeAcquired(): void
     {
         $first  = $this->locks->create('notifications.send', 60);
         $second = $this->locks->create('notifications.send', 60);
 
         $this->assertTrue($first->acquire());
-        $this->assertNull($second->run(static fn (): string => 'sent'));
+        $this->assertFalse($second->run(static fn (): string => 'sent'));
     }
 
     public function testLogicalNamesCanContainReservedCacheCharacters(): void

--- a/tests/system/Lock/LockTest.php
+++ b/tests/system/Lock/LockTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Lock;
+
+use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Exceptions\InvalidArgumentException;
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Lock\Exceptions\LockException;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Cache;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class LockTest extends CIUnitTestCase
+{
+    private Cache $config;
+    private LockManager $locks;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        helper('filesystem');
+
+        $this->config                    = new Cache();
+        $this->config->file['storePath'] = WRITEPATH . 'cache/LockTest';
+
+        if (! is_dir($this->config->file['storePath'])) {
+            mkdir($this->config->file['storePath'], 0777, true);
+        }
+
+        $this->locks = new LockManager(CacheFactory::getHandler($this->config, 'file'));
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Time::setTestNow();
+
+        if (is_dir($this->config->file['storePath'])) {
+            delete_files($this->config->file['storePath'], false, true);
+            rmdir($this->config->file['storePath']);
+        }
+    }
+
+    public function testLockCanBeAcquiredAndReleased(): void
+    {
+        $lock = $this->locks->create('reports.daily-export', 60);
+
+        $this->assertTrue($lock->acquire());
+        $this->assertFileExists($this->lockFile('reports.daily-export'));
+        $this->assertTrue($lock->isAcquired());
+        $this->assertTrue($lock->release());
+        $this->assertFalse($lock->isAcquired());
+        $this->assertTrue($this->locks->create('reports.daily-export', 60)->acquire());
+    }
+
+    public function testCompetingLockCannotBeAcquiredUntilReleased(): void
+    {
+        $first  = $this->locks->create('reports.daily-export', 60);
+        $second = $this->locks->create('reports.daily-export', 60);
+
+        $this->assertTrue($first->acquire());
+        $this->assertFalse($second->acquire());
+
+        $this->assertTrue($first->release());
+        $this->assertTrue($second->acquire());
+    }
+
+    public function testSameLockCannotBeAcquiredTwice(): void
+    {
+        $lock = $this->locks->create('reports.daily-export', 60);
+
+        $this->assertTrue($lock->acquire());
+        $this->assertFalse($lock->acquire());
+    }
+
+    public function testExpiredLockCanBeAcquiredByNewOwner(): void
+    {
+        Time::setTestNow('2026-01-01 12:00:00');
+
+        $first = $this->locks->create('imports.customer-feed', 10);
+
+        $this->assertTrue($first->acquire());
+
+        Time::setTestNow('2026-01-01 12:00:11');
+
+        $second = $this->locks->create('imports.customer-feed', 10);
+
+        $this->assertTrue($second->acquire());
+        $this->assertFalse($first->isAcquired());
+    }
+
+    public function testOnlyOwnerCanReleaseLock(): void
+    {
+        $first  = $this->locks->create('payments.settlement', 60);
+        $second = $this->locks->create('payments.settlement', 60);
+
+        $this->assertTrue($first->acquire());
+        $this->assertFalse($second->release());
+        $this->assertTrue($first->isAcquired());
+    }
+
+    public function testForceReleaseIgnoresOwner(): void
+    {
+        $first  = $this->locks->create('payments.settlement', 60);
+        $second = $this->locks->create('payments.settlement', 60);
+
+        $this->assertTrue($first->acquire());
+        $this->assertTrue($second->forceRelease());
+        $this->assertTrue($second->acquire());
+    }
+
+    public function testRestoreCanReleaseOwnedLock(): void
+    {
+        $lock = $this->locks->create('jobs.unique', 60);
+
+        $this->assertTrue($lock->acquire());
+
+        $restored = $this->locks->restore('jobs.unique', $lock->owner(), 60);
+
+        $this->assertTrue($restored->isAcquired());
+        $this->assertTrue($restored->release());
+        $this->assertFalse($lock->isAcquired());
+    }
+
+    public function testRefreshRequiresOwner(): void
+    {
+        $first  = $this->locks->create('cache.rebuild', 60);
+        $second = $this->locks->create('cache.rebuild', 60);
+
+        $this->assertTrue($first->acquire());
+        $this->assertTrue($first->refresh(120));
+        $this->assertFalse($second->refresh(120));
+    }
+
+    public function testRunReleasesLockAfterCallback(): void
+    {
+        $lock = $this->locks->create('notifications.send', 60);
+
+        $this->assertSame('sent', $lock->run(static fn (): string => 'sent'));
+        $this->assertTrue($this->locks->create('notifications.send', 60)->acquire());
+    }
+
+    public function testRunReturnsNullWhenLockCannotBeAcquired(): void
+    {
+        $first  = $this->locks->create('notifications.send', 60);
+        $second = $this->locks->create('notifications.send', 60);
+
+        $this->assertTrue($first->acquire());
+        $this->assertNull($second->run(static fn (): string => 'sent'));
+    }
+
+    public function testLogicalNamesCanContainReservedCacheCharacters(): void
+    {
+        $lock = $this->locks->create('tenant:1/payments/{settlement}', 60);
+
+        $this->assertTrue($lock->acquire());
+    }
+
+    public function testEmptyLockNameIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Lock name cannot be empty.');
+
+        $this->locks->create('');
+    }
+
+    public function testNonPositiveTtlIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Lock TTL must be a positive integer.');
+
+        $this->locks->create('reports.daily-export', 0);
+    }
+
+    public function testUnsupportedCacheHandlerThrows(): void
+    {
+        $locks = new LockManager(CacheFactory::getHandler($this->config, 'dummy'));
+
+        $this->expectException(LockException::class);
+        $this->expectExceptionMessage('does not support locks');
+
+        $locks->create('reports.daily-export');
+    }
+
+    private function lockFile(string $name): string
+    {
+        return rtrim($this->config->file['storePath'], '\\/') . '/lock_' . hash('sha256', $name);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -222,6 +222,7 @@ Libraries
 
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
+- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers.
 - **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 - **Logging:** Added :ref:`per-call context logging <logging-per-call-context>` with three new ``Config\Logger`` options (``$logContext``, ``$logContextTrace``, ``$logContextUsedKeys``). Per PSR-3, a ``Throwable`` in the ``exception`` context key is automatically normalized to a meaningful array. All options default to ``false``.
 

--- a/user_guide_src/source/extending/core_classes.rst
+++ b/user_guide_src/source/extending/core_classes.rst
@@ -51,6 +51,7 @@ The following is a list of the core system classes that are invoked every time C
 *  ``CodeIgniter\HTTP\SiteURIFactory``
 *  ``CodeIgniter\HTTP\URI``
 *  ``CodeIgniter\HTTP\UserAgent`` (if launched over HTTP)
+*  ``CodeIgniter\Lock\LockManager``
 *  ``CodeIgniter\Log\Logger``
 *  ``CodeIgniter\Log\Handlers\BaseHandler``
 *  ``CodeIgniter\Log\Handlers\FileHandler``

--- a/user_guide_src/source/libraries/index.rst
+++ b/user_guide_src/source/libraries/index.rst
@@ -15,6 +15,7 @@ Library Reference
     file_collections
     honeypot
     images
+    locks
     pagination
     publisher
     security

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -57,7 +57,7 @@ in a ``finally`` block.
 
 .. literalinclude:: locks/002.php
 
-If the lock cannot be acquired, ``run()`` returns ``null`` and the callback is
+If the lock cannot be acquired, ``run()`` returns ``false`` and the callback is
 not called.
 
 Blocking
@@ -143,7 +143,7 @@ Class Reference
 
         :param Closure $callback: The callback to run while the lock is held.
         :param int $waitSeconds: Maximum number of seconds to wait.
-        :returns: The callback result, or ``null`` if the lock was not acquired.
+        :returns: The callback result, or ``false`` if the lock was not acquired.
         :rtype: mixed
 
     .. php:method:: release()

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -88,7 +88,7 @@ If the configured cache handler does not support locks, creating a lock throws a
 ``CodeIgniter\Lock\Exceptions\LockException``.
 
 Custom cache handlers can support locks by implementing
-``CodeIgniter\Lock\LockStoreInterface``. This keeps lock support opt-in and does
+``CodeIgniter\Cache\LockStoreInterface``. This keeps lock support opt-in and does
 not require all cache handlers to implement lock operations.
 
 ***************

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -27,6 +27,12 @@ support locks.
     storage. The File handler is suitable for a single server. For multiple
     application servers, use a shared handler such as Redis.
 
+.. important:: Locks are stored in the configured cache handler. Clearing or
+    flushing that cache storage, for example with ``cache()->clean()`` or a
+    Redis ``FLUSHDB``, may remove active locks. Avoid clearing shared lock
+    storage while lock-protected work is running, or use a dedicated cache
+    store for locks when that separation is important.
+
 *************
 Example Usage
 *************

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -1,0 +1,162 @@
+############
+Atomic Locks
+############
+
+.. versionadded:: 4.8.0
+
+.. contents::
+    :local:
+    :depth: 2
+
+Atomic locks provide a simple way to prevent the same task from running
+concurrently across requests, CLI commands, or workers that share the same
+cache storage.
+
+Locks are advisory. Your code must acquire the lock before entering the
+critical section, and release it when the work is finished.
+
+*************
+Configuration
+*************
+
+The Locks library uses the Cache service. The cache handler must support atomic
+lock operations. The built-in **File**, **Redis**, and **Predis** cache handlers
+support locks.
+
+.. note:: Locks are most useful when all competing processes share the same cache
+    storage. The File handler is suitable for a single server. For multiple
+    application servers, use a shared handler such as Redis.
+
+*************
+Example Usage
+*************
+
+You can create a lock through the ``locks`` service. The second argument is the
+lock TTL, in seconds. The TTL prevents abandoned locks from being held forever
+if a process exits unexpectedly.
+
+.. literalinclude:: locks/001.php
+
+.. warning:: If the work takes longer than the lock TTL, another process may
+    acquire the same lock while the first process is still running. For
+    long-running work, choose a TTL that comfortably covers the operation, call
+    ``refresh()`` while the lock is held, or check ``isAcquired()`` before
+    performing irreversible side effects.
+
+Running a Callback
+==================
+
+The ``run()`` method acquires the lock, runs the callback, and releases the lock
+in a ``finally`` block.
+
+.. literalinclude:: locks/002.php
+
+If the lock cannot be acquired, ``run()`` returns ``null`` and the callback is
+not called.
+
+Blocking
+========
+
+The ``block()`` method waits up to the given number of seconds for the lock to
+become available:
+
+.. literalinclude:: locks/003.php
+
+Restoring a Lock by Owner
+=========================
+
+Each acquired lock has an owner token. You may pass this token to another
+process and restore the lock there, for example to release a lock from a queued
+worker that continues work started by the current request.
+
+.. literalinclude:: locks/004.php
+
+************************
+Locks and Cache Handlers
+************************
+
+The default File cache handler supports locks, so locks work without additional
+configuration in a standard application.
+
+If the configured cache handler does not support locks, creating a lock throws a
+``CodeIgniter\Lock\Exceptions\LockException``.
+
+Custom cache handlers can support locks by implementing
+``CodeIgniter\Lock\LockStoreInterface``. This keeps lock support opt-in and does
+not require all cache handlers to implement lock operations.
+
+***************
+Class Reference
+***************
+
+.. php:namespace:: CodeIgniter\Lock
+
+.. php:class:: LockManager
+
+    .. php:method:: create(string $name[, int $ttl = 300[, ?string $owner = null]])
+
+        :param string $name: The logical lock name.
+        :param int $ttl: Number of seconds before the lock expires.
+        :param string|null $owner: Optional owner token.
+        :returns: A lock instance.
+        :rtype: LockInterface
+
+        Creates a lock for the given logical name.
+
+    .. php:method:: restore(string $name, string $owner[, int $ttl = 300])
+
+        :param string $name: The logical lock name.
+        :param string $owner: The owner token.
+        :param int $ttl: Number of seconds before the lock expires.
+        :returns: A lock instance.
+        :rtype: LockInterface
+
+        Restores a lock instance for an existing owner token.
+
+.. php:interface:: LockInterface
+
+    .. php:method:: acquire()
+
+        :returns: ``true`` if the lock was acquired, ``false`` otherwise.
+        :rtype: bool
+
+    .. php:method:: block(int $seconds)
+
+        :param int $seconds: Maximum number of seconds to wait.
+        :returns: ``true`` if the lock was acquired, ``false`` otherwise.
+        :rtype: bool
+
+    .. php:method:: run(Closure $callback[, int $waitSeconds = 0])
+
+        :param Closure $callback: The callback to run while the lock is held.
+        :param int $waitSeconds: Maximum number of seconds to wait.
+        :returns: The callback result, or ``null`` if the lock was not acquired.
+        :rtype: mixed
+
+    .. php:method:: release()
+
+        :returns: ``true`` if the lock was released by its owner.
+        :rtype: bool
+
+    .. php:method:: forceRelease()
+
+        :returns: ``true`` if the lock was force released.
+        :rtype: bool
+
+        Releases the lock without checking the owner token.
+
+    .. php:method:: refresh([?int $ttl = null])
+
+        :param int|null $ttl: Number of seconds before the lock expires.
+        :returns: ``true`` if the owned lock was refreshed.
+        :rtype: bool
+
+    .. php:method:: isAcquired()
+
+        :returns: ``true`` if this lock instance still owns the lock.
+        :rtype: bool
+
+    .. php:method:: owner()
+
+        :returns: The owner token.
+        :rtype: string

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -84,12 +84,19 @@ Locks and Cache Handlers
 The default File cache handler supports locks, so locks work without additional
 configuration in a standard application.
 
-If the configured cache handler does not support locks, creating a lock throws a
+If the configured cache handler does not support locks, resolving the ``locks``
+service or constructing a lock manager throws a
 ``CodeIgniter\Lock\Exceptions\LockException``.
 
 Custom cache handlers can support locks by implementing
-``CodeIgniter\Cache\LockStoreInterface``. This keeps lock support opt-in and does
-not require all cache handlers to implement lock operations.
+``CodeIgniter\Cache\LockStoreProvider`` and returning a
+``CodeIgniter\Cache\LockStoreInterface`` instance. This keeps lock support
+opt-in and does not require all cache handlers to implement lock operations.
+
+Custom lock stores must implement owner-aware acquisition, release, refresh,
+force release, and owner lookup methods. The owner token is used to ensure
+``release()`` and ``refresh()`` only affect the process that currently owns the
+lock.
 
 ***************
 Class Reference

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -33,6 +33,11 @@ support locks.
     storage while lock-protected work is running, or use a dedicated cache
     store for locks when that separation is important.
 
+.. note:: File-backed locks clear released and expired lock contents, but may
+    leave empty lock files in the cache directory. These files do not represent
+    active locks and may be removed by normal cache cleanup when no
+    lock-protected work is running.
+
 *************
 Example Usage
 *************
@@ -89,14 +94,17 @@ service or constructing a lock manager throws a
 ``CodeIgniter\Lock\Exceptions\LockException``.
 
 Custom cache handlers can support locks by implementing
-``CodeIgniter\Cache\LockStoreProvider`` and returning a
+``CodeIgniter\Cache\LockStoreProviderInterface`` and returning a
 ``CodeIgniter\Cache\LockStoreInterface`` instance. This keeps lock support
 opt-in and does not require all cache handlers to implement lock operations.
 
 Custom lock stores must implement owner-aware acquisition, release, refresh,
-force release, and owner lookup methods. The owner token is used to ensure
-``release()`` and ``refresh()`` only affect the process that currently owns the
-lock.
+force release, and owner lookup methods. ``acquireLock()`` should atomically
+claim the lock for an owner token and TTL. ``releaseLock()`` and
+``refreshLock()`` must only affect the lock when the supplied owner token still
+matches the current owner. ``forceReleaseLock()`` intentionally ignores
+ownership, and ``getLockOwner()`` should return ``null`` when the lock is absent
+or expired.
 
 ***************
 Class Reference

--- a/user_guide_src/source/libraries/locks/001.php
+++ b/user_guide_src/source/libraries/locks/001.php
@@ -1,0 +1,13 @@
+<?php
+
+$lock = service('locks')->create('reports.daily-export', 300);
+
+if (! $lock->acquire()) {
+    return;
+}
+
+try {
+    // Run the work that must not overlap.
+} finally {
+    $lock->release();
+}

--- a/user_guide_src/source/libraries/locks/002.php
+++ b/user_guide_src/source/libraries/locks/002.php
@@ -1,0 +1,5 @@
+<?php
+
+$result = service('locks')
+    ->create('reports.daily-export', 300)
+    ->run(static fn () => build_daily_report());

--- a/user_guide_src/source/libraries/locks/003.php
+++ b/user_guide_src/source/libraries/locks/003.php
@@ -1,0 +1,11 @@
+<?php
+
+$lock = service('locks')->create('imports.customer-feed', 300);
+
+if ($lock->block(10)) {
+    try {
+        import_customer_feed();
+    } finally {
+        $lock->release();
+    }
+}

--- a/user_guide_src/source/libraries/locks/004.php
+++ b/user_guide_src/source/libraries/locks/004.php
@@ -1,0 +1,11 @@
+<?php
+
+$lock = service('locks')->create('exports.monthly', 300);
+
+if ($lock->acquire()) {
+    queue_export_job($lock->owner());
+}
+
+// Later, in another process:
+$restored = service('locks')->restore('exports.monthly', $owner);
+$restored->release();


### PR DESCRIPTION
**Description**

This PR proposes an atomic lock primitive for CodeIgniter 4.

The goal is to give applications a framework-native way to coordinate work across concurrent requests, CLI commands, queue workers, and other long-running processes.

The new lock component includes:

- `service('locks')`
- `CodeIgniter\Lock\LockManager`
- `CodeIgniter\Lock\LockInterface`
- `CodeIgniter\Lock\LockStoreInterface`
- File, Redis, and Predis lock-store support
- User guide documentation, examples, changelog entry, and Deptrac mapping

Supported lock operations include:

- `acquire()` for immediate acquisition
- `block()` for waiting up to a limited number of seconds
- `run()` for acquire/callback/release usage
- `release()` for owner-checked release
- `forceRelease()` for administrative release
- `refresh()` for extending a lock TTL
- `isAcquired()` for checking current ownership
- `owner()` for retrieving the owner token
- `restore()` for restoring a lock from a known owner token

**Background**

Some application work should only happen once at a time, even when multiple PHP processes are active.

Common examples include:

- Preventing overlapping invoice, payout, settlement, or report generation.
- Ensuring only one worker rebuilds a large cache, search index, or export file.
- Coordinating scheduled jobs so the same tenant/date/window is not processed twice.
- Protecting short critical sections such as third-party API token refreshes.

Today, applications can build these patterns manually with cache keys, database flags, or custom tables, but ownership and expiry details are easy to get subtly wrong. A small framework primitive gives users a safer and more consistent baseline without requiring every project to invent its own locking convention.

**Comparison**

This is a common framework-level primitive in other ecosystems:

- Laravel provides atomic locks through its cache system.
- Symfony provides a dedicated Lock component with multiple stores.
- Rails applications commonly use advisory locks or lock libraries for the same class of coordination problems.

This PR follows the same general idea, while keeping the implementation aligned with CodeIgniter’s existing services and cache-handler architecture.

Although the built-in stores are backed by cache handlers, locks are not cache values. They are a concurrency primitive with ownership, release, refresh, and blocking semantics. Keeping the public API under `CodeIgniter\Lock` avoids expanding `CacheInterface` with lock-specific methods and keeps lock support opt-in through `LockStoreInterface`.

This also leaves room for future non-cache stores, such as database or advisory-lock stores, without changing the user-facing API.

**Proposal Scope**

This is intended as a conservative proposal for review. I'll be happy to adjust if the team does not want this in core, prefers a different API, or wants it split differently.

This PR intentionally keeps the feature low-level. It currently does not add:

- Queue integration
- Scheduler integration
- Database lock storage
- Automatic lock renewal
- Fencing tokens
- Metrics or events
- New configuration options

The implementation focuses only on the primitive itself: acquire a named lock, verify ownership, release it safely, and allow the lock to expire if the process disappears.

Higher-level features can build on this later if the team wants them.

**Behavior**

Locks are advisory. Code that needs protection must explicitly acquire the lock before entering the critical section.

Each acquired lock has an owner token. `release()` and `refresh()` only succeed for the current owner, which helps avoid one process accidentally releasing another process’s lock after expiry and reacquisition.

Each lock has a TTL. This prevents abandoned locks from being held forever, but it also means long-running work must choose a suitable TTL, call `refresh()`, or check `isAcquired()` before irreversible side effects.

Logical lock names are hashed before reaching the cache handler, so applications can use descriptive names without worrying about reserved cache-key characters.

**Supported Cache Handlers**

This PR adds lock-store support for:

- File
- Redis
- Predis

Memcached is intentionally not included in this first version.

Memcached can acquire a lock with atomic `add()`, but safe owner-aware release and refresh require compare-and-delete / compare-and-touch semantics. A naive `get owner -> delete` flow can race if the lock expires and another owner acquires it between those operations.

I think Memcached support would be better handled in a separate PR with a CAS-based implementation and dedicated live tests, instead of adding a weaker implementation here.

**Testing**

This PR adds tests for:

- Basic acquire/release behavior
- Competing owners
- Re-acquiring after release
- Expired locks
- Owner-checked release
- Owner-checked refresh
- Force release
- Restoring a lock from an owner token
- `run()` callback behavior
- Logical names containing cache-reserved characters
- Invalid lock names and TTL values
- Unsupported cache handlers
- `service('locks')` behavior
- Redis and Predis live lock operations

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
