### PR TITLE
feat: Add support for callable TTLs in cache handlers

### DIFF
--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -44,9 +44,9 @@ interface CacheInterface
      * Attempts to get an item from the cache, or executes the callback
      * and stores the result on cache miss.
      *
-     * @param string                                          $key      Cache item name
-     * @param callable(): int|callable(mixed $value): int|int $ttl      Time To Live, in seconds
-     * @param Closure(): mixed                                $callback Callback executed on cache miss
+     * @param string                                   $key      Cache item name
+     * @param callable(): int|callable(mixed): int|int $ttl      Time To Live, in seconds
+     * @param Closure(): mixed                         $callback Callback executed on cache miss
      */
     public function remember(string $key, callable|int $ttl, Closure $callback): mixed;
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -44,11 +44,11 @@ interface CacheInterface
      * Attempts to get an item from the cache, or executes the callback
      * and stores the result on cache miss.
      *
-     * @param string           $key      Cache item name
-     * @param int              $ttl      Time To Live, in seconds
-     * @param Closure(): mixed $callback Callback executed on cache miss
+     * @param string                                          $key      Cache item name
+     * @param callable(): int|callable(mixed $value): int|int $ttl      Time To Live, in seconds
+     * @param Closure(): mixed                                $callback Callback executed on cache miss
      */
-    public function remember(string $key, int $ttl, Closure $callback): mixed;
+    public function remember(string $key, callable|int $ttl, Closure $callback): mixed;
 
     /**
      * Deletes a specific item from the cache store.

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -44,9 +44,9 @@ interface CacheInterface
      * Attempts to get an item from the cache, or executes the callback
      * and stores the result on cache miss.
      *
-     * @param string                                   $key      Cache item name
-     * @param callable(): int|callable(mixed): int|int $ttl      Time To Live, in seconds
-     * @param Closure(): mixed                         $callback Callback executed on cache miss
+     * @param string                   $key      Cache item name
+     * @param callable(mixed): int|int $ttl      Time To Live, in seconds
+     * @param Closure(): mixed         $callback Callback executed on cache miss
      */
     public function remember(string $key, callable|int $ttl, Closure $callback): mixed;
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -44,9 +44,9 @@ interface CacheInterface
      * Attempts to get an item from the cache, or executes the callback
      * and stores the result on cache miss.
      *
-     * @param string                   $key      Cache item name
-     * @param callable(mixed): int|int $ttl      Time To Live, in seconds
-     * @param Closure(): mixed         $callback Callback executed on cache miss
+     * @param string                     $key      Cache item name
+     * @param (callable(mixed): int)|int $ttl      Time To Live, in seconds
+     * @param Closure(): mixed           $callback Callback executed on cache miss
      */
     public function remember(string $key, callable|int $ttl, Closure $callback): mixed;
 

--- a/system/Cache/Handlers/ApcuHandler.php
+++ b/system/Cache/Handlers/ApcuHandler.php
@@ -55,9 +55,13 @@ class ApcuHandler extends BaseHandler
         return apcu_store($key, $value, $ttl);
     }
 
-    public function remember(string $key, int $ttl, Closure $callback): mixed
+    public function remember(string $key, callable|int $ttl, Closure $callback): mixed
     {
         $key = static::validateKey($key, $this->prefix);
+
+        if (is_callable($ttl)) {
+            return parent::remember($key, $ttl, $callback);
+        }
 
         return apcu_entry($key, $callback, $ttl);
     }

