### PR TITLE
feat: classify retryable transaction exceptions

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database;
 
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\Exceptions\RetryableTransactionException;
 use CodeIgniter\Events\Events;
 use CodeIgniter\I18n\Time;
 use Exception;
@@ -2139,20 +2140,26 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Checks whether the exception represents a retryable transaction failure.
-     */
-    public function isRetryableTransactionException(Throwable $exception): bool
-    {
-        return $exception instanceof DatabaseException
-            && $this->isRetryableTransactionErrorCode($exception->getDatabaseCode());
-    }
-
-    /**
      * Checks whether the native database code represents a retryable transaction failure.
      */
     protected function isRetryableTransactionErrorCode(int|string $code): bool
     {
         return false;
+    }
+
+    /**
+     * Creates the appropriate database exception for a native database error.
+     */
+    protected function createDatabaseException(
+        string $message,
+        int|string $code = 0,
+        ?Throwable $previous = null,
+    ): DatabaseException {
+        if ($this->isRetryableTransactionErrorCode($code)) {
+            return new RetryableTransactionException($message, $code, $previous);
+        }
+
+        return new DatabaseException($message, $code, $previous);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -2139,6 +2139,23 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
+     * Checks whether the exception represents a retryable transaction failure.
+     */
+    public function isRetryableTransactionException(Throwable $exception): bool
+    {
+        return $exception instanceof DatabaseException
+            && $this->isRetryableTransactionErrorCode($exception->getDatabaseCode());
+    }
+
+    /**
+     * Checks whether the native database code represents a retryable transaction failure.
+     */
+    protected function isRetryableTransactionErrorCode(int|string $code): bool
+    {
+        return false;
+    }
+
+    /**
      * Insert ID
      *
      * @return int|string

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\RetryableTransactionException;
+use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Events\Events;
 use CodeIgniter\I18n\Time;
 use Exception;
@@ -2140,6 +2141,14 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
+     * Checks whether the native database error represents a unique constraint violation.
+     */
+    protected function isUniqueConstraintViolation(int|string $code, string $message): bool
+    {
+        return false;
+    }
+
+    /**
      * Checks whether the native database code represents a retryable transaction failure.
      */
     protected function isRetryableTransactionErrorCode(int|string $code): bool
@@ -2155,6 +2164,10 @@ abstract class BaseConnection implements ConnectionInterface
         int|string $code = 0,
         ?Throwable $previous = null,
     ): DatabaseException {
+        if ($this->isUniqueConstraintViolation($code, $message)) {
+            return new UniqueConstraintViolationException($message, $code, $previous);
+        }
+
         if ($this->isRetryableTransactionErrorCode($code)) {
             return new RetryableTransactionException($message, $code, $previous);
         }

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use Throwable;
-
 /**
  * @template TConnection
  * @template TResult
@@ -150,11 +148,6 @@ interface ConnectionInterface
      * @return false|TReturn
      */
     public function transaction(callable $callback): mixed;
-
-    /**
-     * Checks whether the exception represents a retryable transaction failure.
-     */
-    public function isRetryableTransactionException(Throwable $exception): bool;
 
     /**
      * Returns an instance of the query builder for this connection.

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
+use Throwable;
+
 /**
  * @template TConnection
  * @template TResult
@@ -148,6 +150,11 @@ interface ConnectionInterface
      * @return false|TReturn
      */
     public function transaction(callable $callback): mixed;
+
+    /**
+     * Checks whether the exception represents a retryable transaction failure.
+     */
+    public function isRetryableTransactionException(Throwable $exception): bool;
 
     /**
      * Returns an instance of the query builder for this connection.

--- a/system/Database/Exceptions/RetryableTransactionException.php
+++ b/system/Database/Exceptions/RetryableTransactionException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Exceptions;
+
+class RetryableTransactionException extends DatabaseException
+{
+}

--- a/system/Database/Exceptions/RetryableTransactionException.php
+++ b/system/Database/Exceptions/RetryableTransactionException.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Exceptions;
 
+/**
+ * Thrown when a transaction failure may succeed if the whole transaction is retried.
+ */
 class RetryableTransactionException extends DatabaseException
 {
 }

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Database\TableName;
 use CodeIgniter\Exceptions\LogicException;
 use mysqli;
@@ -97,6 +96,15 @@ class Connection extends BaseConnection
      * Strict SQL mode
      */
     protected bool $strictOn = false;
+
+    /**
+     * Checks whether the native database error represents a unique constraint violation.
+     */
+    protected function isUniqueConstraintViolation(int|string $code, string $message): bool
+    {
+        // ER_DUP_ENTRY: duplicate key value.
+        return $code === 1062;
+    }
 
     /**
      * Checks whether the native database code represents a retryable transaction failure.
@@ -326,10 +334,7 @@ class Connection extends BaseConnection
                 'trace'   => render_backtrace($e->getTrace()),
             ]);
 
-            // MySQL error 1062: ER_DUP_ENTRY – duplicate key value
-            $exception = $e->getCode() === 1062
-                ? new UniqueConstraintViolationException($e->getMessage(), $e->getCode(), $e)
-                : $this->createDatabaseException($e->getMessage(), $e->getCode(), $e);
+            $exception = $this->createDatabaseException($e->getMessage(), $e->getCode(), $e);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -329,7 +329,7 @@ class Connection extends BaseConnection
             // MySQL error 1062: ER_DUP_ENTRY – duplicate key value
             $exception = $e->getCode() === 1062
                 ? new UniqueConstraintViolationException($e->getMessage(), $e->getCode(), $e)
-                : new DatabaseException($e->getMessage(), $e->getCode(), $e);
+                : $this->createDatabaseException($e->getMessage(), $e->getCode(), $e);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -99,6 +99,15 @@ class Connection extends BaseConnection
     protected bool $strictOn = false;
 
     /**
+     * Checks whether the native database code represents a retryable transaction failure.
+     */
+    protected function isRetryableTransactionErrorCode(int|string $code): bool
+    {
+        // ER_LOCK_DEADLOCK: InnoDB rolls back the full transaction.
+        return $code === 1213;
+    }
+
+    /**
      * Connect to the database.
      *
      * @return false|mysqli

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -116,6 +116,14 @@ class Connection extends BaseConnection
     public $lastInsertedTableName;
 
     /**
+     * Checks whether the native database code represents a retryable transaction failure.
+     */
+    protected function isRetryableTransactionErrorCode(int|string $code): bool
+    {
+        return in_array($code, [60, 8177], true);
+    }
+
+    /**
      * confirm DSN format.
      */
     private function isValidDSN(): bool

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Database\OCI8;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Database\TableName;
 use ErrorException;
@@ -114,6 +113,15 @@ class Connection extends BaseConnection
      * @var string|null
      */
     public $lastInsertedTableName;
+
+    /**
+     * Checks whether the native database error represents a unique constraint violation.
+     */
+    protected function isUniqueConstraintViolation(int|string $code, string $message): bool
+    {
+        // ORA-00001: unique constraint violated.
+        return $code === 1;
+    }
 
     /**
      * Checks whether the native database code represents a retryable transaction failure.
@@ -248,11 +256,8 @@ class Connection extends BaseConnection
             $result = oci_execute($this->stmtId, $this->commitMode) ? $this->stmtId : false;
 
             if ($result === false) {
-                // ORA-00001: unique constraint violated
                 $error     = $this->error();
-                $exception = $error['code'] === 1
-                    ? new UniqueConstraintViolationException((string) $error['message'], $error['code'])
-                    : $this->createDatabaseException((string) $error['message'], $error['code']);
+                $exception = $this->createDatabaseException((string) $error['message'], $error['code']);
 
                 if ($this->DBDebug) {
                     throw $exception;
@@ -280,11 +285,8 @@ class Connection extends BaseConnection
                 'trace'   => render_backtrace($trace),
             ]);
 
-            // ORA-00001: unique constraint violated
             $error     = $this->error();
-            $exception = $error['code'] === 1
-                ? new UniqueConstraintViolationException((string) $error['message'], $error['code'], $e)
-                : $this->createDatabaseException((string) $error['message'], $error['code'], $e);
+            $exception = $this->createDatabaseException((string) $error['message'], $error['code'], $e);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -252,7 +252,7 @@ class Connection extends BaseConnection
                 $error     = $this->error();
                 $exception = $error['code'] === 1
                     ? new UniqueConstraintViolationException((string) $error['message'], $error['code'])
-                    : new DatabaseException((string) $error['message'], $error['code']);
+                    : $this->createDatabaseException((string) $error['message'], $error['code']);
 
                 if ($this->DBDebug) {
                     throw $exception;
@@ -284,7 +284,7 @@ class Connection extends BaseConnection
             $error     = $this->error();
             $exception = $error['code'] === 1
                 ? new UniqueConstraintViolationException((string) $error['message'], $error['code'], $e)
-                : new DatabaseException((string) $error['message'], $error['code'], $e);
+                : $this->createDatabaseException((string) $error['message'], $error['code'], $e);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -282,7 +282,7 @@ class Connection extends BaseConnection
 
             $exception = $sqlstate === '23505'
                 ? new UniqueConstraintViolationException($message, $sqlstate)
-                : new DatabaseException($message, $sqlstate);
+                : $this->createDatabaseException($message, $sqlstate);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -64,6 +64,14 @@ class Connection extends BaseConnection
     private ?PgSqlResult $lastFailedResult = null;
 
     /**
+     * Checks whether the native database code represents a retryable transaction failure.
+     */
+    protected function isRetryableTransactionErrorCode(int|string $code): bool
+    {
+        return in_array($code, ['40001', '40P01'], true);
+    }
+
+    /**
      * Connect to the database.
      *
      * @return false|PgSqlConnection

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Database\TableName;
 use ErrorException;
@@ -62,6 +61,14 @@ class Connection extends BaseConnection
      * via pg_result_error_field() without string parsing.
      */
     private ?PgSqlResult $lastFailedResult = null;
+
+    /**
+     * Checks whether the native database error represents a unique constraint violation.
+     */
+    protected function isUniqueConstraintViolation(int|string $code, string $message): bool
+    {
+        return $code === '23505';
+    }
 
     /**
      * Checks whether the native database code represents a retryable transaction failure.
@@ -280,9 +287,7 @@ class Connection extends BaseConnection
                 'trace'   => render_backtrace($trace),
             ]);
 
-            $exception = $sqlstate === '23505'
-                ? new UniqueConstraintViolationException($message, $sqlstate)
-                : $this->createDatabaseException($message, $sqlstate);
+            $exception = $this->createDatabaseException($message, $sqlstate);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Database\SQLSRV;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Database\TableName;
 use stdClass;
 
@@ -89,6 +88,28 @@ class Connection extends BaseConnection
      * @var list<string>
      */
     protected $_reserved_identifiers = ['*'];
+
+    /**
+     * Checks whether the native database error represents a unique constraint violation.
+     */
+    protected function isUniqueConstraintViolation(int|string $code, string $message): bool
+    {
+        $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
+        if (! is_array($errors)) {
+            return false;
+        }
+
+        foreach ($errors as $error) {
+            // SQLSTATE 23000 (integrity constraint violation) with SQL Server error
+            // 2627 (UNIQUE CONSTRAINT or PRIMARY KEY violation) or 2601 (UNIQUE INDEX violation).
+            if (($error['SQLSTATE'] ?? '') === '23000'
+                && in_array($error['code'] ?? 0, [2627, 2601], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Checks whether the native database code represents a retryable transaction failure.
@@ -554,9 +575,7 @@ class Connection extends BaseConnection
             ]);
 
             $error     = $this->error();
-            $exception = $this->isUniqueConstraintViolation()
-                ? new UniqueConstraintViolationException($message, $error['code'])
-                : $this->createDatabaseException($message, $error['code']);
+            $exception = $this->createDatabaseException($message, $error['code']);
 
             if ($this->DBDebug) {
                 throw $exception;
@@ -566,25 +585,6 @@ class Connection extends BaseConnection
         }
 
         return $stmt;
-    }
-
-    private function isUniqueConstraintViolation(): bool
-    {
-        $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
-        if (! is_array($errors)) {
-            return false;
-        }
-
-        foreach ($errors as $error) {
-            // SQLSTATE 23000 (integrity constraint violation) with SQL Server error
-            // 2627 (UNIQUE CONSTRAINT or PRIMARY KEY violation) or 2601 (UNIQUE INDEX violation).
-            if (($error['SQLSTATE'] ?? '') === '23000'
-                && in_array($error['code'] ?? 0, [2627, 2601], true)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -556,7 +556,7 @@ class Connection extends BaseConnection
             $error     = $this->error();
             $exception = $this->isUniqueConstraintViolation()
                 ? new UniqueConstraintViolationException($message, $error['code'])
-                : new DatabaseException($message, $error['code']);
+                : $this->createDatabaseException($message, $error['code']);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -91,6 +91,22 @@ class Connection extends BaseConnection
     protected $_reserved_identifiers = ['*'];
 
     /**
+     * Checks whether the native database code represents a retryable transaction failure.
+     */
+    protected function isRetryableTransactionErrorCode(int|string $code): bool
+    {
+        $vendorCode = (string) (is_string($code) && str_contains($code, '/')
+            ? substr($code, strrpos($code, '/') + 1)
+            : $code);
+
+        if (preg_match('/^\d+$/', $vendorCode) !== 1) {
+            return false;
+        }
+
+        return in_array((int) $vendorCode, [1205, 3960], true);
+    }
+
+    /**
      * Class constructor
      */
     public function __construct(array $params)

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -68,6 +68,14 @@ class Connection extends BaseConnection
     protected ?int $synchronous = null;
 
     /**
+     * Checks whether the native database code represents a retryable transaction failure.
+     */
+    protected function isRetryableTransactionErrorCode(int|string $code): bool
+    {
+        return $code === 5;
+    }
+
+    /**
      * @return void
      */
     public function initialize()

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -182,7 +182,7 @@ class Connection extends BaseConnection
             $error     = $this->error();
             $exception = $this->isUniqueConstraintViolation($e->getMessage())
                 ? new UniqueConstraintViolationException($e->getMessage(), $error['code'], $e)
-                : new DatabaseException($e->getMessage(), $error['code'], $e);
+                : $this->createDatabaseException($e->getMessage(), $error['code'], $e);
 
             if ($this->DBDebug) {
                 throw $exception;

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Database\TableName;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use Exception;
@@ -66,6 +65,18 @@ class Connection extends BaseConnection
      * @see https://www.sqlite.org/pragma.html#pragma_synchronous
      */
     protected ?int $synchronous = null;
+
+    /**
+     * Checks whether the native database error represents a unique constraint violation.
+     */
+    protected function isUniqueConstraintViolation(int|string $code, string $message): bool
+    {
+        // SQLite3 reports unique violations in two formats depending on version:
+        // Modern:  "UNIQUE constraint failed: table.column"
+        // Legacy:  "column X is not unique"
+        return str_contains($message, 'UNIQUE constraint failed')
+            || str_contains($message, 'is not unique');
+    }
 
     /**
      * Checks whether the native database code represents a retryable transaction failure.
@@ -180,9 +191,7 @@ class Connection extends BaseConnection
             ]);
 
             $error     = $this->error();
-            $exception = $this->isUniqueConstraintViolation($e->getMessage())
-                ? new UniqueConstraintViolationException($e->getMessage(), $error['code'], $e)
-                : $this->createDatabaseException($e->getMessage(), $error['code'], $e);
+            $exception = $this->createDatabaseException($e->getMessage(), $error['code'], $e);
 
             if ($this->DBDebug) {
                 throw $exception;
@@ -192,15 +201,6 @@ class Connection extends BaseConnection
         }
 
         return false;
-    }
-
-    private function isUniqueConstraintViolation(string $message): bool
-    {
-        // SQLite3 reports unique violations in two formats depending on version:
-        // Modern:  "UNIQUE constraint failed: table.column"
-        // Legacy:  "column X is not unique"
-        return str_contains($message, 'UNIQUE constraint failed')
-            || str_contains($message, 'is not unique');
     }
 
     /**

--- a/tests/system/Database/RetryableTransactionExceptionTest.php
+++ b/tests/system/Database/RetryableTransactionExceptionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
+use CodeIgniter\Database\MySQLi\Connection as MySQLiConnection;
+use CodeIgniter\Database\OCI8\Connection as OCI8Connection;
+use CodeIgniter\Database\Postgre\Connection as PostgreConnection;
+use CodeIgniter\Database\SQLite3\Connection as SQLite3Connection;
+use CodeIgniter\Database\SQLSRV\Connection as SQLSRVConnection;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class RetryableTransactionExceptionTest extends CIUnitTestCase
+{
+    #[DataProvider('provideRecognizesRetryableTransactionExceptions')]
+    public function testRecognizesRetryableTransactionExceptions(BaseConnection $db, int|string $code): void
+    {
+        $exception = new DatabaseException('Retryable transaction failure.', $code);
+
+        $this->assertTrue($db->isRetryableTransactionException($exception));
+    }
+
+    /**
+     * @return iterable<string, array{BaseConnection, int|string}>
+     */
+    public static function provideRecognizesRetryableTransactionExceptions(): iterable
+    {
+        yield 'MySQLi deadlock' => [self::connection(MySQLiConnection::class, 'MySQLi'), 1213];
+
+        yield 'Postgre serialization failure' => [self::connection(PostgreConnection::class, 'Postgre'), '40001'];
+
+        yield 'Postgre deadlock' => [self::connection(PostgreConnection::class, 'Postgre'), '40P01'];
+
+        yield 'SQLite busy' => [self::connection(SQLite3Connection::class, 'SQLite3'), 5];
+
+        yield 'SQLSRV deadlock' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), '40001/1205'];
+
+        yield 'SQLSRV vendor deadlock' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), 1205];
+
+        yield 'SQLSRV snapshot isolation conflict' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), 'HY000/3960'];
+
+        if (defined('OCI_COMMIT_ON_SUCCESS')) {
+            yield 'OCI8 deadlock' => [self::connection(OCI8Connection::class, 'OCI8'), 60];
+
+            yield 'OCI8 serialization failure' => [self::connection(OCI8Connection::class, 'OCI8'), 8177];
+        }
+    }
+
+    #[DataProvider('provideRejectsNonRetryableTransactionExceptions')]
+    public function testRejectsNonRetryableTransactionExceptions(BaseConnection $db, int|string $code): void
+    {
+        $exception = new DatabaseException('Non-retryable transaction failure.', $code);
+
+        $this->assertFalse($db->isRetryableTransactionException($exception));
+    }
+
+    /**
+     * @return iterable<string, array{BaseConnection, int|string}>
+     */
+    public static function provideRejectsNonRetryableTransactionExceptions(): iterable
+    {
+        yield 'Base connection default' => [self::connection(MockConnection::class, 'MockDriver'), 1213];
+
+        yield 'MySQLi lock wait timeout' => [self::connection(MySQLiConnection::class, 'MySQLi'), 1205];
+
+        yield 'MySQLi duplicate key' => [self::connection(MySQLiConnection::class, 'MySQLi'), 1062];
+
+        yield 'Postgre unique violation' => [self::connection(PostgreConnection::class, 'Postgre'), '23505'];
+
+        yield 'Postgre exclusion violation' => [self::connection(PostgreConnection::class, 'Postgre'), '23P01'];
+
+        yield 'SQLite locked' => [self::connection(SQLite3Connection::class, 'SQLite3'), 6];
+
+        yield 'SQLite busy snapshot extended code' => [self::connection(SQLite3Connection::class, 'SQLite3'), 517];
+
+        yield 'SQLite constraint' => [self::connection(SQLite3Connection::class, 'SQLite3'), 19];
+
+        yield 'SQLSRV lock timeout' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), 'HYT00/1222'];
+
+        yield 'SQLSRV SQLSTATE without vendor code' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), '40001'];
+
+        yield 'SQLSRV unique constraint' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), '23000/2627'];
+
+        yield 'SQLSRV unique index' => [self::connection(SQLSRVConnection::class, 'SQLSRV'), '23000/2601'];
+
+        if (defined('OCI_COMMIT_ON_SUCCESS')) {
+            yield 'OCI8 resource busy' => [self::connection(OCI8Connection::class, 'OCI8'), 54];
+
+            yield 'OCI8 unique constraint' => [self::connection(OCI8Connection::class, 'OCI8'), 1];
+        }
+    }
+
+    public function testRejectsNonDatabaseExceptions(): void
+    {
+        $db = self::connection(MySQLiConnection::class, 'MySQLi');
+
+        $this->assertFalse($db->isRetryableTransactionException(new RuntimeException('Not a database exception.')));
+    }
+
+    public function testRejectsUniqueConstraintViolationExceptions(): void
+    {
+        $db = self::connection(MySQLiConnection::class, 'MySQLi');
+
+        $this->assertFalse($db->isRetryableTransactionException(
+            new UniqueConstraintViolationException('Duplicate key.', 1062),
+        ));
+    }
+
+    /**
+     * @param class-string<BaseConnection> $connectionClass
+     */
+    private static function connection(string $connectionClass, string $driver): BaseConnection
+    {
+        return new $connectionClass([
+            'DSN'      => '',
+            'hostname' => 'localhost',
+            'username' => '',
+            'password' => '',
+            'database' => 'test',
+            'DBDriver' => $driver,
+            'DBDebug'  => true,
+            'charset'  => 'utf8',
+            'DBCollat' => 'utf8_general_ci',
+            'swapPre'  => '',
+            'encrypt'  => false,
+            'compress' => false,
+            'failover' => [],
+        ]);
+    }
+}

