### PR TITLE
fix: suppress tput stderr leak when TERM is not present

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -782,8 +782,8 @@ class CLI
                 static::$height = (int) $matches[1];
                 static::$width  = (int) $matches[2];
             } else {
-                static::$height = (int) exec('tput lines');
-                static::$width  = (int) exec('tput cols');
+                static::$height = (int) exec('tput lines 2>/dev/null');
+                static::$width  = (int) exec('tput cols 2>/dev/null');
             }
         } catch (Throwable $e) {
             // Reset the dimensions so that the default values will be returned later.

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -598,6 +598,28 @@ final class CLITest extends CIUnitTestCase
     #[RequiresOperatingSystem('Darwin|Linux')]
     public function testGenerateDimensionsDoesNotLeakSttyErrorToStderr(): void
     {
+        $this->assertSame('', $this->captureGenerateDimensionsStderr());
+    }
+
+    #[RequiresOperatingSystem('Darwin|Linux')]
+    public function testGenerateDimensionsDoesNotLeakTputErrorToStderrWhenTermIsUnset(): void
+    {
+        $env = getenv();
+        unset($env['TERM']);
+
+        $this->assertSame('', $this->captureGenerateDimensionsStderr($env));
+    }
+
+    /**
+     * Spawns a child PHP process that calls `CLI::generateDimensions()` with
+     * `STDIN` pointed at `/dev/null` (forcing the non-TTY code path), and
+     * returns whatever it wrote to stderr.
+     *
+     * @param array<string, string>|null $env Environment for the child process.
+     *                                        `null` inherits the parent env.
+     */
+    private function captureGenerateDimensionsStderr(?array $env = null): string
+    {
         $code = <<<'PHP'
             require __DIR__ . '/system/Test/bootstrap.php';
             CodeIgniter\CLI\CLI::generateDimensions();
@@ -610,6 +632,7 @@ final class CLITest extends CIUnitTestCase
             [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $pipes,
             ROOTPATH,
+            $env,
         );
         $this->assertIsResource($proc);
 
@@ -619,7 +642,7 @@ final class CLITest extends CIUnitTestCase
         fclose($pipes[2]);
         proc_close($proc);
 
-        $this->assertSame('', $stderr);
+        return $stderr;
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -38,6 +38,7 @@ Bugs Fixed
 
 - **Autoloader:** Fixed a bug where ``Autoloader::unregister()`` (used during tests) silently failed to remove handlers from the SPL autoload stack, causing closures to accumulate permanently.
 - **CLI:** Fixed a bug where ``CLI::generateDimensions()`` leaked ``stty`` error output (e.g., ``stty: 'standard input': Inappropriate ioctl for device``) to stderr when stdin was not a TTY.
+- **CLI:** Fixed a bug where ``CLI::generateDimensions()`` leaked ``tput`` error output (``tput: No value for $TERM and no -T specified``) to stderr when the ``stty`` fallback was reached and the ``TERM`` environment variable was not set.
 - **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 - **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Follow-up to #10124. When `stty size` fails (stdin isn't a TTY), `CLI::generateDimensions()` falls through to `tput lines` / `tput cols`. If the spawned process inherits an environment without `TERM` (common in `phpunit` subprocess invocations and some CI runners), `tput` writes `tput: No value for $TERM and no -T specified` to stderr — `exec()` only captures stdout, so the message leaks. Adding `2>/dev/null` to the two `tput` calls suppresses the noise without changing behavior: `exec()` still returns the empty value and the dimensions fall back to defaults.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
