### PR TITLE
fix: prevent rate limiting in imagemagick pull from GitHub

### DIFF
--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -163,20 +163,49 @@ jobs:
             -N -C \
             -Q "CREATE DATABASE test COLLATE Latin1_General_100_CS_AS_SC_UTF8"
 
+      - name: Resolve latest ImageMagick release tag
+        if: ${{ contains(inputs.extra-extensions, 'imagick') }}
+        id: imagemagick-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=$(gh release view --repo vintagesucks/imagemagick-deb --json tagName --jq .tagName)
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache ImageMagick debs
+        if: ${{ contains(inputs.extra-extensions, 'imagick') }}
+        id: imagemagick-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/imagemagick-debs
+          key: imagemagick-debs-noble-amd64-${{ steps.imagemagick-release.outputs.tag }}
+
       - name: Install latest ImageMagick
         if: ${{ contains(inputs.extra-extensions, 'imagick') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGEMAGICK_TAG: ${{ steps.imagemagick-release.outputs.tag }}
+          IMAGEMAGICK_CACHE_HIT: ${{ steps.imagemagick-cache.outputs.cache-hit }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ghostscript poppler-data libmagickwand-dev
+          if [ "$IMAGEMAGICK_CACHE_HIT" != 'true' ]; then
+            echo "::group::Download ImageMagick debs ($IMAGEMAGICK_TAG)"
+            mkdir -p /tmp/imagemagick-debs
+            gh release download "$IMAGEMAGICK_TAG" \
+              --repo vintagesucks/imagemagick-deb \
+              --pattern '*noble_amd64*' \
+              --dir /tmp/imagemagick-debs \
+              --clobber
+            echo "::endgroup::"
+          else
+            echo "Using cached ImageMagick debs ($IMAGEMAGICK_TAG)"
+          fi
 
-          # Install ImageMagick 7 with AVIF rw+ support (vintagesucks/imagemagick-deb)
-          RELEASE_JSON=$(curl -fsSL https://api.github.com/repos/vintagesucks/imagemagick-deb/releases/latest)
-          mkdir -p /tmp/imagemagick-debs
-          while IFS= read -r url; do
-            curl -fsSL "$url" -o "/tmp/imagemagick-debs/$(basename "$url")"
-          done < <(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name | contains("noble_amd64")) | .browser_download_url')
-          sudo dpkg -i /tmp/imagemagick-debs/*.deb || true
-          sudo apt-get install -f -y
+          echo "::group::Install ImageMagick 7 with AVIF rw+ support"
+          sudo apt-get update
+          sudo apt-get install -y \
+            ghostscript poppler-data libmagickwand-dev \
+            /tmp/imagemagick-debs/*.deb
+          echo "::endgroup::"
 
       - name: Checkout base branch for PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Fixes HTTP 403 rate limiting error when imagemagick is tried to be downloaded from GitHub by caching earlier pulls.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
