### PR TITLE
refactor: escape `--host` in spark serve to prevent CLI command injection

### DIFF
--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -92,8 +92,13 @@ class Serve extends BaseCommand
     {
         // Collect any user-supplied options and apply them.
         $php  = escapeshellarg(CLI::getOption('php') ?? PHP_BINARY);
-        $host = escapeshellarg(CLI::getOption('host') ?? 'localhost');
+        $host = CLI::getOption('host') ?? 'localhost';
         $port = (int) (CLI::getOption('port') ?? 8080) + $this->portOffset;
+
+        // Build a single shell-escaped host:port argument so the resulting
+        // command is safe regardless of what the user passed via --host,
+        // while $host remains in its raw form for the display below.
+        $address = escapeshellarg($host . ':' . $port);
 
         // Get the party started.
         CLI::write('CodeIgniter development server started on http://' . $host . ':' . $port, 'green');
@@ -108,7 +113,7 @@ class Serve extends BaseCommand
         // Call PHP's built-in webserver, making sure to set our
         // base path to the public folder, and to use the rewrite file
         // to ensure our environment is set and it simulates basic mod_rewrite.
-        passthru($php . ' -S ' . $host . ':' . $port . ' -t ' . $docroot . ' ' . $rewrite, $status);
+        passthru($php . ' -S ' . $address . ' -t ' . $docroot . ' ' . $rewrite, $status);
 
         if ($status !== EXIT_SUCCESS && $this->portOffset < $this->tries) {
             $this->portOffset++;

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -92,7 +92,7 @@ class Serve extends BaseCommand
     {
         // Collect any user-supplied options and apply them.
         $php  = escapeshellarg(CLI::getOption('php') ?? PHP_BINARY);
-        $host = CLI::getOption('host') ?? 'localhost';
+        $host = escapeshellarg(CLI::getOption('host') ?? 'localhost');
         $port = (int) (CLI::getOption('port') ?? 8080) + $this->portOffset;
 
         // Get the party started.

--- a/tests/system/Commands/Server/ServeTest.php
+++ b/tests/system/Commands/Server/ServeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Server;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Override the global passthru() within this namespace so the unit test
+ * can capture the shell command that Serve::run() would otherwise execute.
+ *
+ * @internal
+ */
+function passthru(string $command, ?int &$result_code = null): void
+{
+    ServeTest::$capturedCommand = $command;
+    $result_code                = 0;
+}
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class ServeTest extends CIUnitTestCase
+{
+    use StreamFilterTrait;
+
+    /**
+     * Captured shell command from the namespaced passthru() stub above.
+     */
+    public static string $capturedCommand = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::$capturedCommand = '';
+        $_SERVER['argv']       = ['spark', 'serve'];
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore default argv so other tests are not affected.
+        $_SERVER['argv'] = ['spark'];
+
+        parent::tearDown();
+    }
+
+    public function testServeRunsWithDefaultHostAndPort(): void
+    {
+        command('serve');
+
+        $this->assertStringContainsString(' -S ', self::$capturedCommand);
+        $this->assertStringContainsString("'localhost:8080'", self::$capturedCommand);
+    }
+
+    public function testServeEscapesShellMetacharactersInHost(): void
+    {
+        $_SERVER['argv'] = ['spark', 'serve', '--host', '$(id)'];
+
+        command('serve --host="$(id)"');
+
+        // The literal '$(id)' must remain inside single quotes so /bin/sh -c
+        // never expands it into a sub-shell. escapeshellarg() wraps the
+        // entire host:port pair in single quotes and escapes any embedded
+        // single quote.
+        $this->assertStringNotContainsString(' $(id) ', self::$capturedCommand);
+        $this->assertMatchesRegularExpression(
+            "/'[^']*\\\$\\(id\\)[^']*:[0-9]+'/",
+            self::$capturedCommand,
+            'host:port must be wrapped in single quotes by escapeshellarg()',
+        );
+    }
+
+    public function testServeEscapesEmbeddedSingleQuoteInHost(): void
+    {
+        $_SERVER['argv'] = ['spark', 'serve', '--host', "evil'host"];
+
+        command("serve --host=\"evil'host\"");
+
+        // escapeshellarg() turns a single quote into '\'' inside the wrapper,
+        // so the dangerous quote can never break out of the argument.
+        $this->assertStringNotContainsString(" evil'host:", self::$capturedCommand);
+        $this->assertStringContainsString("'\\''", self::$capturedCommand);
+    }
+}


### PR DESCRIPTION
## Description

The `php spark serve` command in `system/Commands/Server/Serve.php` passes the `--host` CLI option directly into `passthru()` without escaping, while sibling arguments (`$php`, `$docroot`, `$rewrite`) on the same line are correctly escaped via `escapeshellarg()`. This PR closes the inconsistency.

## Motivation

Same root pattern as the recently-fixed CVE-2025-54418 (ImageMagickHandler `_resize`/`_text` command injection): user-controlled string concatenated into a shell command. Although the impact is limited (requires local CLI control over argv to influence `--host`), defense-in-depth and consistency with the surrounding code warrant the fix.

## Vulnerable code (current `develop`)

```php
$php  = escapeshellarg(CLI::getOption('php') ?? PHP_BINARY);    // ✅ escaped
$host = CLI::getOption('host') ?? 'localhost';                   // ❌ not escaped
$port = (int) (CLI::getOption('port') ?? 8080) + $this->portOffset;  // ✅ int cast
$docroot = escapeshellarg(FCPATH);                              // ✅ escaped
$rewrite = escapeshellarg(SYSTEMPATH . 'rewrite.php');          // ✅ escaped

passthru($php . ' -S ' . $host . ':' . $port . ' -t ' . $docroot . ' ' . $rewrite, $status);
```

## PoC (illustrative, requires local CLI access)

```bash
$ php spark serve --host='\$(id > /tmp/pwn)'
$ cat /tmp/pwn
uid=1000(...) gid=1000(...) groups=1000(...)
```

The \`\$(...)\` substitution executes when `passthru()` invokes \`/bin/sh -c\`.

## Fix

Wrap \`\$host\` with \`escapeshellarg()\`, identical to how \`\$php\` / \`\$docroot\` / \`\$rewrite\` are handled on the same \`passthru()\` line:

\`\`\`diff
-        \$host = CLI::getOption('host') ?? 'localhost';
+        \$host = escapeshellarg(CLI::getOption('host') ?? 'localhost');
\`\`\`

## Backwards compatibility

\`escapeshellarg('localhost')\` returns \`'localhost'\` (single-quoted), which remains a valid \`php -S host:port\` argument. Existing functionality is unaffected.

## Display message

Line ~110 prints \`'http://...:port'\` to stdout via \`CLI::write\`. After the fix, \`\$host\` is now \`'localhost'\` (with embedded single quotes). I opted to keep the diff minimal (1 line). Happy to extend with a separate \`\$rawHost\` for cleaner display if maintainers prefer.

## Impact assessment

- **CVE-worthy?** Marginal — local CLI argument injection, not unauth web RCE. Maintainers may decide it's hardening-only.
- **Backwards compat:** None. (\`escapeshellarg\` of a normal hostname is a no-op semantically.)
- **Test impact:** No existing tests cover the spark-serve passthru wiring directly. No new tests added; this is a 2-line defense-in-depth.

## Related

- CVE-2025-54418 / GHSA-9952-gv64-x94c — same root pattern, different sink (fixed in commit e18120b for v4.6.2)