### PR TITLE
feat: add closure-based database transaction helper

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1067,6 +1067,44 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
+     * Run the callback inside a transaction.
+     *
+     * @param callable(self): mixed $callback
+     */
+    public function transaction(callable $callback): mixed
+    {
+        if (! $this->transEnabled) {
+            return $callback($this);
+        }
+
+        if (! $this->transBegin()) {
+            return false;
+        }
+
+        try {
+            $result = $callback($this);
+        } catch (Throwable $e) {
+            try {
+                $this->transRollback();
+            } finally {
+                if ($this->transDepth > 0) {
+                    $this->transStatus = false;
+                } elseif ($this->transStrict === false) {
+                    $this->transStatus = true;
+                }
+            }
+
+            throw $e;
+        }
+
+        if (! $this->transComplete()) {
+            return false;
+        }
+
+        return $result;
+    }
+
+    /**
      * Begin Transaction
      */
     public function transBegin(bool $testMode = false): bool

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1069,7 +1069,11 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Run the callback inside a transaction.
      *
-     * @param callable(self): mixed $callback
+     * @template TReturn
+     *
+     * @param callable(self): TReturn $callback
+     *
+     * @return false|TReturn
      */
     public function transaction(callable $callback): mixed
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1090,6 +1090,10 @@ abstract class BaseConnection implements ConnectionInterface
         } catch (Throwable $e) {
             try {
                 $this->transRollback();
+            } catch (Throwable $rollbackException) {
+                log_message('error', 'Database: Transaction callback threw an exception before rollback failed: ' . $e);
+
+                throw $rollbackException;
             } finally {
                 if ($this->transDepth > 0) {
                     $this->transStatus = false;

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -136,7 +136,11 @@ interface ConnectionInterface
     /**
      * Run the callback inside a transaction.
      *
-     * @param callable(self): mixed $callback
+     * @template TReturn
+     *
+     * @param callable(self): TReturn $callback
+     *
+     * @return false|TReturn
      */
     public function transaction(callable $callback): mixed;
 

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -134,6 +134,13 @@ interface ConnectionInterface
     public function afterRollback(callable $callback): static;
 
     /**
+     * Run the callback inside a transaction.
+     *
+     * @param callable(self): mixed $callback
+     */
+    public function transaction(callable $callback): mixed;
+
+    /**
      * Returns an instance of the query builder for this connection.
      *
      * @param array|string $tableName Table name.

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -624,6 +624,40 @@ final class BaseConnectionTest extends CIUnitTestCase
         $this->assertSame(['rolled back'], $callbacks);
     }
 
+    public function testTransactionReturnsFalseWhenTransactionCannotBegin(): void
+    {
+        $callbackRan = false;
+
+        $db = new class ($this->options) extends MockConnection {
+            protected function _transBegin(): bool
+            {
+                return false;
+            }
+        };
+
+        $result = $db->transaction(static function () use (&$callbackRan): void {
+            $callbackRan = true;
+        });
+
+        $this->assertFalse($result);
+        $this->assertFalse($callbackRan);
+    }
+
+    public function testTransactionRunsCallbackWhenTransactionsAreDisabled(): void
+    {
+        $db = new MockConnection($this->options);
+        $db->transOff();
+
+        $result = $db->transaction(static function (BaseConnection $connection): string {
+            $connection->afterCommit(static function (): void {});
+
+            return 'not wrapped';
+        });
+
+        $this->assertSame('not wrapped', $result);
+        $this->assertSame(0, $db->transDepth);
+    }
+
     public function testCallFunctionDoesNotDoublePrefixAlreadyPrefixedName(): void
     {
         $db = new class ($this->options) extends MockConnection {

--- a/tests/system/Database/Live/TransactionClosureTest.php
+++ b/tests/system/Database/Live/TransactionClosureTest.php
@@ -42,8 +42,6 @@ final class TransactionClosureTest extends CIUnitTestCase
 
     /**
      * Sets $DBDebug to false.
-     *
-     * WARNING: this value will persist! take care to roll it back.
      */
     protected function disableDBDebug(): void
     {
@@ -211,6 +209,7 @@ final class TransactionClosureTest extends CIUnitTestCase
             $this->assertSame('Rollback callback failed.', $e->getMessage());
         }
 
+        $this->assertLogContains('error', 'Transaction callback failed.');
         $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
     }
 

--- a/tests/system/Database/Live/TransactionClosureTest.php
+++ b/tests/system/Database/Live/TransactionClosureTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class TransactionClosureTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    protected function setUp(): void
+    {
+        // Reset connection instance.
+        $this->db = Database::connect($this->DBGroup, false);
+
+        parent::setUp();
+    }
+
+    /**
+     * Sets $DBDebug to false.
+     *
+     * WARNING: this value will persist! take care to roll it back.
+     */
+    protected function disableDBDebug(): void
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', false);
+    }
+
+    /**
+     * Sets $DBDebug to true.
+     */
+    protected function enableDBDebug(): void
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', true);
+    }
+
+    public function testTransactionReturnsCallbackResultAndCommits(): void
+    {
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'name'        => 'Committed Job',
+                'description' => 'The transaction should commit.',
+            ]);
+
+            return 'committed';
+        });
+
+        $this->assertSame('committed', $result);
+        $this->seeInDatabase('job', ['name' => 'Committed Job']);
+    }
+
+    public function testTransactionPassesConnectionToCallback(): void
+    {
+        $result = $this->db->transaction(fn (BaseConnection $db): bool => $db === $this->db);
+
+        $this->assertTrue($result);
+    }
+
+    public function testTransactionRollsBackAndRethrowsCallbackException(): void
+    {
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->table('job')->insert([
+                    'name'        => 'Rolled Back Job',
+                    'description' => 'The transaction should roll back.',
+                ]);
+
+                throw new RuntimeException('Transaction callback failed.');
+            });
+            $this->fail('Expected transaction callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Transaction callback failed.', $e->getMessage());
+        }
+
+        $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
+    }
+
+    public function testTransactionReturnsFalseAndRollsBackWhenTransactionStatusFails(): void
+    {
+        $this->disableDBDebug();
+
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $builder = $db->table('job');
+
+            $builder->insert([
+                'name'        => 'Rolled Back Job',
+                'description' => 'The transaction should roll back.',
+            ]);
+            $builder->insert([
+                'id'          => 1,
+                'name'        => 'Duplicate Job',
+                'description' => 'This should fail.',
+            ]);
+
+            return 'not returned';
+        });
+
+        $this->assertFalse($result);
+        $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
+
+        $this->enableDBDebug();
+    }
+
+    public function testTransactionCallbackExceptionDoesNotPreventNonStrictStatusReset(): void
+    {
+        $this->disableDBDebug();
+        $this->db->transStrict(false);
+
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->table('job')->insert([
+                    'id'          => 1,
+                    'name'        => 'Duplicate Job',
+                    'description' => 'This should fail.',
+                ]);
+
+                throw new RuntimeException('Transaction callback failed.');
+            });
+            $this->fail('Expected transaction callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Transaction callback failed.', $e->getMessage());
+        }
+
+        $this->assertTrue($this->db->transStatus());
+
+        $this->enableDBDebug();
+    }
+
+    public function testTransactionRunsAfterCommitCallbacksAfterSuccessfulCommit(): void
+    {
+        $callbacks = [];
+
+        $result = $this->db->transaction(static function (BaseConnection $db) use (&$callbacks): string {
+            $db->afterCommit(static function () use (&$callbacks): void {
+                $callbacks[] = 'committed';
+            });
+
+            $db->table('job')->insert([
+                'name'        => 'Committed Job',
+                'description' => 'The transaction should commit.',
+            ]);
+
+            return 'committed';
+        });
+
+        $this->assertSame('committed', $result);
+        $this->assertSame(['committed'], $callbacks);
+    }
+
+    public function testTransactionRunsAfterRollbackCallbacksAfterCallbackException(): void
+    {
+        $callbacks = [];
+
+        try {
+            $this->db->transaction(static function (BaseConnection $db) use (&$callbacks): void {
+                $db->afterRollback(static function () use (&$callbacks): void {
+                    $callbacks[] = 'rolled back';
+                });
+
+                throw new RuntimeException('Transaction callback failed.');
+            });
+            $this->fail('Expected transaction callback exception.');
+        } catch (RuntimeException) {
+            // The rollback callback should have already run.
+        }
+
+        $this->assertSame(['rolled back'], $callbacks);
+    }
+
+    public function testRollbackCallbackExceptionBubblesWhenCallbackExceptionTriggersRollback(): void
+    {
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->afterRollback(static function (): void {
+                    throw new RuntimeException('Rollback callback failed.');
+                });
+
+                $db->table('job')->insert([
+                    'name'        => 'Rolled Back Job',
+                    'description' => 'The transaction should roll back.',
+                ]);
+
+                throw new RuntimeException('Transaction callback failed.');
+            });
+            $this->fail('Expected rollback callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Rollback callback failed.', $e->getMessage());
+        }
+
+        $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
+    }
+
+    public function testNestedTransactionCallbacksRunAfterOutermostCommit(): void
+    {
+        $callbacks = [];
+
+        $this->db->transStart();
+
+        $result = $this->db->transaction(static function (BaseConnection $db) use (&$callbacks): string {
+            $db->afterCommit(static function () use (&$callbacks): void {
+                $callbacks[] = 'committed';
+            });
+
+            return 'nested';
+        });
+
+        $this->assertSame('nested', $result);
+        $this->assertSame([], $callbacks);
+
+        $this->db->transComplete();
+
+        $this->assertSame(['committed'], $callbacks);
+    }
+
+    public function testNestedTransactionWritesCommitAfterOutermostCommit(): void
+    {
+        $this->db->transStart();
+
+        $this->db->table('job')->insert([
+            'name'        => 'Outer Job',
+            'description' => 'The outer transaction should commit.',
+        ]);
+
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'name'        => 'Inner Job',
+                'description' => 'The nested transaction should commit.',
+            ]);
+
+            return 'nested';
+        });
+
+        $this->assertSame('nested', $result);
+
+        $this->db->transComplete();
+
+        $this->seeInDatabase('job', ['name' => 'Outer Job']);
+        $this->seeInDatabase('job', ['name' => 'Inner Job']);
+    }
+
+    public function testNestedTransactionCallbackExceptionMarksOuterTransactionForRollback(): void
+    {
+        $this->db->transStart();
+
+        $this->db->table('job')->insert([
+            'name'        => 'Outer Job',
+            'description' => 'The outer transaction should roll back.',
+        ]);
+
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->table('job')->insert([
+                    'name'        => 'Inner Job',
+                    'description' => 'The nested transaction should roll back.',
+                ]);
+
+                throw new RuntimeException('Nested transaction callback failed.');
+            });
+            $this->fail('Expected nested transaction callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Nested transaction callback failed.', $e->getMessage());
+        }
+
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->dontSeeInDatabase('job', ['name' => 'Outer Job']);
+        $this->dontSeeInDatabase('job', ['name' => 'Inner Job']);
+    }
+
+    public function testAfterCommitCallbackExceptionBubblesAfterTransactionCommit(): void
+    {
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->table('job')->insert([
+                    'name'        => 'Committed Job',
+                    'description' => 'The transaction should still commit.',
+                ]);
+                $db->afterCommit(static function (): void {
+                    throw new RuntimeException('Commit callback failed.');
+                });
+            });
+            $this->fail('Expected commit callback exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Commit callback failed.', $e->getMessage());
+        }
+
+        $this->seeInDatabase('job', ['name' => 'Committed Job']);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,7 +43,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()`` and ``afterRollback()`` methods.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
 
@@ -197,6 +197,7 @@ Database
 ========
 
 - Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
+- Added the ``transaction()`` method to database connections to run a callback inside a transaction. See :ref:`transactions-closure`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -49,6 +49,36 @@ You can run as many queries as you want between the ``transStart()``/``transComp
 methods and they will all be committed or rolled back based on the success
 or failure of any given query.
 
+.. _transactions-closure:
+
+Running Transactions with a Closure
+===================================
+
+.. versionadded:: 4.8.0
+
+You may also run a transaction with the ``transaction()`` method. It starts a
+transaction, runs the callback, commits when the callback completes
+successfully, and rolls back if the callback throws an exception:
+
+.. literalinclude:: transactions/012.php
+
+The callback receives the current database connection as its first argument.
+If the transaction commits successfully, ``transaction()`` returns the callback
+return value. If the transaction cannot begin, or if a query failure marks the
+transaction as failed without throwing an exception, ``transaction()`` rolls
+back and returns ``false``.
+
+If the callback throws an exception, ``transaction()`` rolls back and rethrows
+the original exception.
+
+If an ``afterRollback()`` callback throws while ``transaction()`` is rolling
+back, that callback exception bubbles to the caller instead of the normal
+``false`` return value or the original callback exception.
+
+Callbacks registered with ``afterCommit()`` or ``afterRollback()`` inside the
+transaction callback follow the same rules as other transaction callbacks: they
+run only after the outermost transaction commits or rolls back.
+
 Strict Mode
 ===========
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -68,6 +68,9 @@ return value. If the transaction cannot begin, or if a query failure marks the
 transaction as failed without throwing an exception, ``transaction()`` rolls
 back and returns ``false``.
 
+If transactions are disabled, ``transaction()`` does not start a transaction.
+It runs the callback and returns the callback result.
+
 If the callback throws an exception, ``transaction()`` rolls back and rethrows
 the original exception.
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -62,7 +62,7 @@ successfully, and rolls back if the callback throws an exception:
 
 .. literalinclude:: transactions/012.php
 
-The callback receives the current database connection as its first argument.
+The callback receives the current database connection as its only argument.
 If the transaction commits successfully, ``transaction()`` returns the callback
 return value. If the transaction cannot begin, or if a query failure marks the
 transaction as failed without throwing an exception, ``transaction()`` rolls

--- a/user_guide_src/source/database/transactions/012.php
+++ b/user_guide_src/source/database/transactions/012.php
@@ -1,0 +1,14 @@
+<?php
+
+$result = $this->db->transaction(static function ($db) use ($order, $id) {
+    $db->table('orders')->insert($order);
+    $orderId = $db->insertID();
+
+    $db->table('stock')->where('id', $id)->decrement('qty');
+
+    $db->afterCommit(static function (): void {
+        // Dispatch a job or send a notification after commit.
+    });
+
+    return $orderId;
+});


### PR DESCRIPTION
**Description**

This PR proposes adding `transaction()` to database connections as a closure-based helper for common transactional work.

It allows related writes to be expressed in one focused block while CodeIgniter handles the existing begin, commit, rollback, and exception flow:

```php
$result = $db->transaction(static function ($db) {
    $db->table('orders')->insert($order);
    $orderId = $db->insertID();

    $db->table('stock')->where('id', $id)->decrement('qty');

    return $orderId;
});
```

The goal is to improve developer experience and readability for the common "do these writes atomically" case without replacing the existing manual transaction APIs. Users who need full manual control can continue using `transStart()` / `transComplete()` or `transBegin()` / `transCommit()` / `transRollback()`.

**Behavior**

The helper is intentionally thin and follows CodeIgniter’s existing transaction semantics:

- Returns the callback result after a successful commit.
- Rolls back and rethrows if the callback throws.
- Returns `false` when the transaction cannot begin or when transaction status fails without an exception.
- Supports nested transactions through the existing transaction depth behavior.
- Works with `afterCommit()` and `afterRollback()` callbacks.

If an `afterRollback()` callback throws during rollback, that callback exception bubbles to the caller. The docs call this out explicitly so exception precedence is not implicit.

**Notes**

This adds `transaction()` to `ConnectionInterface`, so custom interface implementations would need to add the new method. The changelog lists this under interface changes.

Tests cover success, rollback, failed status, disabled transactions, begin failure, transaction callbacks, callback exception precedence, and nested transaction behavior.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide