### PR TITLE
feat: add Time between(), min(), and max() methods

### DIFF
--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -1021,13 +1021,11 @@ trait TimeTrait
      *
      * If $start is after $end, the arguments are swapped.
      *
-     * @param DateTimeInterface|self|string $start
-     * @param DateTimeInterface|self|string $end
-     * @param string|null                   $timezone Used only when $start or $end is a string.
+     * @param string|null $timezone Used only when $start or $end is a string.
      *
      * @throws Exception
      */
-    public function between($start, $end, bool $equals = true, ?string $timezone = null): bool
+    public function between(DateTimeInterface|string $start, DateTimeInterface|string $end, bool $inclusive = true, ?string $timezone = null): bool
     {
         $start = $this->normalizeTime($start, $timezone);
         $end   = $this->normalizeTime($end, $timezone);
@@ -1036,7 +1034,7 @@ trait TimeTrait
             [$start, $end] = [$end, $start];
         }
 
-        if ($equals) {
+        if ($inclusive) {
             return ! $this->isBefore($start) && ! $this->isAfter($end);
         }
 
@@ -1048,12 +1046,11 @@ trait TimeTrait
      *
      * If null is provided, compares against now in the current timezone.
      *
-     * @param DateTimeInterface|self|string|null $time
-     * @param string|null                        $timezone Used only when $time is a string or null.
+     * @param string|null $timezone Used only when $time is a string or null.
      *
      * @throws Exception
      */
-    public function min($time = null, ?string $timezone = null): static
+    public function min(DateTimeInterface|string|null $time = null, ?string $timezone = null): static
     {
         $time = $this->normalizeTime($time, $timezone);
 
@@ -1065,12 +1062,11 @@ trait TimeTrait
      *
      * If null is provided, compares against now in the current timezone.
      *
-     * @param DateTimeInterface|self|string|null $time
-     * @param string|null                        $timezone Used only when $time is a string or null.
+     * @param string|null $timezone Used only when $time is a string or null.
      *
      * @throws Exception
      */
-    public function max($time = null, ?string $timezone = null): static
+    public function max(DateTimeInterface|string|null $time = null, ?string $timezone = null): static
     {
         $time = $this->normalizeTime($time, $timezone);
 
@@ -1206,11 +1202,9 @@ trait TimeTrait
      * or the current instance's timezone when omitted. If null is provided,
      * the current time is used in the same timezone.
      *
-     * @param DateTimeInterface|self|string|null $time
-     *
      * @throws Exception
      */
-    private function normalizeTime($time, ?string $timezone = null): static
+    private function normalizeTime(DateTimeInterface|string|null $time, ?string $timezone = null): static
     {
         if ($time instanceof DateTimeInterface) {
             return static::createFromInstance($time, $this->locale);

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\I18n;
 use CodeIgniter\I18n\Exceptions\I18nException;
 use DateInterval;
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
@@ -1184,15 +1185,25 @@ trait TimeTrait
      *
      * @param DateTimeInterface|self|string $time
      *
-     * @return DateTime
+     * @return DateTime|static
      *
      * @throws Exception
      */
     public function getUTCObject($time, ?string $timezone = null)
     {
-        return $this->normalizeTime($time, $timezone)
-            ->toDateTime()
-            ->setTimezone(new DateTimeZone('UTC'));
+        if ($time instanceof static) {
+            $time = $time->toDateTime();
+        } elseif (is_string($time)) {
+            $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
+            $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
+            $time     = new DateTime($time, $timezone);
+        }
+
+        if ($time instanceof DateTime || $time instanceof DateTimeImmutable) {
+            return $time->setTimezone(new DateTimeZone('UTC'));
+        }
+
+        return $time;
     }
 
     /**

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -1212,17 +1212,15 @@ trait TimeTrait
      */
     private function normalizeTime($time, ?string $timezone = null): static
     {
-        if ($time === null) {
-            $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
+        $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
 
+        if ($time === null) {
             return static::now($timezone, $this->locale);
         }
 
         if ($time instanceof DateTimeInterface) {
             return static::createFromInstance($time, $this->locale);
         }
-
-        $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
 
         return new static($time, $timezone, $this->locale);
     }

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -1212,14 +1212,14 @@ trait TimeTrait
      */
     private function normalizeTime($time, ?string $timezone = null): static
     {
+        if ($time instanceof DateTimeInterface) {
+            return static::createFromInstance($time, $this->locale);
+        }
+
         $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
 
         if ($time === null) {
             return static::now($timezone, $this->locale);
-        }
-
-        if ($time instanceof DateTimeInterface) {
-            return static::createFromInstance($time, $this->locale);
         }
 
         return new static($time, $timezone, $this->locale);

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\I18n;
 use CodeIgniter\I18n\Exceptions\I18nException;
 use DateInterval;
 use DateTime;
-use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
@@ -966,14 +965,7 @@ trait TimeTrait
      */
     public function sameAs($testTime, ?string $timezone = null): bool
     {
-        if ($testTime instanceof DateTimeInterface) {
-            $testTime = $testTime->format('Y-m-d H:i:s.u O');
-        } elseif (is_string($testTime)) {
-            $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
-            $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
-            $testTime = new DateTime($testTime, $timezone);
-            $testTime = $testTime->format('Y-m-d H:i:s.u O');
-        }
+        $testTime = $this->normalizeTime($testTime, $timezone)->format('Y-m-d H:i:s.u O');
 
         $ourTime = $this->format('Y-m-d H:i:s.u O');
 
@@ -1022,6 +1014,67 @@ trait TimeTrait
         }
 
         return $ourTimestamp > $testTimestamp;
+    }
+
+    /**
+     * Determines if the current instance's time is between two others.
+     *
+     * If $start is after $end, the arguments are swapped.
+     *
+     * @param DateTimeInterface|self|string $start
+     * @param DateTimeInterface|self|string $end
+     * @param string|null                   $timezone Used only when $start or $end is a string.
+     *
+     * @throws Exception
+     */
+    public function between($start, $end, bool $equals = true, ?string $timezone = null): bool
+    {
+        $start = $this->normalizeTime($start, $timezone);
+        $end   = $this->normalizeTime($end, $timezone);
+
+        if ($start->isAfter($end)) {
+            [$start, $end] = [$end, $start];
+        }
+
+        if ($equals) {
+            return ! $this->isBefore($start) && ! $this->isAfter($end);
+        }
+
+        return $this->isAfter($start) && $this->isBefore($end);
+    }
+
+    /**
+     * Returns the earlier of the current instance and the provided time.
+     *
+     * If null is provided, compares against now in the current timezone.
+     *
+     * @param DateTimeInterface|self|string|null $time
+     * @param string|null                        $timezone Used only when $time is a string or null.
+     *
+     * @throws Exception
+     */
+    public function min($time = null, ?string $timezone = null): static
+    {
+        $time = $this->normalizeTime($time, $timezone);
+
+        return $this->isAfter($time) ? $time : $this;
+    }
+
+    /**
+     * Returns the later of the current instance and the provided time.
+     *
+     * If null is provided, compares against now in the current timezone.
+     *
+     * @param DateTimeInterface|self|string|null $time
+     * @param string|null                        $timezone Used only when $time is a string or null.
+     *
+     * @throws Exception
+     */
+    public function max($time = null, ?string $timezone = null): static
+    {
+        $time = $this->normalizeTime($time, $timezone);
+
+        return $this->isBefore($time) ? $time : $this;
     }
 
     /**
@@ -1114,17 +1167,10 @@ trait TimeTrait
      */
     public function difference($testTime, ?string $timezone = null)
     {
-        if (is_string($testTime)) {
-            $timezone = ($timezone !== null) ? new DateTimeZone($timezone) : $this->timezone;
-            $testTime = new DateTime($testTime, $timezone);
-        } elseif ($testTime instanceof static) {
-            $testTime = $testTime->toDateTime();
-        }
-
-        assert($testTime instanceof DateTime);
+        $testTime = $this->normalizeTime($testTime, $timezone)->toDateTime();
 
         if ($this->timezone->getOffset($this) !== $testTime->getTimezone()->getOffset($this)) {
-            $testTime = $this->getUTCObject($testTime, $timezone);
+            $testTime = $this->getUTCObject($testTime);
             $ourTime  = $this->getUTCObject($this);
         } else {
             $ourTime = $this->toDateTime();
@@ -1142,25 +1188,43 @@ trait TimeTrait
      *
      * @param DateTimeInterface|self|string $time
      *
-     * @return DateTime|static
+     * @return DateTime
      *
      * @throws Exception
      */
     public function getUTCObject($time, ?string $timezone = null)
     {
-        if ($time instanceof static) {
-            $time = $time->toDateTime();
-        } elseif (is_string($time)) {
+        return $this->normalizeTime($time, $timezone)
+            ->toDateTime()
+            ->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    /**
+     * Returns a Time instance normalized to the current locale.
+     *
+     * If $time is a string, it will be parsed using the provided timezone,
+     * or the current instance's timezone when omitted. If null is provided,
+     * the current time is used in the same timezone.
+     *
+     * @param DateTimeInterface|self|string|null $time
+     *
+     * @throws Exception
+     */
+    private function normalizeTime($time, ?string $timezone = null): static
+    {
+        if ($time === null) {
             $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
-            $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
-            $time     = new DateTime($time, $timezone);
+
+            return static::now($timezone, $this->locale);
         }
 
-        if ($time instanceof DateTime || $time instanceof DateTimeImmutable) {
-            $time = $time->setTimezone(new DateTimeZone('UTC'));
+        if ($time instanceof DateTimeInterface) {
+            return static::createFromInstance($time, $this->locale);
         }
 
-        return $time;
+        $timezone = in_array($timezone, [null, '', '0'], true) ? $this->timezone : $timezone;
+
+        return new static($time, $timezone, $this->locale);
     }
 
     /**

--- a/tests/system/I18n/TimeLegacyTest.php
+++ b/tests/system/I18n/TimeLegacyTest.php
@@ -923,6 +923,74 @@ final class TimeLegacyTest extends CIUnitTestCase
         $this->assertTrue($time2->isAfter($time1));
     }
 
+    public function testBetweenInclusive(): void
+    {
+        $time  = new TimeLegacy('2024-01-01 12:00:00.123456');
+        $start = new TimeLegacy('2024-01-01 12:00:00.123456');
+        $end   = new TimeLegacy('2024-01-01 12:00:01.000000');
+
+        $this->assertTrue($time->between($start, $end));
+    }
+
+    public function testBetweenExclusive(): void
+    {
+        $time  = new TimeLegacy('2024-01-01 12:00:00.123456');
+        $start = new TimeLegacy('2024-01-01 12:00:00.123456');
+        $end   = new TimeLegacy('2024-01-01 12:00:01.000000');
+
+        $this->assertFalse($time->between($start, $end, false));
+    }
+
+    public function testBetweenSwapsReversedBounds(): void
+    {
+        $time = TimeLegacy::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->between('2024-01-01 13:00:00', '2024-01-01 12:00:00'));
+    }
+
+    public function testBetweenSupportsTimezoneForStringInputs(): void
+    {
+        $time = TimeLegacy::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->between('2024-01-01 13:00:00', '2024-01-01 14:00:00', true, 'Europe/Warsaw'));
+    }
+
+    public function testMinWithNullUsesNow(): void
+    {
+        TimeLegacy::setTestNow('2024-01-01 12:00:00', 'UTC');
+
+        $past   = TimeLegacy::parse('2024-01-01 11:59:59', 'UTC');
+        $future = TimeLegacy::parse('2024-01-01 12:00:01', 'UTC');
+
+        $this->assertSame($past, $past->min());
+        $this->assertTrue($future->min()->sameAs(TimeLegacy::now('UTC')));
+    }
+
+    public function testMinSupportsTimezoneForStringInputs(): void
+    {
+        $time = TimeLegacy::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->min('2024-01-01 13:00:00', 'Europe/Warsaw')->sameAs('2024-01-01 13:00:00', 'Europe/Warsaw'));
+    }
+
+    public function testMaxWithNullUsesNow(): void
+    {
+        TimeLegacy::setTestNow('2024-01-01 12:00:00', 'UTC');
+
+        $past   = TimeLegacy::parse('2024-01-01 11:59:59', 'UTC');
+        $future = TimeLegacy::parse('2024-01-01 12:00:01', 'UTC');
+
+        $this->assertTrue($past->max()->sameAs(TimeLegacy::now('UTC')));
+        $this->assertSame($future, $future->max());
+    }
+
+    public function testMaxSupportsTimezoneForStringInputs(): void
+    {
+        $time = TimeLegacy::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->max('2024-01-01 13:00:00', 'Europe/Warsaw')->sameAs($time));
+    }
+
     public function testHumanizeYearsSingle(): void
     {
         TimeLegacy::setTestNow('March 10, 2017', 'America/Chicago');

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1081,6 +1081,17 @@ final class TimeTest extends CIUnitTestCase
         $this->assertTrue($time->between($start, $end));
     }
 
+    public function testGetUTCObjectPreservesDateTimeImmutable(): void
+    {
+        $time      = Time::parse('2024-01-01 12:30:00', 'Europe/Warsaw');
+        $immutable = new DateTimeImmutable('2024-01-01 13:30:00', new DateTimeZone('Europe/Warsaw'));
+        $utcTime   = $time->getUTCObject($immutable);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $utcTime);
+        $this->assertSame('UTC', $utcTime->getTimezone()->getName());
+        $this->assertSame('2024-01-01 12:30:00.000000', $utcTime->format('Y-m-d H:i:s.u'));
+    }
+
     public function testMinReturnsEarlierTime(): void
     {
         $time  = new Time('2024-01-01 12:00:00');

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1040,6 +1040,117 @@ final class TimeTest extends CIUnitTestCase
         $this->assertFalse($time2->isAfter($time1));
     }
 
+    public function testBetweenInclusive(): void
+    {
+        $time  = new Time('2024-01-01 12:00:00.123456');
+        $start = new Time('2024-01-01 12:00:00.123456');
+        $end   = new Time('2024-01-01 12:00:01.000000');
+
+        $this->assertTrue($time->between($start, $end));
+    }
+
+    public function testBetweenExclusive(): void
+    {
+        $time  = new Time('2024-01-01 12:00:00.123456');
+        $start = new Time('2024-01-01 12:00:00.123456');
+        $end   = new Time('2024-01-01 12:00:01.000000');
+
+        $this->assertFalse($time->between($start, $end, false));
+    }
+
+    public function testBetweenSwapsReversedBounds(): void
+    {
+        $time = Time::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->between('2024-01-01 13:00:00', '2024-01-01 12:00:00'));
+    }
+
+    public function testBetweenSupportsTimezoneForStringInputs(): void
+    {
+        $time = Time::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->between('2024-01-01 13:00:00', '2024-01-01 14:00:00', true, 'Europe/Warsaw'));
+    }
+
+    public function testBetweenSupportsDateTimeImmutable(): void
+    {
+        $time  = Time::parse('2024-01-01 12:30:00', 'UTC');
+        $start = new DateTimeImmutable('2024-01-01 12:00:00', new DateTimeZone('UTC'));
+        $end   = new DateTimeImmutable('2024-01-01 13:00:00', new DateTimeZone('UTC'));
+
+        $this->assertTrue($time->between($start, $end));
+    }
+
+    public function testMinReturnsEarlierTime(): void
+    {
+        $time  = new Time('2024-01-01 12:00:00');
+        $later = new Time('2024-01-01 12:00:01');
+
+        $this->assertSame($time, $time->min($later));
+        $this->assertTrue($later->min($time)->sameAs($time));
+    }
+
+    public function testMinReturnsCurrentInstanceOnEqualTime(): void
+    {
+        $time  = new Time('2024-01-01 12:00:00');
+        $equal = new Time('2024-01-01 12:00:00');
+
+        $this->assertSame($time, $time->min($equal));
+    }
+
+    public function testMinSupportsTimezoneForStringInputs(): void
+    {
+        $time = Time::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->min('2024-01-01 13:00:00', 'Europe/Warsaw')->sameAs('2024-01-01 13:00:00', 'Europe/Warsaw'));
+    }
+
+    public function testMinWithNullUsesNow(): void
+    {
+        Time::setTestNow('2024-01-01 12:00:00', 'UTC');
+
+        $past   = Time::parse('2024-01-01 11:59:59', 'UTC');
+        $future = Time::parse('2024-01-01 12:00:01', 'UTC');
+
+        $this->assertSame($past, $past->min());
+        $this->assertTrue($future->min()->sameAs(Time::now('UTC')));
+    }
+
+    public function testMaxReturnsLaterTime(): void
+    {
+        $time    = new Time('2024-01-01 12:00:00');
+        $earlier = new Time('2024-01-01 11:59:59');
+
+        $this->assertSame($time, $time->max($earlier));
+        $this->assertTrue($earlier->max($time)->sameAs($time));
+    }
+
+    public function testMaxReturnsCurrentInstanceOnEqualTime(): void
+    {
+        $time  = new Time('2024-01-01 12:00:00');
+        $equal = new Time('2024-01-01 12:00:00');
+
+        $this->assertSame($time, $time->max($equal));
+    }
+
+    public function testMaxSupportsTimezoneForStringInputs(): void
+    {
+        $time = Time::parse('2024-01-01 12:30:00', 'UTC');
+
+        $this->assertTrue($time->max('2024-01-01 13:00:00', 'Europe/Warsaw')->sameAs($time));
+    }
+
+    public function testMaxWithNullUsesNow(): void
+    {
+        Time::setTestNow('2024-01-01 12:00:00', 'UTC');
+
+        $past   = Time::parse('2024-01-01 11:59:59', 'UTC');
+        $future = Time::parse('2024-01-01 12:00:01', 'UTC');
+
+        $this->assertTrue($past->max()->sameAs(Time::now('UTC')));
+        $this->assertSame($future, $future->max());
+    }
+
     public function testIsPast(): void
     {
         Time::setTestNow('2025-12-30 12:00:00', 'Asia/Tehran');

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -268,6 +268,7 @@ Others
 - Float and Double casting now throws ``CastException::forInvalidFloatRoundingMode()`` if an rounding mode other than up, down, even or odd is provided.
 - **Environment:** Added ``CodeIgniter\EnvironmentDetector`` class and corresponding ``environment`` service as a mockable wrapper around the ``ENVIRONMENT`` constant.
   Framework internals that previously compared ``ENVIRONMENT`` directly now go through this service, making environment-specific branches reachable in tests via ``Services::injectMock()``. See :ref:`environment-detector-service`.
+- **Time:** Added ``Time::between()``, ``Time::min()``, and ``Time::max()`` comparison helpers. See :ref:`between <time-comparing-two-times-between>`, :ref:`min <time-comparing-two-times-min>`, and :ref:`max <time-comparing-two-times-max>`.
 
 ***************
 Message Changes

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -401,7 +401,7 @@ between()
 .. versionadded:: 4.8.0
 
 Determines if the current instance is between two other times. By default, the start and end bounds are included.
-Pass ``false`` as the third argument to exclude both bounds:
+Pass ``false`` as the third ``$inclusive`` argument to exclude both bounds:
 
 .. literalinclude:: time/045.php
 

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -393,6 +393,52 @@ Works exactly the same as ``isBefore()`` except checks if the time is after the 
 
 .. literalinclude:: time/037.php
 
+.. _time-comparing-two-times-between:
+
+between()
+---------
+
+.. versionadded:: 4.8.0
+
+Determines if the current instance is between two other times. By default, the start and end bounds are included.
+Pass ``false`` as the third argument to exclude both bounds:
+
+.. literalinclude:: time/045.php
+
+Like other comparison methods, the values can be ``Time`` instances, ``DateTimeInterface`` instances, or strings that
+``DateTime`` can parse. String values may use a timezone string as the fourth parameter. Otherwise, they are parsed
+using the current instance's timezone. If ``$start`` is after ``$end``, the arguments are swapped automatically.
+
+.. _time-comparing-two-times-min:
+
+min()
+-----
+
+.. versionadded:: 4.8.0
+
+Returns the earlier of the current instance and the provided time:
+
+.. literalinclude:: time/046.php
+
+If ``null`` is provided, it compares against ``Time::now()`` in the current instance's timezone. String values may use
+a timezone string as the second parameter. Otherwise, they are parsed using the current instance's timezone. If both
+times are equal, the current instance is returned.
+
+.. _time-comparing-two-times-max:
+
+max()
+-----
+
+.. versionadded:: 4.8.0
+
+Returns the later of the current instance and the provided time:
+
+.. literalinclude:: time/047.php
+
+If ``null`` is provided, it compares against ``Time::now()`` in the current instance's timezone. String values may use
+a timezone string as the second parameter. Otherwise, they are parsed using the current instance's timezone. If both
+times are equal, the current instance is returned.
+
 .. _time-comparing-two-times-isPast:
 
 isPast()

--- a/user_guide_src/source/libraries/time/045.php
+++ b/user_guide_src/source/libraries/time/045.php
@@ -1,0 +1,10 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time = Time::parse('2024-01-01 12:30:00', 'UTC');
+
+$time->between('2024-01-01 12:00:00', '2024-01-01 13:00:00');        // true
+$time->between('2024-01-01 13:00:00', '2024-01-01 12:00:00');        // true
+$time->between('2024-01-01 13:00:00', '2024-01-01 14:00:00', true, 'Europe/Warsaw'); // true
+$time->between('2024-01-01 12:30:00', '2024-01-01 13:00:00', false); // false

--- a/user_guide_src/source/libraries/time/046.php
+++ b/user_guide_src/source/libraries/time/046.php
@@ -1,0 +1,11 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time1 = Time::parse('2024-01-01 12:00:00', 'UTC');
+$time2 = Time::parse('2024-01-01 13:00:00', 'UTC');
+
+$time1->min($time2);                // 2024-01-01 12:00:00 UTC
+$time2->min('2024-01-01 12:30:00'); // 2024-01-01 12:30:00 UTC
+$time2->min('2024-01-01 13:00:00', 'Europe/Warsaw'); // 2024-01-01 12:00:00 UTC
+$time1->min();                      // earlier of $time1 and now

--- a/user_guide_src/source/libraries/time/047.php
+++ b/user_guide_src/source/libraries/time/047.php
@@ -1,0 +1,11 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time1 = Time::parse('2024-01-01 12:00:00', 'UTC');
+$time2 = Time::parse('2024-01-01 13:00:00', 'UTC');
+
+$time1->max($time2);                // 2024-01-01 13:00:00 UTC
+$time1->max('2024-01-01 12:30:00'); // 2024-01-01 12:30:00 UTC
+$time1->max('2024-01-01 13:00:00', 'Europe/Warsaw'); // 2024-01-01 12:00:00 UTC
+$time2->max();                      // later of $time2 and now


### PR DESCRIPTION
**Description**
This PR adds `between()`, `min()`, and `max()` methods to the `TimeTrait`.

Closes #10143

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
