### PR TITLE
feat: add Query Builder whereColumn methods

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -747,7 +747,7 @@ class BaseBuilder
      *
      * @throws InvalidArgumentException
      */
-    public function whereColumn(string $first, string $second, ?bool $escape = null)
+    public function whereColumn(string $first, string $second, ?bool $escape = null): static
     {
         return $this->whereColumnHaving('QBWhere', $first, $second, 'AND ', $escape);
     }
@@ -763,7 +763,7 @@ class BaseBuilder
      *
      * @throws InvalidArgumentException
      */
-    public function orWhereColumn(string $first, string $second, ?bool $escape = null)
+    public function orWhereColumn(string $first, string $second, ?bool $escape = null): static
     {
         return $this->whereColumnHaving('QBWhere', $first, $second, 'OR ', $escape);
     }
@@ -782,7 +782,7 @@ class BaseBuilder
      *
      * @throws InvalidArgumentException
      */
-    protected function whereColumnHaving(string $qbKey, string $first, string $second, string $type = 'AND ', ?bool $escape = null)
+    protected function whereColumnHaving(string $qbKey, string $first, string $second, string $type = 'AND ', ?bool $escape = null): static
     {
         [$first, $operator] = $this->parseWhereColumnFirst($first);
         $second             = trim($second);
@@ -793,9 +793,7 @@ class BaseBuilder
             throw new InvalidArgumentException(sprintf('%s() expects $first and $second to be non-empty strings', $caller));
         }
 
-        if (! is_bool($escape)) {
-            $escape = $this->db->protectIdentifiers;
-        }
+        $escape ??= $this->db->protectIdentifiers;
 
         $prefix = $this->{$qbKey} === [] ? $this->groupGetType('') : $this->groupGetType($type);
 
@@ -3278,6 +3276,8 @@ class BaseBuilder
     }
 
     /**
+     * @used-by compileWhereHaving()
+     *
      * @param array{columnComparison: true, condition: string, escape: bool, first: string, operator: string, second: string} $condition
      */
     private function compileColumnComparison(array $condition): string

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -737,6 +737,94 @@ class BaseBuilder
     }
 
     /**
+     * Generates a WHERE clause that compares two columns.
+     *
+     * @param non-empty-string      $first    First column name
+     * @param non-empty-string|null $operator Comparison operator, or second column name when $second is null
+     * @param non-empty-string|null $second   Second column name
+     * @param bool|null             $escape   Whether to protect identifiers
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    public function whereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
+    {
+        return $this->whereColumnHaving('QBWhere', $first, $operator, $second, 'AND ', $escape);
+    }
+
+    /**
+     * Generates an OR WHERE clause that compares two columns.
+     *
+     * @param non-empty-string      $first    First column name
+     * @param non-empty-string|null $operator Comparison operator, or second column name when $second is null
+     * @param non-empty-string|null $second   Second column name
+     * @param bool|null             $escape   Whether to protect identifiers
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    public function orWhereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
+    {
+        return $this->whereColumnHaving('QBWhere', $first, $operator, $second, 'OR ', $escape);
+    }
+
+    /**
+     * @used-by whereColumn()
+     * @used-by orWhereColumn()
+     *
+     * @param 'QBHaving'|'QBWhere'  $qbKey
+     * @param non-empty-string      $first    First column name
+     * @param non-empty-string|null $operator Comparison operator, or second column name when $second is null
+     * @param non-empty-string|null $second   Second column name
+     * @param non-empty-string      $type
+     * @param bool|null             $escape   Whether to protect identifiers
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function whereColumnHaving(string $qbKey, string $first, ?string $operator = null, ?string $second = null, string $type = 'AND ', ?bool $escape = null)
+    {
+        if ($second === null) {
+            $second   = $operator;
+            $operator = '=';
+        } elseif ($operator === null) {
+            $operator = '=';
+        }
+
+        $first    = trim($first);
+        $operator = trim($operator);
+        $second   = trim((string) $second);
+
+        if ($first === '' || $second === '') {
+            throw new InvalidArgumentException(sprintf('%s() expects $first and $second to be non-empty strings', debug_backtrace(0, 2)[1]['function']));
+        }
+
+        if (! in_array($operator, ['=', '!=', '<>', '<', '>', '<=', '>='], true)) {
+            throw new InvalidArgumentException(sprintf('%s() expects $operator to be one of: =, !=, <>, <, >, <=, >=', debug_backtrace(0, 2)[1]['function']));
+        }
+
+        if (! is_bool($escape)) {
+            $escape = $this->db->protectIdentifiers;
+        }
+
+        $prefix = $this->{$qbKey} === [] ? $this->groupGetType('') : $this->groupGetType($type);
+
+        $this->{$qbKey}[] = [
+            'columnComparison' => true,
+            'condition'        => $prefix,
+            'escape'           => $escape,
+            'first'            => $first,
+            'operator'         => $operator,
+            'second'           => $second,
+        ];
+
+        return $this;
+    }
+
+    /**
      * @used-by where()
      * @used-by orWhere()
      * @used-by having()
@@ -1383,6 +1471,7 @@ class BaseBuilder
      * @used-by _like()
      * @used-by whereHaving()
      * @used-by _whereIn()
+     * @used-by whereColumnHaving()
      * @used-by havingGroupStart()
      */
     protected function groupGetType(string $type): string
@@ -3114,6 +3203,12 @@ class BaseBuilder
                     continue;
                 }
 
+                if (($qbkey['columnComparison'] ?? false) === true) {
+                    $qbkey = $this->compileColumnComparison($qbkey);
+
+                    continue;
+                }
+
                 if ($qbkey['escape'] === false) {
                     $qbkey = $qbkey['condition'];
 
@@ -3175,6 +3270,19 @@ class BaseBuilder
         }
 
         return '';
+    }
+
+    /**
+     * @param array{columnComparison: true, condition: string, escape: bool, first: string, operator: string, second: string} $condition
+     */
+    private function compileColumnComparison(array $condition): string
+    {
+        if ($condition['escape']) {
+            $condition['first']  = $this->db->protectIdentifiers($condition['first'], false, true);
+            $condition['second'] = $this->db->protectIdentifiers($condition['second'], false, true);
+        }
+
+        return $condition['condition'] . $condition['first'] . ' ' . $condition['operator'] . ' ' . $condition['second'];
     }
 
     /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -739,71 +739,67 @@ class BaseBuilder
     /**
      * Generates a WHERE clause that compares two columns.
      *
-     * @param non-empty-string      $first    First column name
-     * @param non-empty-string|null $operator Comparison operator, or second column name when $second is null
-     * @param non-empty-string|null $second   Second column name
-     * @param bool|null             $escape   Whether to protect identifiers
+     * @param non-empty-string $first  First column name, optionally with comparison operator
+     * @param non-empty-string $second Second column name
+     * @param bool|null        $escape Whether to protect identifiers
      *
      * @return $this
      *
      * @throws InvalidArgumentException
      */
-    public function whereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
+    public function whereColumn(string $first, string $second, ?bool $escape = null)
     {
-        return $this->whereColumnHaving('QBWhere', $first, $operator, $second, 'AND ', $escape);
+        return $this->whereColumnHaving('QBWhere', $first, $second, 'AND ', $escape);
     }
 
     /**
      * Generates an OR WHERE clause that compares two columns.
      *
-     * @param non-empty-string      $first    First column name
-     * @param non-empty-string|null $operator Comparison operator, or second column name when $second is null
-     * @param non-empty-string|null $second   Second column name
-     * @param bool|null             $escape   Whether to protect identifiers
+     * @param non-empty-string $first  First column name, optionally with comparison operator
+     * @param non-empty-string $second Second column name
+     * @param bool|null        $escape Whether to protect identifiers
      *
      * @return $this
      *
      * @throws InvalidArgumentException
      */
-    public function orWhereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
+    public function orWhereColumn(string $first, string $second, ?bool $escape = null)
     {
-        return $this->whereColumnHaving('QBWhere', $first, $operator, $second, 'OR ', $escape);
+        return $this->whereColumnHaving('QBWhere', $first, $second, 'OR ', $escape);
     }
 
     /**
      * @used-by whereColumn()
      * @used-by orWhereColumn()
      *
-     * @param 'QBHaving'|'QBWhere'  $qbKey
-     * @param non-empty-string      $first    First column name
-     * @param non-empty-string|null $operator Comparison operator, or second column name when $second is null
-     * @param non-empty-string|null $second   Second column name
-     * @param non-empty-string      $type
-     * @param bool|null             $escape   Whether to protect identifiers
+     * @param 'QBHaving'|'QBWhere' $qbKey
+     * @param non-empty-string     $first  First column name, optionally with comparison operator
+     * @param non-empty-string     $second Second column name
+     * @param non-empty-string     $type
+     * @param bool|null            $escape Whether to protect identifiers
      *
      * @return $this
      *
      * @throws InvalidArgumentException
      */
-    protected function whereColumnHaving(string $qbKey, string $first, ?string $operator = null, ?string $second = null, string $type = 'AND ', ?bool $escape = null)
+    protected function whereColumnHaving(string $qbKey, string $first, string $second, string $type = 'AND ', ?bool $escape = null)
     {
-        if ($second === null) {
-            $second   = $operator;
-            $operator = '=';
-        } elseif ($operator === null) {
-            $operator = '=';
-        }
-
-        $first    = trim($first);
-        $operator = trim($operator);
-        $second   = trim((string) $second);
+        $caller             = debug_backtrace(0, 2)[1]['function'];
+        [$first, $operator] = $this->parseWhereColumnFirst($first, $caller);
+        $second             = trim($second);
 
         if ($first === '' || $second === '') {
-            throw new InvalidArgumentException(sprintf('%s() expects $first and $second to be non-empty strings', debug_backtrace(0, 2)[1]['function']));
+            throw new InvalidArgumentException(sprintf('%s() expects $first and $second to be non-empty strings', $caller));
         }
 
-        if (! in_array($operator, ['=', '!=', '<>', '<', '>', '<=', '>='], true)) {
-            throw new InvalidArgumentException(sprintf('%s() expects $operator to be one of: =, !=, <>, <, >, <=, >=', debug_backtrace(0, 2)[1]['function']));
+        // The second argument must be a column name, not an operator.
+        // This rejects likely missing-column mistakes like whereColumn('created_at', '>=').
+        if (in_array(
+            strtoupper($second),
+            ['=', '!=', '<>', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'BETWEEN', 'IS NULL', 'IS NOT NULL'],
+            true,
+        )) {
+            throw new InvalidArgumentException(sprintf('%s() expects $second to be a column name, not an operator', $caller));
         }
 
         if (! is_bool($escape)) {
@@ -822,6 +818,38 @@ class BaseBuilder
         ];
 
         return $this;
+    }
+
+    /**
+     * Extracts the operator from the first whereColumn() column.
+     *
+     * @param string $first  The first column, optionally ending with a comparison operator
+     * @param string $caller The public caller for exception messages
+     *
+     * @return array{string, string}
+     *
+     * @throws InvalidArgumentException
+     */
+    private function parseWhereColumnFirst(string $first, string $caller): array
+    {
+        $first = trim($first);
+
+        if (preg_match('/\s*(!=|<>|<=|>=|=|<|>)\s*$/', $first, $match) === 1) {
+            return [rtrim(substr($first, 0, -strlen($match[0]))), trim($match[1])];
+        }
+
+        $operator = $this->getOperatorFromWhereKey($first);
+
+        if ($operator !== false) {
+            end($operator);
+            $operator = trim(current($operator));
+
+            if ($operator !== '') {
+                throw new InvalidArgumentException(sprintf('%s() expects $first to contain one of: =, !=, <>, <, >, <=, >=', $caller));
+            }
+        }
+
+        return [$first, '='];
     }
 
     /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -785,7 +785,7 @@ class BaseBuilder
     protected function whereColumnHaving(string $qbKey, string $first, string $second, string $type = 'AND ', ?bool $escape = null)
     {
         $caller             = debug_backtrace(0, 2)[1]['function'];
-        [$first, $operator] = $this->parseWhereColumnFirst($first, $caller);
+        [$first, $operator] = $this->parseWhereColumnFirst($first);
         $second             = trim($second);
 
         if ($first === '' || $second === '') {
@@ -813,35 +813,16 @@ class BaseBuilder
     /**
      * Extracts the operator from the first whereColumn() column.
      *
-     * @param string $first  The first column, optionally ending with a comparison operator
-     * @param string $caller The public caller for exception messages
+     * @param string $first The first column, optionally ending with a comparison operator
      *
      * @return array{string, string}
-     *
-     * @throws InvalidArgumentException
      */
-    private function parseWhereColumnFirst(string $first, string $caller): array
+    private function parseWhereColumnFirst(string $first): array
     {
         $first = trim($first);
 
         if (preg_match('/\s*(!=|<>|<=|>=|=|<|>)\s*$/', $first, $match) === 1) {
             return [rtrim(substr($first, 0, -strlen($match[0]))), trim($match[1])];
-        }
-
-        $unsupportedOperators = [
-            '\s+IS\s+NULL',
-            '\s+IS\s+NOT\s+NULL',
-            '\s+NOT\s+EXISTS',
-            '\s+EXISTS',
-            '\s+BETWEEN',
-            '\s+NOT\s+IN',
-            '\s+IN',
-            '\s+NOT\s+LIKE',
-            '\s+LIKE',
-        ];
-
-        if (preg_match('/(?:' . implode('|', $unsupportedOperators) . ')\s*$/i', $first) === 1) {
-            throw new InvalidArgumentException(sprintf('%s() expects $first to contain one of: =, !=, <>, <, >, <=, >=', $caller));
         }
 
         return [$first, '='];

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -792,16 +792,6 @@ class BaseBuilder
             throw new InvalidArgumentException(sprintf('%s() expects $first and $second to be non-empty strings', $caller));
         }
 
-        // The second argument must be a column name, not an operator.
-        // This rejects likely missing-column mistakes like whereColumn('created_at', '>=').
-        if (in_array(
-            strtoupper($second),
-            ['=', '!=', '<>', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'BETWEEN', 'IS NULL', 'IS NOT NULL'],
-            true,
-        )) {
-            throw new InvalidArgumentException(sprintf('%s() expects $second to be a column name, not an operator', $caller));
-        }
-
         if (! is_bool($escape)) {
             $escape = $this->db->protectIdentifiers;
         }
@@ -838,15 +828,20 @@ class BaseBuilder
             return [rtrim(substr($first, 0, -strlen($match[0]))), trim($match[1])];
         }
 
-        $operator = $this->getOperatorFromWhereKey($first);
+        $unsupportedOperators = [
+            '\s+IS\s+NULL',
+            '\s+IS\s+NOT\s+NULL',
+            '\s+NOT\s+EXISTS',
+            '\s+EXISTS',
+            '\s+BETWEEN',
+            '\s+NOT\s+IN',
+            '\s+IN',
+            '\s+NOT\s+LIKE',
+            '\s+LIKE',
+        ];
 
-        if ($operator !== false) {
-            end($operator);
-            $operator = trim(current($operator));
-
-            if ($operator !== '') {
-                throw new InvalidArgumentException(sprintf('%s() expects $first to contain one of: =, !=, <>, <, >, <=, >=', $caller));
-            }
+        if (preg_match('/(?:' . implode('|', $unsupportedOperators) . ')\s*$/i', $first) === 1) {
+            throw new InvalidArgumentException(sprintf('%s() expects $first to contain one of: =, !=, <>, <, >, <=, >=', $caller));
         }
 
         return [$first, '='];

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -784,11 +784,12 @@ class BaseBuilder
      */
     protected function whereColumnHaving(string $qbKey, string $first, string $second, string $type = 'AND ', ?bool $escape = null)
     {
-        $caller             = debug_backtrace(0, 2)[1]['function'];
         [$first, $operator] = $this->parseWhereColumnFirst($first);
         $second             = trim($second);
 
         if ($first === '' || $second === '') {
+            $caller = debug_backtrace(0, 2)[1]['function'];
+
             throw new InvalidArgumentException(sprintf('%s() expects $first and $second to be non-empty strings', $caller));
         }
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -72,7 +72,7 @@ use stdClass;
  * @method $this orNotHavingLike($field, string $match = '', string $side = 'both', ?bool $escape = null, bool $insensitiveSearch = false)
  * @method $this orNotLike($field, string $match = '', string $side = 'both', ?bool $escape = null, bool $insensitiveSearch = false)
  * @method $this orWhere($key, $value = null, ?bool $escape = null)
- * @method $this orWhereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
+ * @method $this orWhereColumn(string $first, string $second, ?bool $escape = null)
  * @method $this orWhereIn(?string $key = null, $values = null, ?bool $escape = null)
  * @method $this orWhereNotIn(?string $key = null, $values = null, ?bool $escape = null)
  * @method $this select($select = '*', ?bool $escape = null)
@@ -84,7 +84,7 @@ use stdClass;
  * @method $this when($condition, callable $callback, ?callable $defaultCallback = null)
  * @method $this whenNot($condition, callable $callback, ?callable $defaultCallback = null)
  * @method $this where($key, $value = null, ?bool $escape = null)
- * @method $this whereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
+ * @method $this whereColumn(string $first, string $second, ?bool $escape = null)
  * @method $this whereIn(?string $key = null, $values = null, ?bool $escape = null)
  * @method $this whereNotIn(?string $key = null, $values = null, ?bool $escape = null)
  *

--- a/system/Model.php
+++ b/system/Model.php
@@ -72,6 +72,7 @@ use stdClass;
  * @method $this orNotHavingLike($field, string $match = '', string $side = 'both', ?bool $escape = null, bool $insensitiveSearch = false)
  * @method $this orNotLike($field, string $match = '', string $side = 'both', ?bool $escape = null, bool $insensitiveSearch = false)
  * @method $this orWhere($key, $value = null, ?bool $escape = null)
+ * @method $this orWhereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
  * @method $this orWhereIn(?string $key = null, $values = null, ?bool $escape = null)
  * @method $this orWhereNotIn(?string $key = null, $values = null, ?bool $escape = null)
  * @method $this select($select = '*', ?bool $escape = null)
@@ -83,6 +84,7 @@ use stdClass;
  * @method $this when($condition, callable $callback, ?callable $defaultCallback = null)
  * @method $this whenNot($condition, callable $callback, ?callable $defaultCallback = null)
  * @method $this where($key, $value = null, ?bool $escape = null)
+ * @method $this whereColumn(string $first, ?string $operator = null, ?string $second = null, ?bool $escape = null)
  * @method $this whereIn(?string $key = null, $values = null, ?bool $escape = null)
  * @method $this whereNotIn(?string $key = null, $values = null, ?bool $escape = null)
  *

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -55,6 +55,19 @@ final class PrefixTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    public function testPrefixesSetOnTableNamesWithWhereColumnClause(): void
+    {
+        $builder = $this->db->table('users');
+
+        $expectedSQL   = 'SELECT * FROM "ci_users" WHERE "ci_users"."created_at" < "ci_users"."updated_at"';
+        $expectedBinds = [];
+
+        $builder->whereColumn('users.created_at', '<', 'users.updated_at');
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
     public function testPrefixWithSubquery(): void
     {
         $expected = <<<'NOWDOC'

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -62,7 +62,7 @@ final class PrefixTest extends CIUnitTestCase
         $expectedSQL   = 'SELECT * FROM "ci_users" WHERE "ci_users"."created_at" < "ci_users"."updated_at"';
         $expectedBinds = [];
 
-        $builder->whereColumn('users.created_at', '<', 'users.updated_at');
+        $builder->whereColumn('users.created_at <', 'users.updated_at');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -484,14 +484,6 @@ final class WhereTest extends CIUnitTestCase
         ];
     }
 
-    public function testWhereColumnInvalidOperatorThrowInvalidArgumentException(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $builder = $this->db->table('users');
-        $builder->whereColumn('created_at LIKE', 'updated_at');
-    }
-
     public function testWhereIn(): void
     {
         $builder = $this->db->table('jobs');

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -369,7 +369,7 @@ final class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('users');
 
-        $builder->whereColumn('updated_at', '>', 'created_at');
+        $builder->whereColumn('updated_at >', 'created_at');
 
         $expectedSQL   = 'SELECT * FROM "users" WHERE "updated_at" > "created_at"';
         $expectedBinds = [];
@@ -382,7 +382,7 @@ final class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('users u');
 
-        $builder->whereColumn('u.updated_at', '>', 'u.created_at');
+        $builder->whereColumn('u.updated_at >', 'u.created_at');
 
         $expectedSQL   = 'SELECT * FROM "users" "u" WHERE "u"."updated_at" > "u"."created_at"';
         $expectedBinds = [];
@@ -396,7 +396,7 @@ final class WhereTest extends CIUnitTestCase
         $builder = $this->db->table('users');
 
         $builder->where('active', 1)
-            ->orWhereColumn('updated_at', '>', 'created_at');
+            ->orWhereColumn('updated_at >', 'created_at');
 
         $expectedSQL   = 'SELECT * FROM "users" WHERE "active" = 1 OR "updated_at" > "created_at"';
         $expectedBinds = [
@@ -416,7 +416,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->groupStart()
             ->whereColumn('created_at', 'updated_at')
-            ->orWhereColumn('updated_at', '>', 'created_at')
+            ->orWhereColumn('updated_at >', 'created_at')
             ->groupEnd()
             ->where('active', 1);
 
@@ -439,24 +439,23 @@ final class WhereTest extends CIUnitTestCase
     }
 
     #[DataProvider('provideWhereColumnInvalidColumnThrowInvalidArgumentException')]
-    public function testWhereColumnInvalidColumnThrowInvalidArgumentException(string $first, ?string $operator, ?string $second): void
+    public function testWhereColumnInvalidColumnThrowInvalidArgumentException(string $first, string $second): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         $builder = $this->db->table('users');
-        $builder->whereColumn($first, $operator, $second);
+        $builder->whereColumn($first, $second);
     }
 
     /**
-     * @return iterable<string, array{string, ?string, ?string}>
+     * @return iterable<string, array{string, string}>
      */
     public static function provideWhereColumnInvalidColumnThrowInvalidArgumentException(): iterable
     {
         return [
-            'empty first column'                => ['', '=', 'updated_at'],
-            'empty second column'               => ['created_at', '= ', ''],
-            'empty second column as second arg' => ['created_at', '', null],
-            'missing second'                    => ['created_at', null, null],
+            'empty first column'  => ['', 'updated_at'],
+            'empty second column' => ['created_at =', ''],
+            'operator as second'  => ['created_at', '>='],
         ];
     }
 
@@ -465,7 +464,7 @@ final class WhereTest extends CIUnitTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $builder = $this->db->table('users');
-        $builder->whereColumn('created_at', 'LIKE', 'updated_at');
+        $builder->whereColumn('created_at LIKE', 'updated_at');
     }
 
     public function testWhereIn(): void

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -438,6 +438,32 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    public function testWhereColumnTreatsSecondArgumentAsColumnName(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->whereColumn('created_at', 'like');
+
+        $expectedSQL   = 'SELECT * FROM "users" WHERE "created_at" = "like"';
+        $expectedBinds = [];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereColumnIgnoresOperatorsInsideFirstArgument(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->whereColumn("JSON_EXTRACT(data, '$.a>b')", 'updated_at', escape: false);
+
+        $expectedSQL   = 'SELECT * FROM "users" WHERE JSON_EXTRACT(data, \'$.a>b\') = updated_at';
+        $expectedBinds = [];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
     #[DataProvider('provideWhereColumnInvalidColumnThrowInvalidArgumentException')]
     public function testWhereColumnInvalidColumnThrowInvalidArgumentException(string $first, string $second): void
     {
@@ -455,7 +481,6 @@ final class WhereTest extends CIUnitTestCase
         return [
             'empty first column'  => ['', 'updated_at'],
             'empty second column' => ['created_at =', ''],
-            'operator as second'  => ['created_at', '>='],
         ];
     }
 

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use DateTime;
@@ -349,6 +350,122 @@ final class WhereTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereColumn(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->whereColumn('created_at', 'updated_at');
+
+        $expectedSQL   = 'SELECT * FROM "users" WHERE "created_at" = "updated_at"';
+        $expectedBinds = [];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereColumnWithOperator(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->whereColumn('updated_at', '>', 'created_at');
+
+        $expectedSQL   = 'SELECT * FROM "users" WHERE "updated_at" > "created_at"';
+        $expectedBinds = [];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereColumnWithAlias(): void
+    {
+        $builder = $this->db->table('users u');
+
+        $builder->whereColumn('u.updated_at', '>', 'u.created_at');
+
+        $expectedSQL   = 'SELECT * FROM "users" "u" WHERE "u"."updated_at" > "u"."created_at"';
+        $expectedBinds = [];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testOrWhereColumn(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('active', 1)
+            ->orWhereColumn('updated_at', '>', 'created_at');
+
+        $expectedSQL   = 'SELECT * FROM "users" WHERE "active" = 1 OR "updated_at" > "created_at"';
+        $expectedBinds = [
+            'active' => [
+                1,
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereColumnWithGroupedConditions(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->groupStart()
+            ->whereColumn('created_at', 'updated_at')
+            ->orWhereColumn('updated_at', '>', 'created_at')
+            ->groupEnd()
+            ->where('active', 1);
+
+        $expectedSQL = 'SELECT * FROM "users" WHERE   ( "created_at" = "updated_at" OR "updated_at" > "created_at"  ) AND "active" = 1';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereColumnNoEscape(): void
+    {
+        $builder = $this->db->table('users');
+
+        $builder->whereColumn('LOWER(users.email)', 'normalized_email', escape: false);
+
+        $expectedSQL   = 'SELECT * FROM "users" WHERE LOWER(users.email) = normalized_email';
+        $expectedBinds = [];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    #[DataProvider('provideWhereColumnInvalidColumnThrowInvalidArgumentException')]
+    public function testWhereColumnInvalidColumnThrowInvalidArgumentException(string $first, ?string $operator, ?string $second): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder = $this->db->table('users');
+        $builder->whereColumn($first, $operator, $second);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, ?string}>
+     */
+    public static function provideWhereColumnInvalidColumnThrowInvalidArgumentException(): iterable
+    {
+        return [
+            'empty first column'                => ['', '=', 'updated_at'],
+            'empty second column'               => ['created_at', '= ', ''],
+            'empty second column as second arg' => ['created_at', '', null],
+            'missing second'                    => ['created_at', null, null],
+        ];
+    }
+
+    public function testWhereColumnInvalidOperatorThrowInvalidArgumentException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder = $this->db->table('users');
+        $builder->whereColumn('created_at', 'LIKE', 'updated_at');
     }
 
     public function testWhereIn(): void

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -352,30 +352,35 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
-    public function testWhereColumn(): void
+    #[DataProvider('provideWhereColumnWithOperators')]
+    public function testWhereColumnWithOperators(string $first, string $operator): void
     {
         $builder = $this->db->table('users');
 
-        $builder->whereColumn('created_at', 'updated_at');
+        $builder->whereColumn($first, 'updated_at');
 
-        $expectedSQL   = 'SELECT * FROM "users" WHERE "created_at" = "updated_at"';
+        $expectedSQL   = sprintf('SELECT * FROM "users" WHERE "created_at" %s "updated_at"', $operator);
         $expectedBinds = [];
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
-    public function testWhereColumnWithOperator(): void
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideWhereColumnWithOperators(): iterable
     {
-        $builder = $this->db->table('users');
-
-        $builder->whereColumn('updated_at >', 'created_at');
-
-        $expectedSQL   = 'SELECT * FROM "users" WHERE "updated_at" > "created_at"';
-        $expectedBinds = [];
-
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
-        $this->assertSame($expectedBinds, $builder->getBinds());
+        return [
+            'default' => ['created_at', '='],
+            '='       => ['created_at =', '='],
+            '!='      => ['created_at !=', '!='],
+            '<>'      => ['created_at <>', '<>'],
+            '<'       => ['created_at <', '<'],
+            '>'       => ['created_at >', '>'],
+            '<='      => ['created_at <=', '<='],
+            '>='      => ['created_at >=', '>='],
+        ];
     }
 
     public function testWhereColumnWithAlias(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -202,6 +202,8 @@ Database
 Query Builder
 -------------
 
+- Added ``whereColumn()`` and ``orWhereColumn()`` to compare one column to another column while protecting identifiers by default. See :ref:`query-builder-where-column`.
+
 Forge
 -----
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -365,6 +365,36 @@ instances are joined by **OR**:
 
 .. literalinclude:: query_builder/029.php
 
+.. _query-builder-where-column:
+
+$builder->whereColumn()
+-----------------------
+
+.. versionadded:: 4.8.0
+
+Compares one column to another column. If no operator is provided, ``=`` is
+used:
+
+.. literalinclude:: query_builder/123.php
+
+When two arguments are passed, the second argument is treated as the column to
+compare against. When three arguments are passed, the second argument is treated
+as the comparison operator. Supported operators are ``=``, ``!=``, ``<>``, ``<``,
+``>``, ``<=``, and ``>=``. Empty column names or unsupported operators throw an
+``InvalidArgumentException``.
+
+Column names are protected by default, unless the ``$escape`` parameter is
+``false``.
+
+.. warning:: Do not pass user-supplied data as column names. Values should use
+    ``where()`` or another value-binding method instead.
+
+$builder->orWhereColumn()
+-------------------------
+
+This method is identical to ``whereColumn()``, except that multiple instances
+are joined by **OR**.
+
 $builder->whereIn()
 -------------------
 
@@ -1533,6 +1563,34 @@ Class Reference
         :rtype:     ``BaseBuilder``
 
         Generates the ``WHERE`` portion of the query. Separates multiple calls with ``OR``.
+
+    .. php:method:: whereColumn($first[, $operator = null[, $second = null[, $escape = null]]])
+
+        :param string $first: First column name
+        :param string $operator: Comparison operator, or second column name when ``$second`` is ``null``
+        :param string $second: Second column name
+        :param bool $escape: Whether to protect identifiers
+        :returns:   ``BaseBuilder`` instance (method chaining)
+        :rtype:     ``BaseBuilder``
+
+        Generates a ``WHERE`` clause that compares two columns. Separates multiple calls with ``AND``.
+        If ``$second`` is omitted, ``$operator`` is used as the second column and ``=`` is used as the comparison operator.
+        Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``, and ``>=``.
+        Unsupported operators throw an ``InvalidArgumentException``.
+
+    .. php:method:: orWhereColumn($first[, $operator = null[, $second = null[, $escape = null]]])
+
+        :param string $first: First column name
+        :param string $operator: Comparison operator, or second column name when ``$second`` is ``null``
+        :param string $second: Second column name
+        :param bool $escape: Whether to protect identifiers
+        :returns:   ``BaseBuilder`` instance (method chaining)
+        :rtype:     ``BaseBuilder``
+
+        Generates a ``WHERE`` clause that compares two columns. Separates multiple calls with ``OR``.
+        If ``$second`` is omitted, ``$operator`` is used as the second column and ``=`` is used as the comparison operator.
+        Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``, and ``>=``.
+        Unsupported operators throw an ``InvalidArgumentException``.
 
     .. php:method:: orWhereIn([$key = null[, $values = null[, $escape = null]]])
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -379,8 +379,8 @@ used:
 
 You can include an operator in the first parameter in order to control the
 comparison. Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``,
-and ``>=``. Empty column names, unsupported operators, or passing an operator
-as the second argument throw an ``InvalidArgumentException``.
+and ``>=``. Empty column names or unsupported operators throw an
+``InvalidArgumentException``.
 
 Column names are protected by default, unless the ``$escape`` parameter is
 ``false``.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -379,8 +379,8 @@ used:
 
 You can include an operator in the first parameter in order to control the
 comparison. Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``,
-and ``>=``. Empty column names or unsupported operators throw an
-``InvalidArgumentException``.
+and ``>=``. If none of these operators is detected at the end of the first
+parameter, ``=`` is used. Empty column names throw an ``InvalidArgumentException``.
 
 Column names are protected by default, unless the ``$escape`` parameter is
 ``false``.
@@ -1572,9 +1572,8 @@ Class Reference
         :rtype:     ``BaseBuilder``
 
         Generates a ``WHERE`` clause that compares two columns. Separates multiple calls with ``AND``.
-        If ``$first`` does not include an operator, ``=`` is used as the comparison operator.
+        If ``$first`` does not end with a supported operator, ``=`` is used as the comparison operator.
         Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``, and ``>=``.
-        Unsupported operators throw an ``InvalidArgumentException``.
 
     .. php:method:: orWhereColumn($first, $second[, $escape = null])
 
@@ -1585,9 +1584,8 @@ Class Reference
         :rtype:     ``BaseBuilder``
 
         Generates a ``WHERE`` clause that compares two columns. Separates multiple calls with ``OR``.
-        If ``$first`` does not include an operator, ``=`` is used as the comparison operator.
+        If ``$first`` does not end with a supported operator, ``=`` is used as the comparison operator.
         Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``, and ``>=``.
-        Unsupported operators throw an ``InvalidArgumentException``.
 
     .. php:method:: orWhereIn([$key = null[, $values = null[, $escape = null]]])
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -372,15 +372,16 @@ $builder->whereColumn()
 
 .. versionadded:: 4.8.0
 
-Compares one column to another column. If no operator is provided, ``=`` is
-used:
+Compares one column to another column. If the first parameter does not end with
+a supported operator, ``=`` is used:
 
 .. literalinclude:: query_builder/123.php
 
-You can include an operator in the first parameter in order to control the
-comparison. Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``,
-and ``>=``. If none of these operators is detected at the end of the first
-parameter, ``=`` is used. Empty column names throw an ``InvalidArgumentException``.
+You can include a supported operator at the end of the first parameter in order
+to control the comparison. Supported operators are ``=``, ``!=``, ``<>``, ``<``,
+``>``, ``<=``, and ``>=``. If none of these operators is detected at the end of the first
+parameter, ``=`` is used. Empty
+column names throw an ``InvalidArgumentException``.
 
 Column names are protected by default, unless the ``$escape`` parameter is
 ``false``.
@@ -1565,7 +1566,7 @@ Class Reference
 
     .. php:method:: whereColumn($first, $second[, $escape = null])
 
-        :param string $first: First column name, optionally with comparison operator
+        :param string $first: First column name, optionally ending with a supported comparison operator
         :param string $second: Second column name
         :param bool $escape: Whether to protect identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)
@@ -1577,7 +1578,7 @@ Class Reference
 
     .. php:method:: orWhereColumn($first, $second[, $escape = null])
 
-        :param string $first: First column name, optionally with comparison operator
+        :param string $first: First column name, optionally ending with a supported comparison operator
         :param string $second: Second column name
         :param bool $escape: Whether to protect identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -377,11 +377,10 @@ used:
 
 .. literalinclude:: query_builder/123.php
 
-When two arguments are passed, the second argument is treated as the column to
-compare against. When three arguments are passed, the second argument is treated
-as the comparison operator. Supported operators are ``=``, ``!=``, ``<>``, ``<``,
-``>``, ``<=``, and ``>=``. Empty column names or unsupported operators throw an
-``InvalidArgumentException``.
+You can include an operator in the first parameter in order to control the
+comparison. Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``,
+and ``>=``. Empty column names, unsupported operators, or passing an operator
+as the second argument throw an ``InvalidArgumentException``.
 
 Column names are protected by default, unless the ``$escape`` parameter is
 ``false``.
@@ -1564,31 +1563,29 @@ Class Reference
 
         Generates the ``WHERE`` portion of the query. Separates multiple calls with ``OR``.
 
-    .. php:method:: whereColumn($first[, $operator = null[, $second = null[, $escape = null]]])
+    .. php:method:: whereColumn($first, $second[, $escape = null])
 
-        :param string $first: First column name
-        :param string $operator: Comparison operator, or second column name when ``$second`` is ``null``
+        :param string $first: First column name, optionally with comparison operator
         :param string $second: Second column name
         :param bool $escape: Whether to protect identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 
         Generates a ``WHERE`` clause that compares two columns. Separates multiple calls with ``AND``.
-        If ``$second`` is omitted, ``$operator`` is used as the second column and ``=`` is used as the comparison operator.
+        If ``$first`` does not include an operator, ``=`` is used as the comparison operator.
         Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``, and ``>=``.
         Unsupported operators throw an ``InvalidArgumentException``.
 
-    .. php:method:: orWhereColumn($first[, $operator = null[, $second = null[, $escape = null]]])
+    .. php:method:: orWhereColumn($first, $second[, $escape = null])
 
-        :param string $first: First column name
-        :param string $operator: Comparison operator, or second column name when ``$second`` is ``null``
+        :param string $first: First column name, optionally with comparison operator
         :param string $second: Second column name
         :param bool $escape: Whether to protect identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 
         Generates a ``WHERE`` clause that compares two columns. Separates multiple calls with ``OR``.
-        If ``$second`` is omitted, ``$operator`` is used as the second column and ``=`` is used as the comparison operator.
+        If ``$first`` does not include an operator, ``=`` is used as the comparison operator.
         Supported operators are ``=``, ``!=``, ``<>``, ``<``, ``>``, ``<=``, and ``>=``.
         Unsupported operators throw an ``InvalidArgumentException``.
 

--- a/user_guide_src/source/database/query_builder/123.php
+++ b/user_guide_src/source/database/query_builder/123.php
@@ -3,5 +3,8 @@
 $builder->whereColumn('created_at', 'updated_at');
 // Produces: WHERE created_at = updated_at
 
-$builder->whereColumn('updated_at', '>', 'created_at');
+$builder->whereColumn('updated_at >', 'created_at');
 // Produces: WHERE updated_at > created_at
+
+$builder->whereColumn('updated_at !=', 'created_at');
+// Produces: WHERE updated_at != created_at

--- a/user_guide_src/source/database/query_builder/123.php
+++ b/user_guide_src/source/database/query_builder/123.php
@@ -1,0 +1,7 @@
+<?php
+
+$builder->whereColumn('created_at', 'updated_at');
+// Produces: WHERE created_at = updated_at
+
+$builder->whereColumn('updated_at', '>', 'created_at');
+// Produces: WHERE updated_at > created_at


### PR DESCRIPTION
**Description**

This PR proposes adding `whereColumn()` and `orWhereColumn()` to the Query Builder for comparing one column to another column without dropping down to raw SQL.

This improves Query Builder DX for a common SQL pattern and reduces the need for manually written raw conditions like `where('created_at < updated_at')`. It also keeps the comparison inside the framework’s identifier-protection flow instead of asking users to handle that manually.

```php
$builder->whereColumn('created_at', 'updated_at');
// WHERE "created_at" = "updated_at"

$builder->whereColumn('updated_at >', 'created_at');
// WHERE "updated_at" > "created_at"

$builder->orWhereColumn('published_at <=', 'expires_at');
// OR "published_at" <= "expires_at"
```

This is useful for common column-comparison queries while keeping the existing Query Builder behavior around identifier protection. The API follows the existing Query Builder convention of placing supported comparison operators at the end of the first argument. If no supported operator is detected there, `=` is used. Column names are protected by default, and `$escape = false` remains available for advanced cases such as SQL functions.

Supported operators are `=`, `!=`, `<>`, `<`, `>`, `<=`, and `>=`. The second argument is treated as the column to compare against, and column names are protected by default. `$escape = false` remains available for advanced cases such as SQL functions.

**Implementation note**

This PR keeps the operator parsing local to `whereColumn()` so it does not change the long-standing behavior of `where()` / `having()`. There may be a future internal refactor opportunity to share operator parsing more broadly, but that is intentionally out of scope here to keep this PR focused and low-risk.

**Changes**

- Added `whereColumn()` and `orWhereColumn()` to `BaseBuilder`.
- Added Model PHPDoc forwarding entries.
- Added user guide docs, class reference entries, and changelog entry.
- Added tests for default operator, explicit operators, `OR`, grouping, alias/prefix protection, unescaped expressions, empty columns, second-argument identifier handling, and expressions containing operator-like characters.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide