### PR TITLE
fix: make `Time::createFromTimestamp` locale-independent

### DIFF
--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -263,7 +263,7 @@ trait TimeTrait
      */
     public static function createFromTimestamp(float|int $timestamp, $timezone = null, ?string $locale = null): static
     {
-        $time = new static(sprintf('@%.6f', $timestamp), 'UTC', $locale);
+        $time = new static(sprintf('@%.6F', $timestamp), 'UTC', $locale);
 
         $timezone ??= 'UTC';
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -291,11 +291,18 @@ final class TimeTest extends CIUnitTestCase
     public function testCreateFromTimestampWithMicroseconds(): void
     {
         $timestamp = 1489762800.654321;
+        $locale    = setlocale(LC_NUMERIC, '0');
 
-        // The timezone will be UTC if you don't specify.
-        $time = Time::createFromTimestamp($timestamp);
+        setlocale(LC_NUMERIC, 'de_DE.UTF-8', 'de_DE');
 
-        $this->assertSame('2017-03-17 15:00:00.654321', $time->format('Y-m-d H:i:s.u'));
+        try {
+            // The timezone will be UTC if you don't specify.
+            $time = Time::createFromTimestamp($timestamp);
+
+            $this->assertSame('2017-03-17 15:00:00.654321', $time->format('Y-m-d H:i:s.u'));
+        } finally {
+            setlocale(LC_NUMERIC, $locale);
+        }
     }
 
     public function testCreateFromTimestampWithTimezone(): void

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -41,6 +41,7 @@ Bugs Fixed
 - **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
+- **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
 
 See the repo's


### PR DESCRIPTION
**Description**
This PR fixes `Time::createFromTimestamp()` when `LC_NUMERIC` uses a comma decimal separator.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
