### PR TITLE
test: fix random-order failures in Config, Honeypot, and Test

### DIFF
--- a/.github/scripts/random-tests-config.txt
+++ b/.github/scripts/random-tests-config.txt
@@ -14,7 +14,7 @@ Autoloader
 # Cache
 CLI
 # Commands
-# Config
+Config
 Cookie
 # DataCaster
 # DataConverter
@@ -29,7 +29,7 @@ Files
 Format
 # HTTP
 # Helpers
-# Honeypot
+Honeypot
 HotReloader
 # I18n
 # Images
@@ -42,7 +42,7 @@ RESTful
 # Router
 Security
 # Session
-# Test
+Test
 Throttle
 Typography
 # Validation

--- a/tests/_support/Test/TestForReflectionHelper.php
+++ b/tests/_support/Test/TestForReflectionHelper.php
@@ -28,6 +28,11 @@ class TestForReflectionHelper
         return self::$static_private;
     }
 
+    public static function resetStaticPrivate(): void
+    {
+        self::$static_private = 'xyz';
+    }
+
     private function privateMethod($param1, $param2) // @phpstan-ignore method.unused
     {
         return 'private ' . $param1 . $param2;

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -42,6 +42,7 @@ final class BaseConfigTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        $this->clearLooseEnvironmentOverrides();
         $this->fixturesFolder = __DIR__ . '/fixtures';
 
         if (! class_exists('SimpleConfig', false)) {
@@ -65,10 +66,25 @@ final class BaseConfigTest extends CIUnitTestCase
     {
         parent::tearDown();
 
+        $this->clearLooseEnvironmentOverrides();
         // This test modifies BaseConfig::$modules, so should reset.
         BaseConfig::reset();
         // This test modifies Services locator, so should reset.
         $this->resetServices();
+    }
+
+    private function clearLooseEnvironmentOverrides(): void
+    {
+        foreach ([
+            'SimpleConfig.QZERO',
+            'SimpleConfig.QZEROSTR',
+            'SimpleConfig.QEMPTYSTR',
+            'SimpleConfig.QFALSE',
+        ] as $key) {
+            putenv($key);
+            unset($_ENV[$key]);
+            Services::superglobals()->unsetServer($key);
+        }
     }
 
     public function testBasicValues(): void

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -244,7 +244,7 @@ final class FactoriesTest extends CIUnitTestCase
     {
         Factories::setOptions('widgets', ['instanceOf' => 'stdClass']);
 
-        $result = Factories::widgets('OtherWidget', ['instanceOf' => null]);
+        $result = Factories::widgets(OtherWidget::class, ['instanceOf' => null]);
         $this->assertInstanceOf(OtherWidget::class, $result);
     }
 

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -50,6 +50,8 @@ final class HoneypotTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        $this->resetServices();
+        Factories::reset('config');
         Services::injectMock('superglobals', new Superglobals());
 
         $this->config   = new HoneypotConfig();

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -671,6 +671,10 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $config->autoRoute = true;
         Factories::injectMock('config', Routing::class, $config);
 
+        $collection = service('routes');
+        $collection->setAutoRoute(true);
+        $collection->setDefaultNamespace('App\Controllers');
+
         $response = $this->get('home/index');
 
         $response->assertOK();

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -22,6 +22,13 @@ use Tests\Support\Test\TestForReflectionHelper;
 #[Group('Others')]
 final class ReflectionHelperTest extends CIUnitTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        TestForReflectionHelper::resetStaticPrivate();
+    }
+
     public function testGetPrivatePropertyWithObject(): void
     {
         $obj    = new TestForReflectionHelper();


### PR DESCRIPTION
**Description**

Related to #9968

This fixes several test-order dependencies found while working on random test execution support.

This updates tests in the `Config`, `Honeypot`, and `Test` components so they no longer depend on state left behind by earlier tests:

- reset mutable static fixture state in `ReflectionHelperTest`
- reset shared services/config factory state in `HoneypotTest`
- avoid short-name factory alias pollution in `FactoriesTest`
- clear `loose.env` overrides between `BaseConfigTest` methods
- make `FeatureTestTraitTest::testAutoRoutingLegacy()` configure the actual route collection it uses

Verified locally:

- random-order smoke runs for `Config`, `Honeypot`, and `Test`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide