### PR TITLE
feat(cache): add Memcached lock store

### DIFF
--- a/system/Cache/Exceptions/CacheException.php
+++ b/system/Cache/Exceptions/CacheException.php
@@ -59,4 +59,14 @@ class CacheException extends RuntimeException
     {
         return new static(lang('Cache.handlerNotFound'));
     }
+
+    /**
+     * Thrown when the handler cannot provide a lock store.
+     *
+     * @return static
+     */
+    public static function forUnsupportedLockStore()
+    {
+        return new static(lang('Cache.unsupportedLockStore'));
+    }
 }

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use CodeIgniter\Cache\Exceptions\CacheException;
+use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProviderInterface;
+use CodeIgniter\Cache\LockStores\MemcachedLockStore;
 use CodeIgniter\Exceptions\BadMethodCallException;
 use CodeIgniter\Exceptions\CriticalError;
 use CodeIgniter\I18n\Time;
@@ -26,7 +30,7 @@ use Memcached;
  *
  * @see \CodeIgniter\Cache\Handlers\MemcachedHandlerTest
  */
-class MemcachedHandler extends BaseHandler
+class MemcachedHandler extends BaseHandler implements LockStoreProviderInterface
 {
     /**
      * The memcached object
@@ -34,6 +38,8 @@ class MemcachedHandler extends BaseHandler
      * @var Memcache|Memcached
      */
     protected $memcached;
+
+    private ?LockStoreInterface $lockStore = null;
 
     /**
      * Memcached Configuration
@@ -62,6 +68,7 @@ class MemcachedHandler extends BaseHandler
         try {
             if (class_exists(Memcached::class)) {
                 $this->memcached = new Memcached();
+                $this->lockStore = null;
 
                 if ($this->config['raw']) {
                     $this->memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
@@ -82,6 +89,7 @@ class MemcachedHandler extends BaseHandler
                 }
             } elseif (class_exists(Memcache::class)) {
                 $this->memcached = new Memcache();
+                $this->lockStore = null;
 
                 if (! $this->memcached->connect($this->config['host'], $this->config['port'])) {
                     throw new CriticalError('Cache: Memcache connection failed.');
@@ -217,6 +225,15 @@ class MemcachedHandler extends BaseHandler
     public function isSupported(): bool
     {
         return extension_loaded('memcached') || extension_loaded('memcache');
+    }
+
+    public function lockStore(): LockStoreInterface
+    {
+        if (! $this->memcached instanceof Memcached) {
+            throw CacheException::forUnsupportedLockStore();
+        }
+
+        return $this->lockStore ??= new MemcachedLockStore($this->memcached, $this->prefix);
     }
 
     public function ping(): bool

--- a/system/Cache/LockStores/MemcachedLockStore.php
+++ b/system/Cache/LockStores/MemcachedLockStore.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\LockStores;
+
+use CodeIgniter\Cache\Handlers\MemcachedHandler;
+use CodeIgniter\Cache\LockStoreInterface;
+use Memcached;
+
+class MemcachedLockStore implements LockStoreInterface
+{
+    private const RELEASE_TTL = 2;
+
+    public function __construct(
+        private readonly Memcached $memcached,
+        private readonly string $prefix = '',
+    ) {
+    }
+
+    public function acquireLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = MemcachedHandler::validateKey($key, $this->prefix);
+
+        return $this->memcached->add($key, $owner, $ttl);
+    }
+
+    public function releaseLock(string $key, string $owner): bool
+    {
+        $key = MemcachedHandler::validateKey($key, $this->prefix);
+
+        [$value, $cas] = $this->getValueAndCas($key);
+
+        if ($value !== $owner || $cas === null) {
+            return false;
+        }
+
+        // Memcached has no atomic compare-and-delete command. CAS narrows the
+        // release race by first shortening only the current owner's value.
+        if (! $this->memcached->cas($cas, $key, $owner, self::RELEASE_TTL)) {
+            return false;
+        }
+
+        return $this->memcached->delete($key);
+    }
+
+    public function forceReleaseLock(string $key): bool
+    {
+        $key = MemcachedHandler::validateKey($key, $this->prefix);
+
+        if ($this->memcached->delete($key)) {
+            return true;
+        }
+
+        return $this->memcached->getResultCode() === Memcached::RES_NOTFOUND;
+    }
+
+    public function refreshLock(string $key, string $owner, int $ttl): bool
+    {
+        $key = MemcachedHandler::validateKey($key, $this->prefix);
+
+        [$value, $cas] = $this->getValueAndCas($key);
+
+        if ($value !== $owner || $cas === null) {
+            return false;
+        }
+
+        return $this->memcached->cas($cas, $key, $owner, $ttl);
+    }
+
+    public function getLockOwner(string $key): ?string
+    {
+        $key   = MemcachedHandler::validateKey($key, $this->prefix);
+        $owner = $this->memcached->get($key);
+
+        if ($this->memcached->getResultCode() !== Memcached::RES_SUCCESS) {
+            return null;
+        }
+
+        return is_string($owner) ? $owner : null;
+    }
+
+    /**
+     * @return array{0: mixed, 1: float|int|null}
+     */
+    private function getValueAndCas(string $key): array
+    {
+        $extended = $this->memcached->get($key, null, Memcached::GET_EXTENDED);
+
+        if (! is_array($extended) || ! array_key_exists('value', $extended) || ! array_key_exists('cas', $extended)) {
+            return [null, null];
+        }
+
+        return [$extended['value'], $extended['cas']];
+    }
+}

--- a/system/Language/en/Cache.php
+++ b/system/Language/en/Cache.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 // Cache language settings
 return [
-    'unableToWrite'   => 'Cache unable to write to "{0}".',
-    'invalidHandler'  => 'Cache driver "{0}" is not a valid cache handler.',
-    'invalidHandlers' => 'Cache config must have an array of $validHandlers.',
-    'noBackup'        => 'Cache config must have a handler and backupHandler set.',
-    'handlerNotFound' => 'Cache config has an invalid handler or backup handler specified.',
+    'unableToWrite'        => 'Cache unable to write to "{0}".',
+    'invalidHandler'       => 'Cache driver "{0}" is not a valid cache handler.',
+    'invalidHandlers'      => 'Cache config must have an array of $validHandlers.',
+    'noBackup'             => 'Cache config must have a handler and backupHandler set.',
+    'handlerNotFound'      => 'Cache config has an invalid handler or backup handler specified.',
+    'unsupportedLockStore' => 'The cache handler cannot provide a lock store with the current runtime client.',
 ];

--- a/system/Lock/LockManager.php
+++ b/system/Lock/LockManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Lock;
 
 use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
@@ -36,7 +37,11 @@ final readonly class LockManager
             throw LockException::forUnsupportedStore($cache::class);
         }
 
-        $this->store = $cache->lockStore();
+        try {
+            $this->store = $cache->lockStore();
+        } catch (CacheException) {
+            throw LockException::forUnsupportedStore($cache::class);
+        }
     }
 
     public function create(string $name, int $ttl = 300, ?string $owner = null): LockInterface

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Exceptions\BadMethodCallException;
 use CodeIgniter\I18n\Time;
@@ -102,6 +104,53 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));
+    }
+
+    public function testLockOperations(): void
+    {
+        $handler = $this->handler;
+
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
+
+        $store = $handler->lockStore();
+
+        $this->assertInstanceOf(LockStoreInterface::class, $store);
+        $this->assertTrue($store->acquireLock(self::$key1, 'owner1', 60));
+        $this->assertFalse($store->acquireLock(self::$key1, 'owner2', 60));
+        $this->assertSame('owner1', $store->getLockOwner(self::$key1));
+        $this->assertFalse($store->releaseLock(self::$key1, 'owner2'));
+        $this->assertFalse($store->refreshLock(self::$key1, 'owner2', 120));
+        $this->assertTrue($store->refreshLock(self::$key1, 'owner1', 120));
+        $this->assertTrue($store->releaseLock(self::$key1, 'owner1'));
+        $this->assertNull($store->getLockOwner(self::$key1));
+        $this->assertTrue($store->acquireLock(self::$key1, 'owner1', 60));
+        $this->assertTrue($store->forceReleaseLock(self::$key1));
+        $this->assertNull($store->getLockOwner(self::$key1));
+        $this->assertTrue($store->forceReleaseLock(self::$key1));
+    }
+
+    /**
+     * This test waits for 2 seconds before reacquiring the lock.
+     *
+     * @timeLimit 2.5
+     */
+    public function testExpiredLockCanBeAcquiredByNewOwner(): void
+    {
+        $handler = $this->handler;
+
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
+
+        $store = $handler->lockStore();
+
+        $this->assertTrue($store->acquireLock(self::$key1, 'owner1', 1));
+
+        CLI::wait(2);
+
+        $this->assertTrue($store->acquireLock(self::$key1, 'owner2', 60));
+        $this->assertSame('owner2', $store->getLockOwner(self::$key1));
+        $this->assertFalse($store->releaseLock(self::$key1, 'owner1'));
+        $this->assertFalse($store->refreshLock(self::$key1, 'owner1', 120));
+        $this->assertTrue($store->releaseLock(self::$key1, 'owner2'));
     }
 
     public function testSavePermanent(): void
@@ -200,11 +249,18 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
 
     public function testReconnect(): void
     {
+        $handler = $this->handler;
+
+        $this->assertInstanceOf(LockStoreProviderInterface::class, $handler);
+
+        $lockStore = $handler->lockStore();
+
         $this->handler->save(self::$key1, 'value');
         $this->assertSame('value', $this->handler->get(self::$key1));
 
         $this->assertTrue($this->handler->reconnect());
 
         $this->assertSame('value', $this->handler->get(self::$key1));
+        $this->assertNotSame($lockStore, $handler->lockStore());
     }
 }

--- a/tests/system/Lock/LockTest.php
+++ b/tests/system/Lock/LockTest.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace CodeIgniter\Lock;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Cache\Exceptions\CacheException;
+use CodeIgniter\Cache\Handlers\DummyHandler;
+use CodeIgniter\Cache\LockStoreInterface;
+use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Lock\Exceptions\LockException;
@@ -196,6 +200,21 @@ final class LockTest extends CIUnitTestCase
 
         // @phpstan-ignore argument.type
         new LockManager(CacheFactory::getHandler($this->config, 'dummy'));
+    }
+
+    public function testUnsupportedLockStoreProviderThrows(): void
+    {
+        $cache = new class () extends DummyHandler implements LockStoreProviderInterface {
+            public function lockStore(): LockStoreInterface
+            {
+                throw CacheException::forUnsupportedLockStore();
+            }
+        };
+
+        $this->expectException(LockException::class);
+        $this->expectExceptionMessage('does not support locks');
+
+        new LockManager($cache);
     }
 
     private function lockFile(string $name): string

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -225,7 +225,7 @@ Libraries
 
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
-- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers.
+- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**.
 - **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 - **Logging:** Added :ref:`per-call context logging <logging-per-call-context>` with three new ``Config\Logger`` options (``$logContext``, ``$logContextTrace``, ``$logContextUsedKeys``). Per PSR-3, a ``Throwable`` in the ``exception`` context key is automatically normalized to a meaningful array. All options default to ``false``.
 

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -225,7 +225,7 @@ Libraries
 
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
-- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**.
+- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**. Memcached support has driver-specific release limitations because Memcached has no atomic compare-and-delete command.
 - **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 - **Logging:** Added :ref:`per-call context logging <logging-per-call-context>` with three new ``Config\Logger`` options (``$logContext``, ``$logContextTrace``, ``$logContextUsedKeys``). Per PSR-3, a ``Throwable`` in the ``exception`` context key is automatically normalized to a meaningful array. All options default to ``false``.
 

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -274,6 +274,9 @@ Others
 Message Changes
 ***************
 
+- Added new language key:
+    - ``Cache.unsupportedLockStore`` (``CacheException::forUnsupportedLockStore()``)
+
 - Removed deprecated language keys tied to removed exception constructors:
     - ``Core.missingExtension`` (``FrameworkException::forMissingExtension()``)
     - ``HTTP.cannotSetCache`` (``DownloadException::forCannotSetCache()``)

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -20,8 +20,8 @@ Configuration
 *************
 
 The Locks library uses the Cache service. The cache handler must support atomic
-lock operations. The built-in **File**, **Redis**, and **Predis** cache handlers
-support locks.
+lock operations. The built-in **File**, **Redis**, **Predis**, and
+**Memcached** cache handlers support locks.
 
 .. note:: Locks are most useful when all competing processes share the same cache
     storage. The File handler is suitable for a single server. For multiple
@@ -32,6 +32,11 @@ support locks.
     Redis ``FLUSHDB``, may remove active locks. Avoid clearing shared lock
     storage while lock-protected work is running, or use a dedicated cache
     store for locks when that separation is important.
+
+.. note:: Memcached lock support requires the ``memcached`` PHP extension.
+    The older ``memcache`` extension does not provide the CAS operations needed
+    for owner-aware release and refresh. Memcached locks may also be lost if the
+    Memcached server restarts, evicts keys, or flushes its cache.
 
 .. note:: File-backed locks clear released and expired lock contents, but may
     leave empty lock files in the cache directory. These files do not represent

--- a/user_guide_src/source/libraries/locks.rst
+++ b/user_guide_src/source/libraries/locks.rst
@@ -19,9 +19,10 @@ critical section, and release it when the work is finished.
 Configuration
 *************
 
-The Locks library uses the Cache service. The cache handler must support atomic
-lock operations. The built-in **File**, **Redis**, **Predis**, and
-**Memcached** cache handlers support locks.
+The Locks library uses the Cache service. The cache handler must support
+owner-aware lock operations. The built-in **File**, **Redis**, and **Predis**
+cache handlers support atomic lock operations. The **Memcached** cache handler
+also supports locks, with Memcached-specific limitations described below.
 
 .. note:: Locks are most useful when all competing processes share the same cache
     storage. The File handler is suitable for a single server. For multiple
@@ -34,9 +35,13 @@ lock operations. The built-in **File**, **Redis**, **Predis**, and
     store for locks when that separation is important.
 
 .. note:: Memcached lock support requires the ``memcached`` PHP extension.
-    The older ``memcache`` extension does not provide the CAS operations needed
-    for owner-aware release and refresh. Memcached locks may also be lost if the
-    Memcached server restarts, evicts keys, or flushes its cache.
+    The older ``memcache`` extension does not provide the CAS operations used
+    for owner-aware refresh and best-effort release. Memcached does not provide
+    an atomic compare-and-delete command, so releasing a Memcached lock cannot
+    provide the same owner-checked atomic release guarantee as Redis or Predis.
+    A delayed release may delete a lock that expired and was acquired by another
+    owner. Memcached locks may also be lost if the Memcached server restarts,
+    evicts keys, or flushes its cache.
 
 .. note:: File-backed locks clear released and expired lock contents, but may
     leave empty lock files in the cache directory. These files do not represent


### PR DESCRIPTION
**Description**

This PR follows up on the new Atomic Locks feature added in #10145 by adding Memcached as a supported lock store.

The initial locks PR intentionally shipped with File, Redis, and Predis support first because Memcached needed a more careful owner-aware design. This PR adds that missing store using the `memcached` PHP extension and CAS-based release/refresh behavior.

**Implementation**

This adds:

- `CodeIgniter\Cache\LockStores\MemcachedLockStore`
- `MemcachedHandler::lockStore()`
- live Memcached lock tests
- docs and changelog updates

The implementation keeps the structure introduced in #10145:

- Lock behavior lives in a dedicated `*LockStore` class.
- `MemcachedHandler` only acts as a `LockStoreProviderInterface`.
- `CodeIgniter\Lock` continues to depend on cache lock-store contracts, not concrete cache handlers.

**Memcached Behavior**

Lock acquisition uses Memcached's atomic `add()` operation.

Owner-aware `release()` and `refresh()` use CAS tokens from `Memcached::GET_EXTENDED`. This avoids the unsafe `get owner -> delete/touch` pattern where a lock could expire and be reacquired by another owner between operations.

Memcached does not provide an atomic compare-and-delete command, so release first uses CAS to shorten the TTL for the current owner before deleting the key. This keeps the owner check atomic while staying within Memcached's available operations.

The older `memcache` PHP extension is not supported for locks because it does not provide the CAS operations needed for owner-aware release and refresh. If `MemcachedHandler` is running with `memcache`, resolving locks fails with the normal lock unsupported-store exception.

**Research Notes**

This follows the same general direction as other ecosystems. Symfony provides a dedicated MemcachedStore in its Lock component [[1]](https://symfony.com/doc/current/components/lock.html#memcachedstore), [[2]](https://github.com/symfony/lock/blob/7.3/Store/MemcachedStore.php), and Laravel has a [MemcachedLock](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Cache/MemcachedLock.php) implementation in its cache lock system.

For the Memcached-specific design, the important primitives are atomic `add()` for acquisition and CAS tokens for owner-aware updates. PHP exposes CAS metadata through [`Memcached::GET_EXTENDED`](https://www.php.net/manual/en/memcached.get.php), while Memcached’s protocol documents `add` / CAS as the available race-safe storage primitives.

**Testing**

Added live Memcached coverage for:

- acquiring a lock
- rejecting competing owners
- owner-aware release
- owner-aware refresh
- active and missing-key force release
- expiry and reacquisition by a new owner
- handler reconnect refreshing the memoized lock store
- normalizing provider-time unsupported-store failures

**Checklist**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
