### PR TITLE
feat: add CURLRequest retry option

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -91,7 +91,7 @@ class CURLRequest extends OutgoingRequest
         'max_retries'         => 3,
         'delay'               => 1000,
         'max_delay'           => 30_000,
-        'status_codes'        => [429, 503],
+        'status_codes'        => [429, 503, 504],
         'curl_errors'         => false,
         'respect_retry_after' => true,
     ];
@@ -980,7 +980,7 @@ class CURLRequest extends OutgoingRequest
         if ($output === false) {
             $this->lastCurlError = curl_errno($ch);
 
-            throw HTTPException::forCurlError((string) curl_errno($ch), curl_error($ch));
+            throw HTTPException::forCurlError((string) $this->lastCurlError, curl_error($ch));
         }
 
         return $output;

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -480,7 +480,7 @@ class CURLRequest extends OutgoingRequest
 
             if (! $this->shouldRetryResponse($response, $retry, $attempt)) {
                 if ($httpErrors && $response->getStatusCode() >= 400) {
-                    throw HTTPException::forCurlError('22', 'The requested URL returned error: ' . $response->getStatusCode());
+                    throw HTTPException::forCurlError((string) CURLE_HTTP_RETURNED_ERROR, 'The requested URL returned error: ' . $response->getStatusCode());
                 }
 
                 return $response;
@@ -623,9 +623,9 @@ class CURLRequest extends OutgoingRequest
         $delay = $retry['delay'];
 
         if (is_array($delay)) {
-            $lastDelay = end($delay);
+            $lastDelay = $delay[array_key_last($delay)] ?? 0;
 
-            return $this->limitRetryDelay((int) ($delay[$attempt] ?? ($lastDelay !== false ? $lastDelay : 0)), $retry);
+            return $this->limitRetryDelay((int) ($delay[$attempt] ?? $lastDelay), $retry);
         }
 
         return $this->limitRetryDelay((int) $delay, $retry);

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -101,13 +101,7 @@ class CURLRequest extends OutgoingRequest
      *
      * @var list<int>
      */
-    protected $transientCurlErrors = [
-        CURLE_COULDNT_RESOLVE_HOST,
-        CURLE_COULDNT_CONNECT,
-        CURLE_OPERATION_TIMEDOUT,
-        CURLE_SEND_ERROR,
-        CURLE_RECV_ERROR,
-    ];
+    protected $transientCurlErrors = [];
 
     /**
      * The number of milliseconds to delay before
@@ -158,6 +152,14 @@ class CURLRequest extends OutgoingRequest
         if (! function_exists('curl_version')) {
             throw HTTPException::forMissingCurl(); // @codeCoverageIgnore
         }
+
+        $this->transientCurlErrors = [
+            CURLE_COULDNT_RESOLVE_HOST,
+            CURLE_COULDNT_CONNECT,
+            CURLE_OPERATION_TIMEDOUT,
+            CURLE_SEND_ERROR,
+            CURLE_RECV_ERROR,
+        ];
 
         parent::__construct(Method::GET, $uri);
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -87,7 +87,7 @@ class CURLRequest extends OutgoingRequest
      *
      * @var array<string, bool|int|list<int>>
      */
-    protected $retryDefaults = [
+    protected array $retryDefaults = [
         'max_retries'         => 3,
         'delay'               => 1000,
         'max_delay'           => 30_000,
@@ -101,7 +101,7 @@ class CURLRequest extends OutgoingRequest
      *
      * @var list<int>
      */
-    protected $transientCurlErrors = [];
+    protected array $transientCurlErrors = [];
 
     /**
      * The number of milliseconds to delay before

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -83,12 +83,44 @@ class CURLRequest extends OutgoingRequest
     ];
 
     /**
+     * Default values for when 'retry' is enabled.
+     *
+     * @var array<string, bool|int|list<int>>
+     */
+    protected $retryDefaults = [
+        'max_retries'         => 3,
+        'delay'               => 1000,
+        'max_delay'           => 30_000,
+        'status_codes'        => [429, 503],
+        'curl_errors'         => false,
+        'respect_retry_after' => true,
+    ];
+
+    /**
+     * cURL error numbers that may succeed on another attempt.
+     *
+     * @var list<int>
+     */
+    protected $transientCurlErrors = [
+        CURLE_COULDNT_RESOLVE_HOST,
+        CURLE_COULDNT_CONNECT,
+        CURLE_OPERATION_TIMEDOUT,
+        CURLE_SEND_ERROR,
+        CURLE_RECV_ERROR,
+    ];
+
+    /**
      * The number of milliseconds to delay before
      * sending the request.
      *
      * @var float
      */
     protected $delay = 0.0;
+
+    /**
+     * The last cURL error number.
+     */
+    protected int $lastCurlError = 0;
 
     /**
      * The default options from the constructor. Applied to all requests.
@@ -374,6 +406,8 @@ class CURLRequest extends OutgoingRequest
     {
         // Reset our curl options so we're on a fresh slate.
         $curlOptions = [];
+        $config      = $this->config;
+        $retry       = $this->normalizeRetryOption($config['retry'] ?? false);
 
         if (! empty($this->config['query']) && is_array($this->config['query'])) {
             // This is likely too naive a solution.
@@ -394,14 +428,75 @@ class CURLRequest extends OutgoingRequest
         // Disable @file uploads in post data.
         $curlOptions[CURLOPT_SAFE_UPLOAD] = true;
 
-        $curlOptions = $this->setCURLOptions($curlOptions, $this->config);
+        $curlOptions = $this->setCURLOptions($curlOptions, $config);
         $curlOptions = $this->applyMethod($method, $curlOptions);
         $curlOptions = $this->applyRequestHeaders($curlOptions);
 
+        if ($retry !== null) {
+            $curlOptions[CURLOPT_FAILONERROR] = false;
+        }
+
         // Do we need to delay this request?
         if ($this->delay > 0) {
-            usleep((int) $this->delay * 1_000_000);
+            $this->sleep($this->delay);
         }
+
+        if ($retry === null) {
+            return $this->sendAttempt($curlOptions);
+        }
+
+        $httpErrors = array_key_exists('http_errors', $config) ? (bool) $config['http_errors'] : true;
+
+        return $this->sendWithRetries($curlOptions, $retry, $httpErrors);
+    }
+
+    /**
+     * Sends the request until it succeeds or retry attempts are exhausted.
+     *
+     * @param array<int, mixed>                 $curlOptions
+     * @param array<string, bool|int|list<int>> $retry
+     */
+    protected function sendWithRetries(array $curlOptions, array $retry, bool $httpErrors): ResponseInterface
+    {
+        $attempt = 0;
+
+        while (true) {
+            $this->response = clone $this->responseOrig;
+
+            try {
+                $response = $this->sendAttempt($curlOptions);
+            } catch (HTTPException $e) {
+                if (! $this->shouldRetryCurlError($retry, $attempt)) {
+                    throw $e;
+                }
+
+                $this->sleep($this->getRetryDelay($retry, $attempt) / 1000);
+                $attempt++;
+
+                continue;
+            }
+
+            if (! $this->shouldRetryResponse($response, $retry, $attempt)) {
+                if ($httpErrors && $response->getStatusCode() >= 400) {
+                    throw HTTPException::forCurlError('22', 'The requested URL returned error: ' . $response->getStatusCode());
+                }
+
+                return $response;
+            }
+
+            $this->sleep($this->getRetryDelay($retry, $attempt, $response) / 1000);
+            $attempt++;
+        }
+    }
+
+    /**
+     * Sends a single cURL request attempt and populates the response.
+     *
+     * @param array<int, mixed> $curlOptions
+     */
+    protected function sendAttempt(array $curlOptions): ResponseInterface
+    {
+        $this->lastCurlError = 0;
 
         $output = $this->sendRequest($curlOptions);
 
@@ -428,6 +523,158 @@ class CURLRequest extends OutgoingRequest
         }
 
         return $this->response;
+    }
+
+    /**
+     * Normalizes the retry option into retry settings.
+     *
+     * @return array<string, bool|int|list<int>>|null
+     */
+    protected function normalizeRetryOption(mixed $retry): ?array
+    {
+        if (in_array($retry, [false, null, 0], true)) {
+            return null;
+        }
+
+        $config = $this->retryDefaults;
+
+        if (is_int($retry)) {
+            $config['max_retries'] = $retry;
+        } elseif (is_array($retry)) {
+            $config = array_merge($config, $retry);
+        } else {
+            return null;
+        }
+
+        $config['max_retries'] = max(0, (int) $config['max_retries']);
+
+        if ($config['max_retries'] === 0) {
+            return null;
+        }
+
+        $config['delay']               = $this->normalizeRetryDelay($config['delay']);
+        $config['max_delay']           = max(0, (int) $config['max_delay']);
+        $config['status_codes']        = array_map(intval(...), (array) $config['status_codes']);
+        $config['curl_errors']         = (bool) $config['curl_errors'];
+        $config['respect_retry_after'] = (bool) $config['respect_retry_after'];
+
+        return $config;
+    }
+
+    /**
+     * Normalizes the retry delay setting.
+     *
+     * @return int|list<int>
+     */
+    protected function normalizeRetryDelay(mixed $delay): array|int
+    {
+        if (is_array($delay)) {
+            return array_map(static fn ($value): int => max(0, (int) $value), $delay);
+        }
+
+        return max(0, (int) $delay);
+    }
+
+    /**
+     * Determines whether a response should be retried.
+     *
+     * @param array<string, bool|int|list<int>> $retry
+     */
+    protected function shouldRetryResponse(ResponseInterface $response, array $retry, int $attempt): bool
+    {
+        if ($attempt >= $retry['max_retries']) {
+            return false;
+        }
+
+        return in_array($response->getStatusCode(), $retry['status_codes'], true);
+    }
+
+    /**
+     * Determines whether a cURL error should be retried.
+     *
+     * @param array<string, bool|int|list<int>> $retry
+     */
+    protected function shouldRetryCurlError(array $retry, int $attempt): bool
+    {
+        if ($attempt >= $retry['max_retries'] || $retry['curl_errors'] === false) {
+            return false;
+        }
+
+        return in_array($this->lastCurlError, $this->transientCurlErrors, true);
+    }
+
+    /**
+     * Returns the delay before the next retry attempt.
+     *
+     * @param array<string, bool|int|list<int>> $retry
+     */
+    protected function getRetryDelay(array $retry, int $attempt, ?ResponseInterface $response = null): int
+    {
+        if ($response instanceof ResponseInterface && $retry['respect_retry_after'] === true) {
+            $retryAfter = $this->getRetryAfterDelay($response);
+
+            if ($retryAfter !== null) {
+                return $this->limitRetryDelay($retryAfter * 1000, $retry);
+            }
+        }
+
+        $delay = $retry['delay'];
+
+        if (is_array($delay)) {
+            $lastDelay = end($delay);
+
+            return $this->limitRetryDelay((int) ($delay[$attempt] ?? ($lastDelay !== false ? $lastDelay : 0)), $retry);
+        }
+
+        return $this->limitRetryDelay((int) $delay, $retry);
+    }
+
+    /**
+     * Caps the retry delay when configured.
+     *
+     * @param array<string, bool|int|list<int>> $retry
+     */
+    protected function limitRetryDelay(int $delay, array $retry): int
+    {
+        $maxDelay = (int) $retry['max_delay'];
+
+        if ($maxDelay === 0) {
+            return $delay;
+        }
+
+        return min($delay, $maxDelay);
+    }
+
+    /**
+     * Returns the delay from a Retry-After header in seconds.
+     */
+    protected function getRetryAfterDelay(ResponseInterface $response): ?int
+    {
+        $retryAfter = $response->getHeaderLine('Retry-After');
+
+        if ($retryAfter === '') {
+            return null;
+        }
+
+        if (ctype_digit($retryAfter)) {
+            return (int) $retryAfter;
+        }
+
+        $timestamp = strtotime($retryAfter);
+
+        if ($timestamp === false) {
+            return null;
+        }
+
+        return max(0, $timestamp - time());
+    }
+
+    /**
+     * Sleeps for the configured number of seconds.
+     */
+    protected function sleep(float $seconds): void
+    {
+        usleep((int) ($seconds * 1_000_000));
     }
 
     /**
@@ -731,6 +978,8 @@ class CURLRequest extends OutgoingRequest
         $output = curl_exec($ch);
 
         if ($output === false) {
+            $this->lastCurlError = curl_errno($ch);
+
             throw HTTPException::forCurlError((string) curl_errno($ch), curl_error($ch));
         }
 

--- a/system/Test/Mock/MockCURLRequest.php
+++ b/system/Test/Mock/MockCURLRequest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Test\Mock;
 
 use CodeIgniter\HTTP\CURLRequest;
+use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\URI;
 
 /**
@@ -34,6 +35,21 @@ class MockCURLRequest extends CURLRequest
     protected $output = '';
 
     /**
+     * @var list<string>
+     */
+    protected array $outputs = [];
+
+    /**
+     * @var list<array{0: int, 1: string}>
+     */
+    protected array $curlErrors = [];
+
+    /**
+     * @var list<float>
+     */
+    protected array $sleeps = [];
+
+    /**
      * @param string $output
      *
      * @return $this
@@ -41,6 +57,30 @@ class MockCURLRequest extends CURLRequest
     public function setOutput($output)
     {
         $this->output = $output;
+
+        return $this;
+    }
+
+    /**
+     * @param list<string> $outputs
+     *
+     * @return $this
+     */
+    public function setOutputs(array $outputs)
+    {
+        $this->outputs = $outputs;
+
+        return $this;
+    }
+
+    /**
+     * @param list<array{0: int, 1: string}> $curlErrors
+     *
+     * @return $this
+     */
+    public function setCurlErrors(array $curlErrors)
+    {
+        $this->curlErrors = $curlErrors;
 
         return $this;
     }
@@ -54,7 +94,28 @@ class MockCURLRequest extends CURLRequest
 
         $this->curl_options = $curlOptions;
 
-        return $this->output;
+        if ($this->curlErrors !== []) {
+            [$this->lastCurlError, $message] = array_shift($this->curlErrors);
+
+            throw HTTPException::forCurlError((string) $this->lastCurlError, $message);
+        }
+
+        return $this->outputs !== [] ? array_shift($this->outputs) : $this->output;
+    }
+
+    protected function sleep(float $seconds): void
+    {
+        $this->sleeps[] = $seconds;
+    }
+
+    /**
+     * for testing purposes only
+     *
+     * @return list<float>
+     */
+    public function getSleeps(): array
+    {
+        return $this->sleeps;
     }
 
     /**

--- a/tests/system/HTTP/CURLRequestRetryTest.php
+++ b/tests/system/HTTP/CURLRequestRetryTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Config\Services;
+use CodeIgniter\HTTP\Exceptions\HTTPException;
+use CodeIgniter\Superglobals;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockCURLRequest;
+use Config\App;
+use Config\CURLRequest as ConfigCURLRequest;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class CURLRequestRetryTest extends CIUnitTestCase
+{
+    private MockCURLRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetServices();
+        Services::injectMock('superglobals', new Superglobals());
+        $this->request = $this->getRequest();
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function getRequest(array $options = []): MockCURLRequest
+    {
+        $uri = new URI($options['baseURI'] ?? null);
+
+        $config               = new ConfigCURLRequest();
+        $config->shareOptions = false;
+
+        Factories::injectMock('config', 'CURLRequest', $config);
+
+        return new MockCURLRequest(new App(), $uri, new Response(), $options);
+    }
+
+    public function testRetryIntegerRetriesDefaultStatusCodes(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFirst failure",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry'       => 3,
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Success', $response->getBody());
+        $this->assertSame([1.0], $this->request->getSleeps());
+    }
+
+    public function testRetryUsesCustomStatusCodes(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 500 Internal Server Error\r\n\r\nFirst failure",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries'  => 1,
+                'delay'        => 100,
+                'status_codes' => [500],
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([0.1], $this->request->getSleeps());
+    }
+
+    public function testRetryDoesNotRetryUnconfiguredStatusCode(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 404 Not Found\r\n\r\nMissing",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry'       => 3,
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('Missing', $response->getBody());
+        $this->assertSame([], $this->request->getSleeps());
+    }
+
+    public function testZeroRetriesDisableRetryHandling(): void
+    {
+        $this->request->setOutput("HTTP/1.1 200 OK\r\n\r\nSuccess");
+
+        $this->request->get('http://example.com', [
+            'retry' => ['max_retries' => 0],
+        ]);
+
+        $this->assertTrue($this->request->curl_options[CURLOPT_FAILONERROR]);
+        $this->assertSame([], $this->request->getSleeps());
+    }
+
+    public function testRetryUsesDelayBackoffArray(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFirst failure",
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nSecond failure",
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nThird failure",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 3,
+                'delay'       => [100, 500],
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([0.1, 0.5, 0.5], $this->request->getSleeps());
+    }
+
+    public function testRetryClampsNegativeDelays(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFirst failure",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => -100,
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([0.0], $this->request->getSleeps());
+    }
+
+    public function testRetryAfterSecondsOverridesConfiguredDelay(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 2\r\n\r\nRate limited",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => 100,
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([2.0], $this->request->getSleeps());
+    }
+
+    public function testRetryAfterDateOverridesConfiguredDelay(): void
+    {
+        $retryAfter = gmdate('D, d M Y H:i:s', time() + 3600) . ' GMT';
+
+        $this->request->setOutputs([
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: {$retryAfter}\r\n\r\nUnavailable",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => 100,
+                'max_delay'   => 5000,
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([5.0], $this->request->getSleeps());
+    }
+
+    public function testRetryAfterIsCappedByDefaultMaxDelay(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 3600\r\n\r\nRate limited",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry'       => 1,
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([30.0], $this->request->getSleeps());
+    }
+
+    public function testRetryAfterCanBeDisabled(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 2\r\n\r\nRate limited",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries'         => 1,
+                'delay'               => 100,
+                'respect_retry_after' => false,
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([0.1], $this->request->getSleeps());
+    }
+
+    public function testRetryThrowsAfterExhaustingRetriesWhenHttpErrorsEnabled(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFirst failure",
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFinal failure",
+        ]);
+
+        $this->expectException(HTTPException::class);
+        $this->expectExceptionMessage('22 : The requested URL returned error: 503');
+
+        $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => 100,
+            ],
+        ]);
+    }
+
+    public function testRetryReturnsFinalResponseAfterExhaustingRetriesWhenHttpErrorsDisabled(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFirst failure",
+            "HTTP/1.1 503 Service Unavailable\r\n\r\nFinal failure",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => 100,
+            ],
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(503, $response->getStatusCode());
+        $this->assertSame('Final failure', $response->getBody());
+        $this->assertSame([0.1], $this->request->getSleeps());
+    }
+
+    public function testCurlErrorsAreNotRetriedByDefault(): void
+    {
+        $this->request->setCurlErrors([
+            [CURLE_OPERATION_TIMEDOUT, 'Operation timed out'],
+        ]);
+
+        $this->expectException(HTTPException::class);
+
+        $this->request->get('http://example.com', [
+            'retry' => 3,
+        ]);
+    }
+
+    public function testCurlErrorsCanBeRetried(): void
+    {
+        $this->request->setCurlErrors([
+            [CURLE_OPERATION_TIMEDOUT, 'Operation timed out'],
+        ])->setOutput("HTTP/1.1 200 OK\r\n\r\nSuccess");
+
+        $response = $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => 100,
+                'curl_errors' => true,
+            ],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Success', $response->getBody());
+        $this->assertSame([0.1], $this->request->getSleeps());
+    }
+
+    public function testNonTransientCurlErrorsAreNotRetried(): void
+    {
+        $this->request->setCurlErrors([
+            [CURLE_UNSUPPORTED_PROTOCOL, 'Unsupported protocol'],
+        ]);
+
+        $this->expectException(HTTPException::class);
+
+        $this->request->get('http://example.com', [
+            'retry' => [
+                'max_retries' => 1,
+                'delay'       => 100,
+                'curl_errors' => true,
+            ],
+        ]);
+    }
+}

--- a/tests/system/HTTP/CURLRequestRetryTest.php
+++ b/tests/system/HTTP/CURLRequestRetryTest.php
@@ -72,6 +72,23 @@ final class CURLRequestRetryTest extends CIUnitTestCase
         $this->assertSame([1.0], $this->request->getSleeps());
     }
 
+    public function testRetryIntegerRetriesDefaultGatewayTimeoutStatusCode(): void
+    {
+        $this->request->setOutputs([
+            "HTTP/1.1 504 Gateway Timeout\r\n\r\nFirst failure",
+            "HTTP/1.1 200 OK\r\n\r\nSuccess",
+        ]);
+
+        $response = $this->request->get('http://example.com', [
+            'retry'       => 1,
+            'http_errors' => false,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Success', $response->getBody());
+        $this->assertSame([1.0], $this->request->getSleeps());
+    }
+
     public function testRetryUsesCustomStatusCodes(): void
     {
         $this->request->setOutputs([

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -239,6 +239,7 @@ Helpers and Functions
 HTTP
 ====
 
+- Added the ``retry`` option to ``CURLRequest`` for retrying failed responses with configurable delays, retryable status codes, optional transient cURL error retries, and ``Retry-After`` support. See :ref:`curlrequest-request-options-retry`.
 - Added :ref:`Form Requests <form-requests>` - a new ``FormRequest`` base class that encapsulates validation rules, custom error messages, and authorization logic for a single HTTP request.
 - Added ``SSEResponse`` class for streaming Server-Sent Events (SSE) over HTTP. See :ref:`server-sent-events`.
 - ``Response`` and its child classes no longer require ``Config\App`` passed to their constructors.

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -374,6 +374,60 @@ You can pass along data to send as query string variables by passing an associat
 
 .. literalinclude:: curlrequest/029.php
 
+.. _curlrequest-request-options-retry:
+
+retry
+=====
+
+.. versionadded:: 4.8.0
+
+The ``retry`` option retries failed requests before returning the final response or throwing an exception.
+For simple cases, set ``retry`` to the number of retry attempts:
+
+.. code-block:: php
+
+    $response = $client->request('GET', 'https://api.example.com/items', [
+        'retry' => 3,
+    ]);
+
+For more control, pass an array:
+
+.. literalinclude:: curlrequest/041.php
+
+The available retry settings are:
+
+- ``max_retries``: Number of retries after the initial request. The default is ``3``.
+- ``delay``: Delay in milliseconds before retrying. This may be an integer or a list of integers
+  for simple backoff. If the list is shorter than the retry count, the last value is reused.
+  The default is ``1000``.
+- ``max_delay``: Maximum delay in milliseconds. This caps both the configured ``delay`` and a
+  valid ``Retry-After`` header. Set to ``0`` for no maximum delay. The default is ``30000``.
+- ``status_codes``: HTTP status codes that should be retried. The default is ``[429, 503]``.
+- ``curl_errors``: Whether to retry transient cURL errors. The default is ``false``.
+- ``respect_retry_after``: Whether to use a valid ``Retry-After`` header instead of the configured
+  ``delay``. The default is ``true``.
+
+When ``respect_retry_after`` is enabled, a valid ``Retry-After`` header takes priority over the
+configured ``delay``. The header may be either a number of seconds or an HTTP date. If the header
+is invalid, the configured ``delay`` is used instead.
+
+Because ``Retry-After`` is supplied by the remote server, it is capped by ``max_delay`` by default
+to avoid unexpectedly long waits in the current PHP process.
+
+When ``curl_errors`` is enabled, only DNS resolution failures, connection failures, timeouts,
+and send or receive failures are retried.
+
+When `http_errors`_ is enabled, an HTTP error response is retried first if its status code is
+configured in ``status_codes``. If all retry attempts are exhausted, the final HTTP error response
+throws the same as a request without retries.
+
+.. note:: Retry delays block the current PHP process. The total request time may exceed the
+    configured `timeout`_ because each retry attempt has its own cURL timeout and retry delays
+    are added between attempts.
+
+.. warning:: Be careful when retrying non-idempotent requests such as ``POST`` or ``PATCH``.
+    The remote server may receive the request more than once.
+
 timeout
 =======
 

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -402,7 +402,7 @@ The available retry settings are:
   The default is ``1000``.
 - ``max_delay``: Maximum delay in milliseconds. This caps both the configured ``delay`` and a
   valid ``Retry-After`` header. Set to ``0`` for no maximum delay. The default is ``30000``.
-- ``status_codes``: HTTP status codes that should be retried. The default is ``[429, 503]``.
+- ``status_codes``: HTTP status codes that should be retried. The default is ``[429, 503, 504]``.
 - ``curl_errors``: Whether to retry transient cURL errors. The default is ``false``.
 - ``respect_retry_after``: Whether to use a valid ``Retry-After`` header instead of the configured
   ``delay``. The default is ``true``.

--- a/user_guide_src/source/libraries/curlrequest/041.php
+++ b/user_guide_src/source/libraries/curlrequest/041.php
@@ -1,0 +1,12 @@
+<?php
+
+$response = $client->request('GET', 'https://api.example.com/items', [
+    'retry' => [
+        'max_retries'         => 3,
+        'delay'               => [100, 500, 1000],
+        'max_delay'           => 5000,
+        'status_codes'        => [429, 500, 502, 503, 504],
+        'curl_errors'         => true,
+        'respect_retry_after' => true,
+    ],
+]);


### PR DESCRIPTION
**Description**

This PR proposes adding `retry` option to `CURLRequest`.

Modern applications often depend on external APIs for payments, notifications, search, analytics, AI services, webhooks, and internal service-to-service calls. These requests can fail temporarily because of rate limits, short outages, gateway errors, DNS/connectivity issues, or upstream overload. Today, users need to write this retry flow manually around `CURLRequest`.

This PR adds a small, opt-in retry layer directly to `CURLRequest` so common transient failures can be handled in a framework-native way.

For simple cases, users can pass an integer retry count:

```php
$response = $client->request('GET', 'https://api.example.com/items', [
    'retry' => 3,
]);
```

For more control, users can pass an array:

```php
$response = $client->request('GET', 'https://api.example.com/items', [
    'retry' => [
        'max_retries'         => 3,
        'delay'               => [100, 500, 1000],
        'max_delay'           => 30000,
        'status_codes'        => [429, 500, 502, 503, 504],
        'curl_errors'         => true,
        'respect_retry_after' => true,
    ],
]);
```

The feature is intentionally contained within `CURLRequest` and does not change existing request behavior unless `retry` is explicitly configured.

**Behavior and Defaults**

- `retry` may be an integer retry count or an array of retry settings.
- `max_retries` is the number of retries after the initial request.
- `delay` is in milliseconds and may be a fixed integer or a simple backoff array.
- `status_codes` defaults to `[429, 503, 504]`, covering rate limiting and service unavailability without retrying every server error by default.
- `respect_retry_after` defaults to `true`, so valid `Retry-After` headers are honored.
- `max_delay` defaults to `30000` ms to avoid unexpectedly long blocking waits in synchronous PHP processes.
- `max_delay` caps both configured delays and valid `Retry-After` values. Users can set it to `0` for no cap.
- `curl_errors` defaults to `false`; transient cURL/network retries are available explicitly with `curl_errors => true`.
- When `http_errors` is enabled, retryable HTTP errors are retried first. If retries are exhausted, the final HTTP error still throws as expected.
- Non-idempotent requests such as `POST` and `PATCH` are not blocked, but the docs warn that the remote server may receive the request more than once.

**Design Notes**

The API is deliberately small:

- Simple users get `'retry' => 3`.
- Advanced users can configure attempts, delay, max delay, status codes, cURL error retries, and `Retry-After` behavior.
- Retry delays are synchronous because `CURLRequest` itself is synchronous.
- The default `max_delay` protects PHP-FPM workers, queue workers, and long-running processes from accidentally sleeping for a very long server-supplied `Retry-After`.
- cURL error retries are opt-in because network-level failures can be ambiguous for non-idempotent requests.
- Method-based blocking is avoided because only the application knows whether a request is safe to retry, for example when using idempotency keys.

**Documentation**

The user guide documents:

- Simple integer retry usage.
- Advanced array configuration.
- All retry settings and defaults.
- `Retry-After` priority and max delay behavior.
- Interaction with `http_errors`.
- Which transient cURL errors may be retried.
- Blocking behavior in synchronous PHP.
- Caution for non-idempotent requests.

**Tests**

Tests cover:

- Integer retry shorthand.
- Default retryable status codes.
- Custom retryable status codes.
- Non-retryable status codes.
- Disabled retry handling.
- Fixed and backoff delays.
- Negative delay normalization.
- `Retry-After` seconds and HTTP-date handling.
- Default `max_delay` cap.
- Disabling `Retry-After` handling.
- Exhausted retries with `http_errors` enabled.
- Exhausted retries with `http_errors` disabled.
- Default non-retry behavior for cURL errors.
- Opt-in retry behavior for transient cURL errors.
- Non-transient cURL errors.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide