### PR TITLE
refactor: keep CSP lazy when resetting Kint in worker mode

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -39,6 +39,8 @@ use Config\App;
 use Config\Cache;
 use Config\Feature;
 use Config\Services;
+use Kint\Kint;
+use Kint\Renderer\RichRenderer;
 use Locale;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
@@ -207,10 +209,17 @@ class CodeIgniter
             return;
         }
 
-        $csp = service('csp');
-        if ($csp->enabled()) {
-            RichRenderer::$js_nonce  = $csp->getScriptNonce();
-            RichRenderer::$css_nonce = $csp->getStyleNonce();
+        // Keep CSP lazy unless it was already initialized or explicitly enabled.
+        if (Services::has('csp') || config(App::class)->CSPEnabled) {
+            $csp = service('csp');
+
+            if ($csp->enabled()) {
+                RichRenderer::$js_nonce  = $csp->getScriptNonce();
+                RichRenderer::$css_nonce = $csp->getStyleNonce();
+            } else {
+                RichRenderer::$js_nonce  = null;
+                RichRenderer::$css_nonce = null;
+            }
         } else {
             RichRenderer::$js_nonce  = null;
             RichRenderer::$css_nonce = null;

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -1306,4 +1306,26 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertSame($csp->getStyleNonce(), RichRenderer::$css_nonce);
         $this->assertTrue(RichRenderer::$needs_pre_render);
     }
+
+    public function testResetForWorkerModeDoesNotLoadCspWhenDisabled(): void
+    {
+        $this->resetServices();
+
+        config(App::class)->CSPEnabled = false;
+
+        RichRenderer::$js_nonce         = 'stale-script-nonce';
+        RichRenderer::$css_nonce        = 'stale-style-nonce';
+        RichRenderer::$needs_pre_render = false;
+
+        $codeigniter = new MockCodeIgniter(new App());
+
+        $this->assertFalse(Services::has('csp'));
+
+        $codeigniter->resetForWorkerMode();
+
+        $this->assertFalse(Services::has('csp'));
+        $this->assertNull(RichRenderer::$js_nonce);
+        $this->assertNull(RichRenderer::$css_nonce);
+        $this->assertTrue(RichRenderer::$needs_pre_render);
+    }
 }


### PR DESCRIPTION
**Description**
This PR keeps the CSP lazy-loading behavior intact while still resetting the Kint static request-specific state correctly in worker mode.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