--- a/system/Cache/Handlers/ApcuHandler.php
+++ b/system/Cache/Handlers/ApcuHandler.php
@@ -57,11 +57,11 @@ class ApcuHandler extends BaseHandler
 
     public function remember(string $key, callable|int $ttl, Closure $callback): mixed
     {
-        $key = static::validateKey($key, $this->prefix);
-
         if (is_callable($ttl)) {
             return parent::remember($key, $ttl, $callback);
         }
+
+        $key = static::validateKey($key, $this->prefix);
 
         return apcu_entry($key, $callback, $ttl);
     }

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -76,9 +76,22 @@ abstract class BaseHandler implements CacheInterface
         $value = $callback();
 
         if (is_callable($ttl)) {
-            $ttl = (new ReflectionFunction(Closure::fromCallable($ttl)))->getNumberOfParameters() > 0
-                ? $ttl($value)
-                : $ttl();
+            $ttlClosure = Closure::fromCallable($ttl);
+            $rf         = new ReflectionFunction($ttlClosure);
+            $params     = $rf->getNumberOfRequiredParameters();
+
+            if ($params === 0) {
+                /** @var Closure(): int $ttlClosure */
+                $ttl = $ttlClosure();
+            } elseif ($params === 1) {
+                /** @var Closure(mixed): int $ttlClosure */
+                $ttl = $ttlClosure($value);
+            } else {
+                throw new InvalidArgumentException(sprintf(
+                    'Argument #2 ($ttl) must accept 0 or 1 parameter, %d given.',
+                    $params,
+                ));
+            }
         }
 
         $this->save($key, $value, $ttl);

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -76,7 +76,7 @@ abstract class BaseHandler implements CacheInterface
         $value = $callback();
 
         if (is_callable($ttl)) {
-            $ttl = (new ReflectionFunction($ttl(...)))->getNumberOfParameters() > 0
+            $ttl = (new ReflectionFunction(Closure::fromCallable($ttl)))->getNumberOfParameters() > 0
                 ? $ttl($value)
                 : $ttl();
         }

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -17,7 +17,6 @@ use Closure;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use Config\Cache;
-use ReflectionFunction;
 
 /**
  * Base class for cache handling
@@ -76,22 +75,7 @@ abstract class BaseHandler implements CacheInterface
         $value = $callback();
 
         if (is_callable($ttl)) {
-            $ttlClosure = Closure::fromCallable($ttl);
-            $rf         = new ReflectionFunction($ttlClosure);
-            $params     = $rf->getNumberOfRequiredParameters();
-
-            if ($params === 0) {
-                /** @var Closure(): int $ttlClosure */
-                $ttl = $ttlClosure();
-            } elseif ($params === 1) {
-                /** @var Closure(mixed): int $ttlClosure */
-                $ttl = $ttlClosure($value);
-            } else {
-                throw new InvalidArgumentException(sprintf(
-                    'Argument #2 ($ttl) must accept 0 or 1 parameter, %d given.',
-                    $params,
-                ));
-            }
+            $ttl = $ttl($value);
         }
 
         $this->save($key, $value, $ttl);

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -17,6 +17,7 @@ use Closure;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use Config\Cache;
+use ReflectionFunction;
 
 /**
  * Base class for cache handling
@@ -64,7 +65,7 @@ abstract class BaseHandler implements CacheInterface
         return strlen($prefix . $key) > static::MAX_KEY_LENGTH ? $prefix . md5($key) : $prefix . $key;
     }
 
-    public function remember(string $key, int $ttl, Closure $callback): mixed
+    public function remember(string $key, callable|int $ttl, Closure $callback): mixed
     {
         $value = $this->get($key);
 
@@ -72,7 +73,15 @@ abstract class BaseHandler implements CacheInterface
             return $value;
         }
 
-        $this->save($key, $value = $callback(), $ttl);
+        $value = $callback();
+
+        if (is_callable($ttl)) {
+            $ttl = (new ReflectionFunction($ttl(...)))->getNumberOfParameters() > 0
+                ? $ttl($value)
+                : $ttl();
+        }
+
+        $this->save($key, $value, $ttl);
 
         return $value;
     }

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -31,7 +31,7 @@ class DummyHandler extends BaseHandler
         return null;
     }
 
-    public function remember(string $key, int $ttl, Closure $callback): mixed
+    public function remember(string $key, callable|int $ttl, Closure $callback): mixed
     {
         return null;
     }

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -18,10 +18,8 @@ use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\Handlers\BaseHandler;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Assert;
-use ReflectionFunction;
 
 class MockCache extends BaseHandler implements CacheInterface, LockStoreProviderInterface
 {
@@ -85,22 +83,7 @@ class MockCache extends BaseHandler implements CacheInterface, LockStoreProvider
         $value = $callback();
 
         if (is_callable($ttl)) {
-            $ttlClosure = Closure::fromCallable($ttl);
-            $rf         = new ReflectionFunction($ttlClosure);
-            $params     = $rf->getNumberOfRequiredParameters();
-
-            if ($params === 0) {
-                /** @var Closure(): int $ttlClosure */
-                $ttl = $ttlClosure();
-            } elseif ($params === 1) {
-                /** @var Closure(mixed): int $ttlClosure */
-                $ttl = $ttlClosure($value);
-            } else {
-                throw new InvalidArgumentException(sprintf(
-                    'Argument #2 ($ttl) must accept 0 or 1 parameter, %d given.',
-                    $params,
-                ));
-            }
+            $ttl = $ttl($value);
         }
 
         $this->save($key, $value, $ttl);

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -18,6 +18,7 @@ use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\Handlers\BaseHandler;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Assert;
 use ReflectionFunction;
@@ -84,9 +85,22 @@ class MockCache extends BaseHandler implements CacheInterface, LockStoreProvider
         $value = $callback();
 
         if (is_callable($ttl)) {
-            $ttl = (new ReflectionFunction($ttl(...)))->getNumberOfParameters() > 0
-                ? $ttl($value)
-                : $ttl();
+            $ttlClosure = Closure::fromCallable($ttl);
+            $rf         = new ReflectionFunction($ttlClosure);
+            $params     = $rf->getNumberOfRequiredParameters();
+
+            if ($params === 0) {
+                /** @var Closure(): int $ttlClosure */
+                $ttl = $ttlClosure();
+            } elseif ($params === 1) {
+                /** @var Closure(mixed): int $ttlClosure */
+                $ttl = $ttlClosure($value);
+            } else {
+                throw new InvalidArgumentException(sprintf(
+                    'Argument #2 ($ttl) must accept 0 or 1 parameter, %d given.',
+                    $params,
+                ));
+            }
         }
 
         $this->save($key, $value, $ttl);

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -20,6 +20,7 @@ use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\I18n\Time;
 use PHPUnit\Framework\Assert;
+use ReflectionFunction;
 
 class MockCache extends BaseHandler implements CacheInterface, LockStoreProviderInterface
 {
@@ -72,7 +73,7 @@ class MockCache extends BaseHandler implements CacheInterface, LockStoreProvider
      *
      * @return bool|null
      */
-    public function remember(string $key, int $ttl, Closure $callback): mixed
+    public function remember(string $key, callable|int $ttl, Closure $callback): mixed
     {
         $value = $this->get($key);
 
@@ -80,7 +81,15 @@ class MockCache extends BaseHandler implements CacheInterface, LockStoreProvider
             return $value;
         }
 
-        $this->save($key, $value = $callback(), $ttl);
+        $value = $callback();
+
+        if (is_callable($ttl)) {
+            $ttl = (new ReflectionFunction($ttl(...)))->getNumberOfParameters() > 0
+                ? $ttl($value)
+                : $ttl();
+        }
+
+        $this->save($key, $value, $ttl);
 
         return $value;
     }

--- a/tests/system/Cache/Handlers/ApcuHandlerTest.php
+++ b/tests/system/Cache/Handlers/ApcuHandlerTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -124,6 +125,14 @@ final class ApcuHandlerTest extends AbstractHandlerTestCase
 
         CLI::wait(3);
         $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    public function testRememberWithTTLCallableAndMultipleParameters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+
+        $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 
     public function testSave(): void

--- a/tests/system/Cache/Handlers/ApcuHandlerTest.php
+++ b/tests/system/Cache/Handlers/ApcuHandlerTest.php
@@ -92,6 +92,40 @@ final class ApcuHandlerTest extends AbstractHandlerTestCase
         $this->assertNull($this->handler->get(self::$key1));
     }
 
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallable(): void
+    {
+        $this->handler->remember(self::$key1, static fn (): int => 2, static fn (): string => 'value');
+
+        $this->assertSame('value', $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallableAndValuePassed(): void
+    {
+        $this->handler->remember(self::$key1, static fn ($value): int => $value[0], static fn (): array => [2, 3]);
+
+        $this->assertSame([2, 3], $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/ApcuHandlerTest.php
+++ b/tests/system/Cache/Handlers/ApcuHandlerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use ArgumentCountError;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -129,8 +129,7 @@ final class ApcuHandlerTest extends AbstractHandlerTestCase
 
     public function testRememberWithTTLCallableAndMultipleParameters(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+        $this->expectException(ArgumentCountError::class);
 
         /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');

--- a/tests/system/Cache/Handlers/ApcuHandlerTest.php
+++ b/tests/system/Cache/Handlers/ApcuHandlerTest.php
@@ -132,6 +132,7 @@ final class ApcuHandlerTest extends AbstractHandlerTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
 
+        /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -48,6 +48,20 @@ final class DummyHandlerTest extends CIUnitTestCase
         $this->assertNull($dummyHandler);
     }
 
+    public function testRememberWithTTLCallable(): void
+    {
+        $dummyHandler = $this->handler->remember('key', static fn (): int => 2, static fn (): string => 'value');
+
+        $this->assertNull($dummyHandler);
+    }
+
+    public function testRememberWithTTLCallableAndValuePassed(): void
+    {
+        $dummyHandler = $this->handler->remember('key', static fn ($value): int => $value[0], static fn (): array => [2, 3]);
+
+        $this->assertNull($dummyHandler);
+    }
+
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save('key', 'value'));

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheFactory;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -145,6 +145,40 @@ final class FileHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallable(): void
+    {
+        $this->handler->remember(self::$key1, static fn (): int => 2, static fn (): string => 'value');
+
+        $this->assertSame('value', $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallableAndValuePassed(): void
+    {
+        $this->handler->remember(self::$key1, static fn ($value): int => $value[0], static fn (): array => [2, 3]);
+
+        $this->assertSame([2, 3], $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    /**
      * chmod('path', 0444) does not work on Windows
      */
     #[RequiresOperatingSystem('Linux|Darwin')]

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use ArgumentCountError;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -181,8 +181,7 @@ final class FileHandlerTest extends AbstractHandlerTestCase
 
     public function testRememberWithTTLCallableAndMultipleParameters(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+        $this->expectException(ArgumentCountError::class);
 
         /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -184,6 +184,7 @@ final class FileHandlerTest extends AbstractHandlerTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
 
+        /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -176,6 +177,14 @@ final class FileHandlerTest extends AbstractHandlerTestCase
 
         CLI::wait(3);
         $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    public function testRememberWithTTLCallableAndMultipleParameters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+
+        $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 
     /**

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use ArgumentCountError;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Exceptions\BadMethodCallException;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -138,8 +138,7 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
 
     public function testRememberWithTTLCallableAndMultipleParameters(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+        $this->expectException(ArgumentCountError::class);
 
         /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -141,6 +141,7 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
 
+        /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -18,6 +18,7 @@ use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Exceptions\BadMethodCallException;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -133,6 +134,14 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
 
         CLI::wait(3);
         $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    public function testRememberWithTTLCallableAndMultipleParameters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+
+        $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 
     public function testSave(): void

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -101,6 +101,40 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
         $this->assertNull($this->handler->get(self::$key1));
     }
 
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallable(): void
+    {
+        $this->handler->remember(self::$key1, static fn (): int => 2, static fn (): string => 'value');
+
+        $this->assertSame('value', $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallableAndValuePassed(): void
+    {
+        $this->handler->remember(self::$key1, static fn ($value): int => $value[0], static fn (): array => [2, 3]);
+
+        $this->assertSame([2, 3], $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -109,6 +109,40 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
         $this->assertNull($this->handler->get(self::$key1));
     }
 
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallable(): void
+    {
+        $this->handler->remember(self::$key1, static fn (): int => 2, static fn (): string => 'value');
+
+        $this->assertSame('value', $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallableAndValuePassed(): void
+    {
+        $this->handler->remember(self::$key1, static fn ($value): int => $value[0], static fn (): array => [2, 3]);
+
+        $this->assertSame([2, 3], $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use ArgumentCountError;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -146,8 +146,7 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 
     public function testRememberWithTTLCallableAndMultipleParameters(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+        $this->expectException(ArgumentCountError::class);
 
         /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -149,6 +149,7 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
 
+        /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -141,6 +142,14 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 
         CLI::wait(3);
         $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    public function testRememberWithTTLCallableAndMultipleParameters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+
+        $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 
     public function testSave(): void

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -150,6 +150,7 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
 
+        /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use ArgumentCountError;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -147,8 +147,7 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 
     public function testRememberWithTTLCallableAndMultipleParameters(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+        $this->expectException(ArgumentCountError::class);
 
         /** @phpstan-ignore argument.type */
         $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -110,6 +110,40 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         $this->assertNull($this->handler->get(self::$key1));
     }
 
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallable(): void
+    {
+        $this->handler->remember(self::$key1, static fn (): int => 2, static fn (): string => 'value');
+
+        $this->assertSame('value', $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    /**
+     * This test waits for 3 seconds before last assertion so this
+     * is naturally a "slow" test on the perspective of the default limit.
+     *
+     * @timeLimit 3.5
+     */
+    public function testRememberWithTTLCallableAndValuePassed(): void
+    {
+        $this->handler->remember(self::$key1, static fn ($value): int => $value[0], static fn (): array => [2, 3]);
+
+        $this->assertSame([2, 3], $this->handler->get(self::$key1));
+        $this->assertNull($this->handler->get(self::$dummy));
+
+        CLI::wait(3);
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
     public function testSave(): void
     {
         $this->assertTrue($this->handler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\LockStoreInterface;
 use CodeIgniter\Cache\LockStoreProviderInterface;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -142,6 +143,14 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 
         CLI::wait(3);
         $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    public function testRememberWithTTLCallableAndMultipleParameters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument #2 ($ttl) must accept 0 or 1 parameter, 2 given.');
+
+        $this->handler->remember(self::$key1, static fn ($a, $b): int => 2, static fn (): string => 'value');
     }
 
     public function testSave(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -231,7 +231,7 @@ Model
 Libraries
 =========
 
-- **Cache:** Added support for TTL callables in the ``remember()`` method of cache handlers. This allows you to specify a callable that returns a TTL value, which can be useful for dynamic TTL. See :ref:`cache-ttl-callables` for details.
+- **Cache:** Added support for TTL callables in the ``remember()`` method of cache handlers. This allows you to specify a callable that returns a TTL value, which can be useful for dynamic TTL.
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
 - **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**. Memcached support has driver-specific release limitations because Memcached has no atomic compare-and-delete command.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -46,6 +46,7 @@ update your implementations to include the new methods or method changes to ensu
 - **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
+- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. All built-in cache handlers inherit this method via ``BaseHandler``, so no changes are required for them.
 
 Method Signature Changes
 ========================
@@ -230,6 +231,7 @@ Model
 Libraries
 =========
 
+- **Cache:** Added support for TTL callables in the ``remember()`` method of cache handlers. This allows you to specify a callable that returns a TTL value, which can be useful for dynamic TTL. See :ref:`cache-ttl-callables` for details.
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
 - **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**. Memcached support has driver-specific release limitations because Memcached has no atomic compare-and-delete command.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,10 +43,10 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
+- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. All built-in cache handlers inherit this method via ``BaseHandler``, so no changes are required for them.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
-- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. All built-in cache handlers inherit this method via ``BaseHandler``, so no changes are required for them.
 
 Method Signature Changes
 ========================
@@ -203,13 +203,10 @@ Database
 
 - Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
 - Added the ``transaction()`` method to database connections to run a callback inside a transaction. See :ref:`transactions-closure`.
-- Added ``inTransaction()`` to database connections to check whether the connection is inside an active CodeIgniter-managed transaction. See :ref:`transactions-checking-transaction-state`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder
 -------------
-
-- Added ``whereColumn()`` and ``orWhereColumn()`` to compare one column to another column while protecting identifiers by default. See :ref:`query-builder-where-column`.
 
 Forge
 -----
@@ -234,7 +231,7 @@ Libraries
 - **Cache:** Added support for TTL callables in the ``remember()`` method of cache handlers. This allows you to specify a callable that returns a TTL value, which can be useful for dynamic TTL.
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
-- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**. Memcached support has driver-specific release limitations because Memcached has no atomic compare-and-delete command.
+- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers.
 - **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 - **Logging:** Added :ref:`per-call context logging <logging-per-call-context>` with three new ``Config\Logger`` options (``$logContext``, ``$logContextTrace``, ``$logContextUsedKeys``). Per PSR-3, a ``Throwable`` in the ``exception`` context key is automatically normalized to a meaningful array. All options default to ``false``.
 
@@ -283,9 +280,6 @@ Others
 ***************
 Message Changes
 ***************
-
-- Added new language key:
-    - ``Cache.unsupportedLockStore`` (``CacheException::forUnsupportedLockStore()``)
 
 - Removed deprecated language keys tied to removed exception constructors:
     - ``Core.missingExtension`` (``FrameworkException::forMissingExtension()``)

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,7 +43,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. All built-in cache handlers inherit this method via ``BaseHandler``, so no changes are required for them.
+- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. Custom implementations of ``CacheInterface`` must update the ``$ttl`` parameter type from ``int`` to `callable|int``.
 - **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -44,7 +44,7 @@ Interface Changes
 update your implementations to include the new methods or method changes to ensure compatibility.
 
 - **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. All built-in cache handlers inherit this method via ``BaseHandler``, so no changes are required for them.
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, and ``transaction()`` methods.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
 
@@ -203,10 +203,13 @@ Database
 
 - Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
 - Added the ``transaction()`` method to database connections to run a callback inside a transaction. See :ref:`transactions-closure`.
+- Added ``inTransaction()`` to database connections to check whether the connection is inside an active CodeIgniter-managed transaction. See :ref:`transactions-checking-transaction-state`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder
 -------------
+
+- Added ``whereColumn()`` and ``orWhereColumn()`` to compare one column to another column while protecting identifiers by default. See :ref:`query-builder-where-column`.
 
 Forge
 -----
@@ -231,7 +234,7 @@ Libraries
 - **Cache:** Added support for TTL callables in the ``remember()`` method of cache handlers. This allows you to specify a callable that returns a TTL value, which can be useful for dynamic TTL.
 - **Context**: This new feature allows you to easily set and retrieve normal or hidden contextual data for the current request. See :ref:`Context <context>` for details.
 - **Images:**: Added support for the AVIF file format.
-- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers.
+- **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**. Memcached support has driver-specific release limitations because Memcached has no atomic compare-and-delete command.
 - **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 - **Logging:** Added :ref:`per-call context logging <logging-per-call-context>` with three new ``Config\Logger`` options (``$logContext``, ``$logContextTrace``, ``$logContextUsedKeys``). Per PSR-3, a ``Throwable`` in the ``exception`` context key is automatically normalized to a meaningful array. All options default to ``false``.
 
@@ -280,6 +283,9 @@ Others
 ***************
 Message Changes
 ***************
+
+- Added new language key:
+    - ``Cache.unsupportedLockStore`` (``CacheException::forUnsupportedLockStore()``)
 
 - Removed deprecated language keys tied to removed exception constructors:
     - ``Core.missingExtension`` (``FrameworkException::forMissingExtension()``)

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,7 +43,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. Custom implementations of ``CacheInterface`` must update the ``$ttl`` parameter type from ``int`` to `callable|int``.
+- **Cache:** ``CodeIgniter\Cache\CacheInterface::remember()`` now accepts a TTL callable. Custom implementations of ``CacheInterface`` must update the ``$ttl`` parameter type from ``int`` to ``callable|int``.
 - **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -145,8 +145,8 @@ Class Reference
         calculation.
 
         When a callable is provided, it will only be executed on a cache miss,
-        after the callback has been invoked. The callable may optionally accept
-        the computed value as its first argument:
+        after the callback has been invoked. The callable always receives the
+        computed value as its first argument:
 
         .. literalinclude:: caching/015.php
 

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -128,16 +128,39 @@ Class Reference
 
         .. literalinclude:: caching/003.php
 
-    .. php:method:: remember(string $key, int $ttl, Closure $callback)
+    .. php:method:: remember(string $key, callable|int $ttl, Closure $callback)
 
         :param string $key: Cache item name
-        :param int $ttl: Time to live in seconds
+        :param callable|int $ttl: Time to live in seconds
         :param Closure $callback: Callback to invoke when the cache item returns null
         :returns: The value of the cache item
         :rtype: mixed
 
         Gets an item from the cache. If ``null`` was returned, this will invoke the callback
         and save the result. Either way, this will return the value.
+
+        The ``$ttl`` parameter may also be a callable, allowing the TTL to be
+        determined dynamically at runtime. This is especially useful when the
+        expiration time depends on the computed value or requires an expensive
+        calculation.
+
+        When a callable is provided, it will only be executed on a cache miss,
+        after the callback has been invoked. The callable may optionally accept
+        the computed value as its first argument:
+
+        .. literalinclude:: caching/015.php
+
+        This ensures that TTL computation is deferred until necessary and avoids
+        unnecessary overhead when the cache item already exists.
+
+        .. note:: Prior to v4.8.0, the second parameter only accepted an integer TTL value. The ability to pass a callable was added in v4.8.0.
+
+        .. note:: When using the APCu cache handler, providing a callable TTL disables
+            the use of ``apcu_entry()`` and falls back to a manual cache retrieval
+            and storage process. As a result, the operation is no longer atomic
+            and may be subject to race conditions under high concurrency.
+
+            If atomic behavior is required, use an integer TTL value.
 
     .. php:method:: save(string $key, $data[, int $ttl = 60])
 
@@ -276,7 +299,7 @@ Drivers
 APCu Caching
 ============
 
-APCu is an in-memory key-value store for PHP. 
+APCu is an in-memory key-value store for PHP.
 
 To use it, you need the `APCu PHP extension <https://www.php.net/apcu>`_.
 

--- a/user_guide_src/source/libraries/caching/015.php
+++ b/user_guide_src/source/libraries/caching/015.php
@@ -1,0 +1,11 @@
+<?php
+
+// Simple dynamic TTL
+$cache->remember('key', static fn () => 60, static fn () => fetchData());
+
+// Value-aware TTL
+$cache->remember(
+    'key',
+    static fn ($value) => $value->expires_at - time(),
+    static fn () => fetchData(),
+);

--- a/user_guide_src/source/libraries/caching/015.php
+++ b/user_guide_src/source/libraries/caching/015.php
@@ -1,7 +1,7 @@
 <?php
 
 // Simple dynamic TTL
-$cache->remember('key', static fn () => 60, static fn () => fetchData());
+$cache->remember('key', static fn ($value) => 60, static fn () => fetchData());
 
 // Value-aware TTL
 $cache->remember(


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This PR adds support for callable for TTL in cache handlers.

Many times the following two cases arise while calculating TTLs:
- Calculating TTL is expensive operation
- TTL depends on the return value of the callback function (for e.g, cache until the first item's expires_at is reached).

In the first senario, calculating TTL everytime, even if its a cache hit, is redundant. And in second senario, you can't just use the `remember()` method. You have to rely on traditional `get()/save()` methods.

This PR solves both problems by adding support for callables as TTL. The passed callable may optionally accept the computed value as first parameter which solves the second senario.
And by passing callable without any parameter just defers calculating TTL until cache miss.

This can be considered as a Breaking Change as the Interface method's signature is changed. However, the usage of `remember()` method remains mostly unchanged.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
