### PR TITLE
fix: SQLSRV driver's `decrement()` method

### DIFF
--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -269,7 +269,7 @@ class Builder extends BaseBuilder
         if ($this->castTextToInt) {
             $values = [$column => "CONVERT(VARCHAR(MAX),CONVERT(INT,CONVERT(VARCHAR(MAX), {$column})) - {$value})"];
         } else {
-            $values = [$column => "{$column} + {$value}"];
+            $values = [$column => "{$column} - {$value}"];
         }
 
         $sql = $this->_update($this->QBFrom[0], $values);

--- a/tests/system/Database/Live/SQLSRV/IncrementTest.php
+++ b/tests/system/Database/Live/SQLSRV/IncrementTest.php
@@ -43,7 +43,7 @@ final class IncrementTest extends CIUnitTestCase
     {
         $this->hasInDatabase('job', ['name' => 'incremental', 'created_at' => 6]);
 
-        $this->assertTrue($this->db->table('job') instanceof Builder);
+        $this->assertInstanceOf(Builder::class, $this->db->table('job'));
 
         $this->db->table('job')->castTextToInt = false;
 
@@ -58,7 +58,7 @@ final class IncrementTest extends CIUnitTestCase
     {
         $this->hasInDatabase('job', ['name' => 'decremental', 'created_at' => 6]);
 
-        $this->assertTrue($this->db->table('job') instanceof Builder);
+        $this->assertInstanceOf(Builder::class, $this->db->table('job'));
 
         $this->db->table('job')->castTextToInt = false;
 

--- a/tests/system/Database/Live/SQLSRV/IncrementTest.php
+++ b/tests/system/Database/Live/SQLSRV/IncrementTest.php
@@ -65,7 +65,7 @@ final class IncrementTest extends CIUnitTestCase
 
         $builder->castTextToInt = false;
 
-        $builder->where('name', 'incremental')
+        $builder->where('name', 'decremental')
             ->decrement('created_at');
 
         $this->seeInDatabase('job', ['name' => 'decremental', 'created_at' => 5]);

--- a/tests/system/Database/Live/SQLSRV/IncrementTest.php
+++ b/tests/system/Database/Live/SQLSRV/IncrementTest.php
@@ -43,9 +43,9 @@ final class IncrementTest extends CIUnitTestCase
     {
         $this->hasInDatabase('job', ['name' => 'incremental', 'created_at' => 6]);
 
-        $this->assertInstanceOf(Builder::class, $this->db->table('job'));
-
         $builder = $this->db->table('job');
+
+        $this->assertInstanceOf(Builder::class, $builder);
 
         $builder->castTextToInt = false;
 
@@ -59,9 +59,9 @@ final class IncrementTest extends CIUnitTestCase
     {
         $this->hasInDatabase('job', ['name' => 'decremental', 'created_at' => 6]);
 
-        $this->assertInstanceOf(Builder::class, $this->db->table('job'));
-
         $builder = $this->db->table('job');
+
+        $this->assertInstanceOf(Builder::class, $builder);
 
         $builder->castTextToInt = false;
 

--- a/tests/system/Database/Live/SQLSRV/IncrementTest.php
+++ b/tests/system/Database/Live/SQLSRV/IncrementTest.php
@@ -45,10 +45,11 @@ final class IncrementTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Builder::class, $this->db->table('job'));
 
-        $this->db->table('job')->castTextToInt = false;
+        $builder = $this->db->table('job');
 
-        $this->db->table('job')
-            ->where('name', 'incremental')
+        $builder->castTextToInt = false;
+
+        $builder->where('name', 'incremental')
             ->increment('created_at');
 
         $this->seeInDatabase('job', ['name' => 'incremental', 'created_at' => 7]);
@@ -60,10 +61,11 @@ final class IncrementTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Builder::class, $this->db->table('job'));
 
-        $this->db->table('job')->castTextToInt = false;
+        $builder = $this->db->table('job');
 
-        $this->db->table('job')
-            ->where('name', 'decremental')
+        $builder->castTextToInt = false;
+
+        $builder->where('name', 'incremental')
             ->decrement('created_at');
 
         $this->seeInDatabase('job', ['name' => 'decremental', 'created_at' => 5]);

--- a/tests/system/Database/Live/SQLSRV/IncrementTest.php
+++ b/tests/system/Database/Live/SQLSRV/IncrementTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live\SQLSRV;
+
+use CodeIgniter\Database\SQLSRV\Builder;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class IncrementTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->db->DBDriver !== 'SQLSRV') {
+            $this->markTestSkipped('This test is only for SQLSRV.');
+        }
+    }
+
+    public function testIncrementWhenCastTextToIntFalse(): void
+    {
+        $this->hasInDatabase('job', ['name' => 'incremental', 'created_at' => 6]);
+
+        $this->assertTrue($this->db->table('job') instanceof Builder);
+
+        $this->db->table('job')->castTextToInt = false;
+
+        $this->db->table('job')
+            ->where('name', 'incremental')
+            ->increment('created_at');
+
+        $this->seeInDatabase('job', ['name' => 'incremental', 'created_at' => 7]);
+    }
+
+    public function testDecrementWhenCastTextToIntFalse(): void
+    {
+        $this->hasInDatabase('job', ['name' => 'decremental', 'created_at' => 6]);
+
+        $this->assertTrue($this->db->table('job') instanceof Builder);
+
+        $this->db->table('job')->castTextToInt = false;
+
+        $this->db->table('job')
+            ->where('name', 'decremental')
+            ->decrement('created_at');
+
+        $this->seeInDatabase('job', ['name' => 'decremental', 'created_at' => 5]);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -40,9 +40,9 @@ Bugs Fixed
 - **CLI:** Fixed a bug where ``CLI::generateDimensions()`` leaked ``stty`` error output (e.g., ``stty: 'standard input': Inappropriate ioctl for device``) to stderr when stdin was not a TTY.
 - **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
+- **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.
-- **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
 
 See the repo's

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -43,6 +43,7 @@ Bugs Fixed
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
+- **SQLSRV Database Driver:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -42,8 +42,8 @@ Bugs Fixed
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.
+- **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
-- **SQLSRV Database Driver:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
As discovered by @paulbalandan in [this](https://github.com/codeigniter4/CodeIgniter4/pull/10140#discussion_r3143852662) comment, SQLSRV Database Driver was incorrectly adding instead of subtracting the decrement value when `$castTextToInt` was false.

This PR fixes that bug by flipping the sign in `decrement()` function.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