--- a/tests/system/Database/RetryableTransactionExceptionTest.php
+++ b/tests/system/Database/RetryableTransactionExceptionTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\RetryableTransactionException;
+use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
 use CodeIgniter\Database\MySQLi\Connection as MySQLiConnection;
 use CodeIgniter\Database\OCI8\Connection as OCI8Connection;
 use CodeIgniter\Database\Postgre\Connection as PostgreConnection;
@@ -32,6 +33,56 @@ use ReflectionMethod;
 #[Group('Others')]
 final class RetryableTransactionExceptionTest extends CIUnitTestCase
 {
+    #[DataProvider('provideCreatesUniqueConstraintViolationExceptions')]
+    public function testCreatesUniqueConstraintViolationExceptions(
+        BaseConnection $db,
+        int|string $code,
+        string $message,
+    ): void {
+        $exception = self::createDatabaseException($db, $message, $code);
+
+        $this->assertInstanceOf(UniqueConstraintViolationException::class, $exception);
+        $this->assertSame($code, $exception->getDatabaseCode());
+    }
+
+    /**
+     * @return iterable<string, array{BaseConnection, int|string, string}>
+     */
+    public static function provideCreatesUniqueConstraintViolationExceptions(): iterable
+    {
+        yield 'MySQLi duplicate key' => [
+            self::connection(MySQLiConnection::class, 'MySQLi'),
+            1062,
+            'Duplicate entry.',
+        ];
+
+        yield 'Postgre unique violation' => [
+            self::connection(PostgreConnection::class, 'Postgre'),
+            '23505',
+            'Unique violation.',
+        ];
+
+        yield 'SQLite unique constraint' => [
+            self::connection(SQLite3Connection::class, 'SQLite3'),
+            19,
+            'UNIQUE constraint failed: table.column',
+        ];
+
+        yield 'SQLite legacy unique constraint' => [
+            self::connection(SQLite3Connection::class, 'SQLite3'),
+            19,
+            'column email is not unique',
+        ];
+
+        if (defined('OCI_COMMIT_ON_SUCCESS')) {
+            yield 'OCI8 unique constraint' => [
+                self::connection(OCI8Connection::class, 'OCI8'),
+                1,
+                'Unique constraint violated.',
+            ];
+        }
+    }
+
     #[DataProvider('provideCreatesRetryableTransactionExceptions')]
     public function testCreatesRetryableTransactionExceptions(BaseConnection $db, int|string $code): void
     {

--- a/tests/system/Database/RetryableTransactionExceptionTest.php
+++ b/tests/system/Database/RetryableTransactionExceptionTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
+use CodeIgniter\Database\Exceptions\RetryableTransactionException;
 use CodeIgniter\Database\MySQLi\Connection as MySQLiConnection;
 use CodeIgniter\Database\OCI8\Connection as OCI8Connection;
 use CodeIgniter\Database\Postgre\Connection as PostgreConnection;
@@ -24,7 +24,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use RuntimeException;
+use ReflectionMethod;
 
 /**
  * @internal
@@ -32,18 +32,19 @@ use RuntimeException;
 #[Group('Others')]
 final class RetryableTransactionExceptionTest extends CIUnitTestCase
 {
-    #[DataProvider('provideRecognizesRetryableTransactionExceptions')]
-    public function testRecognizesRetryableTransactionExceptions(BaseConnection $db, int|string $code): void
+    #[DataProvider('provideCreatesRetryableTransactionExceptions')]
+    public function testCreatesRetryableTransactionExceptions(BaseConnection $db, int|string $code): void
     {
-        $exception = new DatabaseException('Retryable transaction failure.', $code);
+        $exception = self::createDatabaseException($db, 'Retryable transaction failure.', $code);
 
-        $this->assertTrue($db->isRetryableTransactionException($exception));
+        $this->assertInstanceOf(RetryableTransactionException::class, $exception);
+        $this->assertSame($code, $exception->getDatabaseCode());
     }
 
     /**
      * @return iterable<string, array{BaseConnection, int|string}>
      */
-    public static function provideRecognizesRetryableTransactionExceptions(): iterable
+    public static function provideCreatesRetryableTransactionExceptions(): iterable
     {
         yield 'MySQLi deadlock' => [self::connection(MySQLiConnection::class, 'MySQLi'), 1213];
 
@@ -66,18 +67,18 @@ final class RetryableTransactionExceptionTest extends CIUnitTestCase
         }
     }
 
-    #[DataProvider('provideRejectsNonRetryableTransactionExceptions')]
-    public function testRejectsNonRetryableTransactionExceptions(BaseConnection $db, int|string $code): void
+    #[DataProvider('provideCreatesBaseDatabaseExceptionsForNonRetryableErrors')]
+    public function testCreatesBaseDatabaseExceptionsForNonRetryableErrors(BaseConnection $db, int|string $code): void
     {
-        $exception = new DatabaseException('Non-retryable transaction failure.', $code);
+        $exception = self::createDatabaseException($db, 'Non-retryable transaction failure.', $code);
 
-        $this->assertFalse($db->isRetryableTransactionException($exception));
+        $this->assertNotInstanceOf(RetryableTransactionException::class, $exception);
     }
 
     /**
      * @return iterable<string, array{BaseConnection, int|string}>
      */
-    public static function provideRejectsNonRetryableTransactionExceptions(): iterable
+    public static function provideCreatesBaseDatabaseExceptionsForNonRetryableErrors(): iterable
     {
         yield 'Base connection default' => [self::connection(MockConnection::class, 'MockDriver'), 1213];
 
@@ -110,20 +111,21 @@ final class RetryableTransactionExceptionTest extends CIUnitTestCase
         }
     }
 
-    public function testRejectsNonDatabaseExceptions(): void
+    public function testQueryThrowsRetryableTransactionExceptionFromDriverExecutionPath(): void
     {
-        $db = self::connection(MySQLiConnection::class, 'MySQLi');
+        $db = $this->getMockBuilder(MySQLiConnection::class)
+            ->setConstructorArgs([self::config('MySQLi')])
+            ->onlyMethods(['connect', 'execute'])
+            ->getMock();
 
-        $this->assertFalse($db->isRetryableTransactionException(new RuntimeException('Not a database exception.')));
-    }
+        $db->method('connect')->willReturn(mysqli_init());
+        $db->method('execute')->willThrowException(
+            self::createDatabaseException($db, 'Deadlock found when trying to get lock.', 1213),
+        );
 
-    public function testRejectsUniqueConstraintViolationExceptions(): void
-    {
-        $db = self::connection(MySQLiConnection::class, 'MySQLi');
+        $this->expectException(RetryableTransactionException::class);
 
-        $this->assertFalse($db->isRetryableTransactionException(
-            new UniqueConstraintViolationException('Duplicate key.', 1062),
-        ));
+        $db->query('SELECT * FROM test');
     }
 
     /**
@@ -131,7 +133,15 @@ final class RetryableTransactionExceptionTest extends CIUnitTestCase
      */
     private static function connection(string $connectionClass, string $driver): BaseConnection
     {
-        return new $connectionClass([
+        return new $connectionClass(self::config($driver));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function config(string $driver): array
+    {
+        return [
             'DSN'      => '',
             'hostname' => 'localhost',
             'username' => '',
@@ -145,6 +155,16 @@ final class RetryableTransactionExceptionTest extends CIUnitTestCase
             'encrypt'  => false,
             'compress' => false,
             'failover' => [],
-        ]);
+        ];
+    }
+
+    private static function createDatabaseException(
+        BaseConnection $db,
+        string $message,
+        int|string $code,
+    ): DatabaseException {
+        $method = new ReflectionMethod($db, 'createDatabaseException');
+
+        return $method->invoke($db, $message, $code);
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,7 +43,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, ``isRetryableTransactionException()``, and ``transaction()`` methods.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()`` and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
 
@@ -202,7 +202,7 @@ Database
 
 - Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
 - Added ``inTransaction()`` to database connections to check whether the connection is inside an active CodeIgniter-managed transaction. See :ref:`transactions-checking-transaction-state`.
-- Added ``isRetryableTransactionException()`` to database connections to identify driver-specific retryable transaction failures such as deadlocks and serialization failures. See :ref:`transactions-retryable-exceptions`.
+- Added ``RetryableTransactionException`` for driver-specific retryable transaction failures such as deadlocks and serialization failures. See :ref:`transactions-retryable-exceptions`.
 - Added the ``transaction()`` method to database connections to run a callback inside a transaction. See :ref:`transactions-closure`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,7 +43,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, ``isRetryableTransactionException()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
 
@@ -201,8 +201,9 @@ Database
 ========
 
 - Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
-- Added the ``transaction()`` method to database connections to run a callback inside a transaction. See :ref:`transactions-closure`.
 - Added ``inTransaction()`` to database connections to check whether the connection is inside an active CodeIgniter-managed transaction. See :ref:`transactions-checking-transaction-state`.
+- Added ``isRetryableTransactionException()`` to database connections to identify driver-specific retryable transaction failures such as deadlocks and serialization failures. See :ref:`transactions-retryable-exceptions`.
+- Added the ``transaction()`` method to database connections to run a callback inside a transaction. See :ref:`transactions-closure`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,7 +43,7 @@ Interface Changes
 **NOTE:** If you've implemented your own classes that implement these interfaces from scratch, you will need to
 update your implementations to include the new methods or method changes to ensure compatibility.
 
-- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()`` and ``transaction()`` methods.
+- **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -82,6 +82,32 @@ Callbacks registered with ``afterCommit()`` or ``afterRollback()`` inside the
 transaction callback follow the same rules as other transaction callbacks: they
 run only after the outermost transaction commits or rolls back.
 
+.. _transactions-retryable-exceptions:
+
+Classifying Retryable Transaction Failures
+==========================================
+
+.. versionadded:: 4.8.0
+
+Some database engines report transaction failures that may succeed when the
+entire transaction is attempted again, such as deadlocks or serialization
+failures. The ``isRetryableTransactionException()`` method checks whether a
+``DatabaseException`` represents one of these driver-specific failures so you
+can decide how your application should respond:
+
+.. literalinclude:: transactions/015.php
+
+This method is only a classifier. It does not retry the transaction
+automatically. If you retry, run the whole transaction again. Avoid
+non-transactional side effects inside transaction bodies that may be retried.
+For side effects such as queued jobs, emails, cache invalidation, or external
+API calls, register them with ``afterCommit()`` so they run only after the
+transaction commits.
+
+When ``DBDebug`` is ``false`` and a failed query returns ``false`` instead of
+throwing, inspect ``getLastException()`` immediately after the failed operation
+and pass that exception to ``isRetryableTransactionException()``.
+
 Strict Mode
 ===========
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -91,22 +91,24 @@ Classifying Retryable Transaction Failures
 
 Some database engines report transaction failures that may succeed when the
 entire transaction is attempted again, such as deadlocks or serialization
-failures. The ``isRetryableTransactionException()`` method checks whether a
-``DatabaseException`` represents one of these driver-specific failures so you
-can decide how your application should respond:
+failures. When a driver classifies a query execution failure as one of these
+retryable transaction failures, CodeIgniter throws
+``RetryableTransactionException`` so you can decide how your application should
+respond:
 
 .. literalinclude:: transactions/015.php
 
-This method is only a classifier. It does not retry the transaction
+This exception is only a classifier. CodeIgniter does not retry the transaction
 automatically. If you retry, run the whole transaction again. Avoid
-non-transactional side effects inside transaction bodies that may be retried.
-For side effects such as queued jobs, emails, cache invalidation, or external
-API calls, register them with ``afterCommit()`` so they run only after the
-transaction commits.
+non-transactional side effects inside transaction bodies that may be retried. For
+side effects such as queued jobs, emails, cache invalidation, or external API
+calls, register them with ``afterCommit()`` so they run only after the transaction
+commits.
 
 When ``DBDebug`` is ``false`` and a failed query returns ``false`` instead of
-throwing, inspect ``getLastException()`` immediately after the failed operation
-and pass that exception to ``isRetryableTransactionException()``.
+throwing, inspect ``getLastException()`` immediately after the failed operation.
+It will contain the ``RetryableTransactionException`` instance when the driver
+classifies the failure as retryable.
 
 Strict Mode
 ===========

--- a/user_guide_src/source/database/transactions/015.php
+++ b/user_guide_src/source/database/transactions/015.php
@@ -1,0 +1,17 @@
+<?php
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
+try {
+    $result = $db->transException(true)->transaction(static function ($db) {
+        $db->table('orders')->insert($order);
+
+        return $db->insertID();
+    });
+} catch (DatabaseException $e) {
+    if ($db->isRetryableTransactionException($e)) {
+        // Retry the whole transaction according to your application's policy.
+    }
+
+    throw $e;
+}

--- a/user_guide_src/source/database/transactions/015.php
+++ b/user_guide_src/source/database/transactions/015.php
@@ -1,6 +1,6 @@
 <?php
 
-use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\Exceptions\RetryableTransactionException;
 
 try {
     $result = $db->transException(true)->transaction(static function ($db) {
@@ -8,10 +8,7 @@ try {
 
         return $db->insertID();
     });
-} catch (DatabaseException $e) {
-    if ($db->isRetryableTransactionException($e)) {
-        // Retry the whole transaction according to your application's policy.
-    }
-
+} catch (RetryableTransactionException $e) {
+    // Retry the whole transaction according to your application's policy.
     throw $e;
 }


### PR DESCRIPTION
**Description**

This PR proposes adding `RetryableTransactionException` for driver-specific transaction failures that are reasonable candidates for retrying the whole transaction, such as deadlocks and serialization failures.

The goal is to give CodeIgniter a small, conservative, driver-aware classification point without adding another public helper method to database connections. This follows the same direction as `UniqueConstraintViolationException`: when the driver recognizes a known database condition, it can throw a more specific exception type instead of a plain `DatabaseException`.

This can already help applications that want to implement their own retry policy:

```php
try {
    $orderId = $db->transException(true)->transaction(static function ($db) use ($order) {
        $db->table('orders')->insert($order);

        return $db->insertID();
    });
} catch (RetryableTransactionException $e) {
    // Retry the whole transaction according to the application's policy.
    throw $e;
}
```

It is also intended as groundwork for a possible follow-up proposal to add opt-in retry support to the closure-based `transaction()` helper. Keeping the exception classification separate makes that later discussion smaller: retryable database errors can be reviewed independently from retry control flow, attempt counts, backoff behavior, and callback side-effect concerns.

This PR does not retry anything automatically. It only classifies known retryable transaction failures through a dedicated exception type.

**Changes**

- Added `RetryableTransactionException`, extending `DatabaseException`.
- Added centralized semantic exception creation in `BaseConnection`.
- Routed unique constraint and retryable transaction classification through the shared database exception factory.
- Added driver-specific retryable transaction classification.
- Simplified driver query execution paths to use the shared exception factory.
- Added focused tests for retryable, non-retryable, and unique-constraint exception classification.
- Updated the transaction docs and v4.8.0 changelog.

**Driver Policy**

The retryable classification is intentionally conservative. It includes transaction-level concurrency failures where retrying the whole transaction is a reasonable default:

- MySQLi deadlock: `1213`
- Postgre serialization failure/deadlock: `40001`, `40P01`
- SQLite busy: `5`
- SQLSRV deadlock/snapshot conflict: `1205`, `3960`
- OCI8 deadlock/serialization failure: `60`, `8177`

It intentionally does not classify lock timeouts, unique constraint violations, resource-busy errors, or SQLite extended busy codes as framework-default retryable transaction failures. Those can be valid retry cases in some applications, but they are more policy-dependent.

References: [MySQL](https://dev.mysql.com/doc/refman/en/innodb-error-handling.html), [PostgreSQL](https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html), [SQLite](https://www.sqlite.org/rescode.html), [SQL Server deadlocks](https://learn.microsoft.com/en-us/sql/relational-databases/sql-server-deadlocks-guide), [SQL Server 3960](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-3000-to-3999), [Oracle ORA-00060](https://docs.oracle.com/en/error-help/db/ora-00060/), [Oracle ORA-08177](https://docs.oracle.com/en/error-help/db/ora-08177/).

**Scope Note**

This PR focuses on the normal driver query execution paths. Prepared queries still have separate exception paths today, similar to the existing unique-constraint behavior. I kept that out of this PR so it stays focused, but I’m happy to work on prepared-query exception consistency as a follow-up.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide