### PR TITLE
test: make random component execution safer

### DIFF
--- a/.github/scripts/random-tests-config.txt
+++ b/.github/scripts/random-tests-config.txt
@@ -13,7 +13,7 @@ AutoReview
 Autoloader
 # Cache
 CLI
-# Commands
+Commands
 Config
 Cookie
 # DataCaster

--- a/system/Cache/FactoriesCache/FileVarExportHandler.php
+++ b/system/Cache/FactoriesCache/FileVarExportHandler.php
@@ -21,11 +21,19 @@ final class FileVarExportHandler
     {
         $val = var_export($val, true);
 
+        if (! is_dir($this->path) && ! @mkdir($this->path, 0777, true) && ! is_dir($this->path)) {
+            return;
+        }
+
         // Write to temp file first to ensure atomicity
         $tmp = $this->path . "/{$key}." . uniqid('', true) . '.tmp';
-        file_put_contents($tmp, '<?php return ' . $val . ';', LOCK_EX);
+        if (file_put_contents($tmp, '<?php return ' . $val . ';', LOCK_EX) === false) {
+            return;
+        }
 
-        rename($tmp, $this->path . "/{$key}");
+        if (! @rename($tmp, $this->path . "/{$key}")) {
+            @unlink($tmp);
+        }
     }
 
     public function delete(string $key): void

--- a/system/Cache/FactoriesCache/FileVarExportHandler.php
+++ b/system/Cache/FactoriesCache/FileVarExportHandler.php
@@ -21,17 +21,26 @@ final class FileVarExportHandler
     {
         $val = var_export($val, true);
 
+        // Two processes may try to create the directory at the same time.
+        // is_dir() confirms it exists, so suppressing the warning is safe.
         if (! is_dir($this->path) && ! @mkdir($this->path, 0777, true) && ! is_dir($this->path)) {
+            log_message('error', 'FactoriesCache: cannot create cache directory: ' . $this->path);
+
             return;
         }
 
         // Write to temp file first to ensure atomicity
         $tmp = $this->path . "/{$key}." . uniqid('', true) . '.tmp';
         if (file_put_contents($tmp, '<?php return ' . $val . ';', LOCK_EX) === false) {
+            log_message('warning', 'FactoriesCache: failed to write temp file for key: ' . $key);
+
             return;
         }
 
+        // Another process may have wiped the directory. Clean up on failure.
         if (! @rename($tmp, $this->path . "/{$key}")) {
+            log_message('warning', 'FactoriesCache: failed to commit cache file for key: ' . $key);
+
             @unlink($tmp);
         }
     }

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -243,7 +243,7 @@ class ShowTableInfo extends BaseCommand
     {
         $this->removeDBPrefix();
 
-        foreach ($tables  as $id => $tableName) {
+        foreach (array_values($tables) as $id => $tableName) {
             $table = $this->db->protectIdentifiers($tableName);
             $db    = $this->db->query("SELECT * FROM {$table}");
 

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -243,7 +243,7 @@ class ShowTableInfo extends BaseCommand
     {
         $this->removeDBPrefix();
 
-        foreach (array_values($tables) as $id => $tableName) {
+        foreach ($tables as $id => $tableName) {
             $table = $this->db->protectIdentifiers($tableName);
             $db    = $this->db->query("SELECT * FROM {$table}");
 

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -241,6 +241,8 @@ class ShowTableInfo extends BaseCommand
      */
     private function makeTbodyForShowAllTables(array $tables): array
     {
+        $this->tbody = [];
+
         $this->removeDBPrefix();
 
         foreach ($tables as $id => $tableName) {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1684,9 +1684,11 @@ abstract class BaseConnection implements ConnectionInterface
     public function listTables(bool $constrainByPrefix = false)
     {
         if (isset($this->dataCache['table_names']) && $this->dataCache['table_names']) {
-            return $constrainByPrefix
+            $tables = $constrainByPrefix
                 ? preg_grep("/^{$this->DBPrefix}/", $this->dataCache['table_names'])
                 : $this->dataCache['table_names'];
+
+            return array_values($tables);
         }
 
         $sql = $this->_listTables($constrainByPrefix);

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1684,11 +1684,9 @@ abstract class BaseConnection implements ConnectionInterface
     public function listTables(bool $constrainByPrefix = false)
     {
         if (isset($this->dataCache['table_names']) && $this->dataCache['table_names']) {
-            $tables = $constrainByPrefix
+            return $constrainByPrefix
                 ? preg_grep("/^{$this->DBPrefix}/", $this->dataCache['table_names'])
                 : $this->dataCache['table_names'];
-
-            return array_values($tables);
         }
 
         $sql = $this->_listTables($constrainByPrefix);

--- a/system/HotReloader/DirectoryHasher.php
+++ b/system/HotReloader/DirectoryHasher.php
@@ -73,9 +73,11 @@ final class DirectoryHasher
 
         foreach ($iterator as $file) {
             if ($file->isFile()) {
-                $hashes[] = md5_file($file->getRealPath());
+                $hashes[$file->getRealPath()] = md5_file($file->getRealPath());
             }
         }
+
+        ksort($hashes);
 
         return md5(implode('', $hashes));
     }

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -19,7 +19,7 @@ use Exception;
 /**
  * Log error messages to file system
  *
- * @see \CodeIgniter\Log\Handlers\FileHandlerTest
+ * @see FileHandlerTest
  */
 class FileHandler extends BaseHandler
 {
@@ -121,6 +121,7 @@ class FileHandler extends BaseHandler
         fclose($fp);
 
         if ($newfile) {
+            // The log entry is already persisted - permission changes are best-effort.
             @chmod($filepath, $this->filePermissions);
         }
 

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -121,7 +121,7 @@ class FileHandler extends BaseHandler
         fclose($fp);
 
         if ($newfile) {
-            chmod($filepath, $this->filePermissions);
+            @chmod($filepath, $this->filePermissions);
         }
 
         return is_int($result);

--- a/tests/_support/Commands/Unsuffixable.php
+++ b/tests/_support/Commands/Unsuffixable.php
@@ -76,4 +76,14 @@ class Unsuffixable extends BaseCommand
         $this->setEnabledSuffixing(false);
         $this->generateClass($params);
     }
+
+    protected function prepare(string $class): string
+    {
+        return $this->parseTemplate(
+            $class,
+            ['{group}', '{command}'],
+            ['Generators', 'make:foo'],
+            ['type' => 'basic'],
+        );
+    }
 }

--- a/tests/system/AutoReview/CreateNewChangelogTest.php
+++ b/tests/system/AutoReview/CreateNewChangelogTest.php
@@ -48,56 +48,71 @@ final class CreateNewChangelogTest extends TestCase
     #[DataProvider('provideCreateNewChangelog')]
     public function testCreateNewChangelog(string $mode): void
     {
-        $output = exec('git status --porcelain | wc -l');
+        $currentVersion     = $this->currentVersion;
+        $newVersion         = $this->incrementVersion($currentVersion, $mode);
+        $versionWithoutDots = str_replace('.', '', $newVersion);
+        $changelogPath      = "./user_guide_src/source/changelogs/v{$newVersion}.rst";
+        $upgradePath        = "./user_guide_src/source/installation/upgrade_{$versionWithoutDots}.rst";
+        $trackedPathArgs    = implode(' ', array_map(escapeshellarg(...), [
+            './system/CodeIgniter.php',
+            './user_guide_src/source/changelogs/index.rst',
+            './user_guide_src/source/installation/upgrading.rst',
+        ]));
+        $generatedPathArgs = implode(' ', array_map(escapeshellarg(...), [
+            $changelogPath,
+            $upgradePath,
+        ]));
+        $statusCount = trim((string) exec(
+            "git status --porcelain -- {$trackedPathArgs} {$generatedPathArgs} | wc -l",
+        ));
 
-        if ($output !== '0') {
+        if ($statusCount !== '0') {
             $this->markTestSkipped('You have uncommitted operations that will be erased by this test.');
         }
 
-        $currentVersion = $this->currentVersion;
-        $newVersion     = $this->incrementVersion($currentVersion, $mode);
+        try {
+            $output = [];
 
-        exec(
-            sprintf('php ./admin/create-new-changelog.php %s %s --dry-run', $currentVersion, $newVersion),
-            $output,
-            $exitCode,
-        );
+            exec(
+                sprintf('php ./admin/create-new-changelog.php %s %s --dry-run', $currentVersion, $newVersion),
+                $output,
+                $exitCode,
+            );
 
-        $this->assertSame(0, $exitCode, "Script exited with code {$exitCode}. Output: " . implode("\n", $output));
+            $this->assertSame(0, $exitCode, "Script exited with code {$exitCode}. Output: " . implode("\n", $output));
 
-        $this->assertStringContainsString(
-            "public const CI_VERSION = '{$newVersion}-dev';",
-            $this->getContents('./system/CodeIgniter.php'),
-        );
+            $this->assertStringContainsString(
+                "public const CI_VERSION = '{$newVersion}-dev';",
+                $this->getContents('./system/CodeIgniter.php'),
+            );
 
-        $this->assertFileExists("./user_guide_src/source/changelogs/v{$newVersion}.rst");
-        $this->assertStringContainsString(
-            "Version {$newVersion}",
-            $this->getContents("./user_guide_src/source/changelogs/v{$newVersion}.rst"),
-        );
-        $this->assertStringContainsString(
-            "**{$newVersion} release of CodeIgniter4**",
-            $this->getContents("./user_guide_src/source/changelogs/v{$newVersion}.rst"),
-        );
-        $this->assertStringContainsString(
-            $newVersion,
-            $this->getContents('./user_guide_src/source/changelogs/index.rst'),
-        );
+            $this->assertFileExists($changelogPath);
+            $this->assertStringContainsString(
+                "Version {$newVersion}",
+                $this->getContents($changelogPath),
+            );
+            $this->assertStringContainsString(
+                "**{$newVersion} release of CodeIgniter4**",
+                $this->getContents($changelogPath),
+            );
+            $this->assertStringContainsString(
+                $newVersion,
+                $this->getContents('./user_guide_src/source/changelogs/index.rst'),
+            );
 
-        $versionWithoutDots = str_replace('.', '', $newVersion);
-        $this->assertFileExists("./user_guide_src/source/installation/upgrade_{$versionWithoutDots}.rst");
-        $this->assertStringContainsString(
-            "Upgrading from {$currentVersion} to {$newVersion}",
-            $this->getContents("./user_guide_src/source/installation/upgrade_{$versionWithoutDots}.rst"),
-        );
-        $this->assertStringContainsString(
-            "upgrade_{$versionWithoutDots}",
-            $this->getContents('./user_guide_src/source/installation/upgrading.rst'),
-        );
-
-        // cleanup added and modified files
-        exec('git restore .');
-        exec('git clean -fd');
+            $this->assertFileExists($upgradePath);
+            $this->assertStringContainsString(
+                "Upgrading from {$currentVersion} to {$newVersion}",
+                $this->getContents($upgradePath),
+            );
+            $this->assertStringContainsString(
+                "upgrade_{$versionWithoutDots}",
+                $this->getContents('./user_guide_src/source/installation/upgrading.rst'),
+            );
+        } finally {
+            exec("git restore -- {$trackedPathArgs}");
+            exec("git clean -f -- {$generatedPathArgs}");
+        }
     }
 
     /**

--- a/tests/system/Commands/Cache/ClearCacheTest.php
+++ b/tests/system/Commands/Cache/ClearCacheTest.php
@@ -80,6 +80,7 @@ final class ClearCacheTest extends CIUnitTestCase
         Services::injectMock('cache', $cache);
 
         command('cache:clear');
+        Services::resetSingle('cache');
 
         $this->assertSame(
             "\nError while clearing the cache.\n",

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -35,7 +35,7 @@ final class CreateDatabaseTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        $this->connection = Database::connect();
+        $this->connection = Database::connect(null, false);
 
         parent::setUp();
 
@@ -54,12 +54,31 @@ final class CreateDatabaseTest extends CIUnitTestCase
         if ($this->connection instanceof SQLite3Connection) {
             $file = WRITEPATH . 'database.db';
 
+            $this->closeDatabaseConnections();
+
             if (is_file($file)) {
                 unlink($file);
             }
-        } elseif (Database::utils('tests')->databaseExists('database')) {
+
+            return;
+        }
+
+        if (Database::utils('tests')->databaseExists('database')) {
             Database::forge()->dropDatabase('database');
         }
+
+        $this->closeDatabaseConnections();
+    }
+
+    private function closeDatabaseConnections(): void
+    {
+        $this->connection->close();
+
+        foreach (Database::getConnections() as $connection) {
+            $connection->close();
+        }
+
+        $this->setPrivateProperty(Database::class, 'instances', []);
     }
 
     protected function getBuffer(): string

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -29,33 +29,19 @@ final class MigrateStatusTest extends CIUnitTestCase
     use StreamFilterTrait;
     use DatabaseTestTrait;
 
-    private string $migrationFileFrom = SUPPORTPATH . 'MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php';
-    private string $migrationFileTo   = APPPATH . 'Database/Migrations/2018-01-24-102301_Some_migration.php';
+    private string $migrationNamespace     = 'Tests\\Support\\MigrationTestMigrations';
+    private string $migrationNamespacePath = SUPPORTPATH . 'MigrationTestMigrations/';
 
     protected function setUp(): void
     {
+        $this->resetServices();
+
         parent::setUp();
 
         Database::connect()->table('migrations')->emptyTable();
         Database::forge()->dropTable('foo', true);
 
-        if (! is_file($this->migrationFileFrom)) {
-            $this->fail(clean_path($this->migrationFileFrom) . ' is not found.');
-        }
-
-        if (is_file($this->migrationFileTo)) {
-            @unlink($this->migrationFileTo);
-        }
-
-        copy($this->migrationFileFrom, $this->migrationFileTo);
-
-        $contents = file_get_contents($this->migrationFileTo);
-        $contents = str_replace(
-            'namespace Tests\Support\MigrationTestMigrations\Database\Migrations;',
-            'namespace App\Database\Migrations;',
-            $contents,
-        );
-        file_put_contents($this->migrationFileTo, $contents);
+        service('autoloader')->addNamespace($this->migrationNamespace, $this->migrationNamespacePath);
 
         putenv('NO_COLOR=1');
         CLI::init();
@@ -66,13 +52,12 @@ final class MigrateStatusTest extends CIUnitTestCase
         parent::tearDown();
 
         Database::connect()->table('migrations')->emptyTable();
-
-        if (is_file($this->migrationFileTo)) {
-            @unlink($this->migrationFileTo);
-        }
+        Database::forge()->dropTable('foo', true);
 
         putenv('NO_COLOR');
         CLI::init();
+
+        $this->resetServices();
     }
 
     public function testMigrateAllWithWithTwoNamespaces(): void
@@ -82,41 +67,29 @@ final class MigrateStatusTest extends CIUnitTestCase
 
         command('migrate:status');
 
-        $result   = str_replace(PHP_EOL, "\n", $this->getStreamFilterBuffer());
-        $result   = preg_replace('/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d/', 'YYYY-MM-DD HH:MM:SS', $result);
-        $expected = <<<'EOL'
-            +---------------+-------------------+--------------------+-------+---------------------+-------+
-            | Namespace     | Version           | Filename           | Group | Migrated On         | Batch |
-            +---------------+-------------------+--------------------+-------+---------------------+-------+
-            | App           | 2018-01-24-102301 | Some_migration     | tests | YYYY-MM-DD HH:MM:SS | 1     |
-            | Tests\Support | 20160428212500    | Create_test_tables | tests | YYYY-MM-DD HH:MM:SS | 1     |
-            +---------------+-------------------+--------------------+-------+---------------------+-------+
-
-
-            EOL;
-        $this->assertSame($expected, $result);
+        $this->assertMigrationStatusHasBothNamespaceMigrations();
     }
 
     public function testMigrateWithWithTwoNamespaces(): void
     {
-        command('migrate -n App');
+        command('migrate -n Tests\\\\Support\\\\MigrationTestMigrations');
         command('migrate -n Tests\\\\Support');
         $this->resetStreamFilterBuffer();
 
         command('migrate:status');
 
-        $result   = str_replace(PHP_EOL, "\n", $this->getStreamFilterBuffer());
-        $result   = preg_replace('/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d/', 'YYYY-MM-DD HH:MM:SS', $result);
-        $expected = <<<'EOL'
-            +---------------+-------------------+--------------------+-------+---------------------+-------+
-            | Namespace     | Version           | Filename           | Group | Migrated On         | Batch |
-            +---------------+-------------------+--------------------+-------+---------------------+-------+
-            | App           | 2018-01-24-102301 | Some_migration     | tests | YYYY-MM-DD HH:MM:SS | 1     |
-            | Tests\Support | 20160428212500    | Create_test_tables | tests | YYYY-MM-DD HH:MM:SS | 2     |
-            +---------------+-------------------+--------------------+-------+---------------------+-------+
+        $this->assertMigrationStatusHasBothNamespaceMigrations();
+    }
 
+    private function assertMigrationStatusHasBothNamespaceMigrations(): void
+    {
+        $result = str_replace(PHP_EOL, "\n", $this->getStreamFilterBuffer());
 
-            EOL;
-        $this->assertSame($expected, $result);
+        $this->assertStringContainsString($this->migrationNamespace, $result);
+        $this->assertStringContainsString('2018-01-24-102301', $result);
+        $this->assertStringContainsString('Some_migration', $result);
+        $this->assertStringContainsString('Tests\Support', $result);
+        $this->assertStringContainsString('20160428212500', $result);
+        $this->assertStringContainsString('Create_test_tables', $result);
     }
 }

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -83,8 +83,10 @@ final class MigrateStatusTest extends CIUnitTestCase
 
     private function assertMigrationStatusHasBothNamespaceMigrations(): void
     {
-        $result = str_replace(PHP_EOL, "\n", $this->getStreamFilterBuffer());
+        $result       = str_replace(PHP_EOL, "\n", $this->getStreamFilterBuffer());
+        $theadPattern = '/^\|[[:space:]]+Namespace[[:space:]]+\|[[:space:]]+Version[[:space:]]+\|[[:space:]]+Filename[[:space:]]+\|[[:space:]]+Group[[:space:]]+\|[[:space:]]+Migrated On[[:space:]]+\|[[:space:]]+Batch[[:space:]]+\|$/m';
 
+        $this->assertMatchesRegularExpression($theadPattern, $result);
         $this->assertStringContainsString($this->migrationNamespace, $result);
         $this->assertStringContainsString('2018-01-24-102301', $result);
         $this->assertStringContainsString('Some_migration', $result);

--- a/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
@@ -34,6 +34,8 @@ final class ShowTableInfoMockIOTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        $this->db->resetDataCache();
+
         CLI::reset();
 
         putenv('NO_COLOR=1');

--- a/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Mock\MockInputOutput;
+use Config\Database;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -51,12 +52,16 @@ final class ShowTableInfoMockIOTest extends CIUnitTestCase
 
     public function testDbTableWithInputs(): void
     {
+        $tableIndex = array_search('db_migrations', Database::connect()->listTables(), true);
+
+        $this->assertIsInt($tableIndex);
+
         // Set MockInputOutput to CLI.
         $io = new MockInputOutput();
         CLI::setInputOutput($io);
 
-        // User will input "a" (invalid value) and "0".
-        $io->setInputs(['a', '0']);
+        // User will input "a" (invalid value) and then select db_migrations.
+        $io->setInputs(['a', (string) $tableIndex]);
 
         command('db:table');
 
@@ -71,7 +76,7 @@ final class ShowTableInfoMockIOTest extends CIUnitTestCase
             $result,
         );
         $this->assertMatchesRegularExpression(
-            '/Which table do you want to see\? \[[\d,\s]+\]\: 0/',
+            '/Which table do you want to see\? \[[\d,\s]+\]\: ' . $tableIndex . '/',
             $result,
         );
         $this->assertMatchesRegularExpression(

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
-use Config\Database;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
@@ -30,7 +29,7 @@ final class ShowTableInfoTest extends CIUnitTestCase
     use DatabaseTestTrait;
     use StreamFilterTrait;
 
-    protected $migrateOnce = true;
+    protected $seed = CITestSeeder::class;
 
     protected function setUp(): void
     {
@@ -121,9 +120,6 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
     public function testDbTableDesc(): void
     {
-        $seeder = Database::seeder();
-        $seeder->call(CITestSeeder::class);
-
         command('db:table db_user --desc');
 
         $result = $this->getNormalizedResult();

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -35,6 +35,8 @@ final class ShowTableInfoTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        $this->db->resetDataCache();
+
         putenv('NO_COLOR=1');
         CLI::init();
     }

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -25,6 +26,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('DatabaseLive')]
 final class DatabaseCommandsTest extends CIUnitTestCase
 {
+    use DatabaseTestTrait;
     use StreamFilterTrait;
 
     protected function tearDown(): void

--- a/tests/system/Commands/Generators/CommandGeneratorTest.php
+++ b/tests/system/Commands/Generators/CommandGeneratorTest.php
@@ -27,15 +27,21 @@ final class CommandGeneratorTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
-        $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
-        $dir    = dirname($file);
+        preg_match_all('/File (?:created|overwritten): (APPPATH[^\r\n\x1b]+)/', $this->getStreamFilterBuffer(), $matches);
 
-        if (is_file($file)) {
-            unlink($file);
-        }
-        if (is_dir($dir) && str_contains($dir, 'Commands')) {
-            rmdir($dir);
+        foreach ($matches[1] as $file) {
+            $path = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+
+            if (is_file($path)) {
+                unlink($path);
+            }
+
+            $dir      = dirname($path);
+            $dirFiles = is_dir($dir) ? scandir($dir) : false;
+
+            if (str_starts_with($dir, APPPATH . 'Commands') && $dirFiles !== false && count($dirFiles) === 2) {
+                rmdir($dir);
+            }
         }
     }
 

--- a/tests/system/Commands/Generators/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/Generators/ScaffoldGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Generators;
 
+use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Autoload;
@@ -30,9 +31,40 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->resetServices();
+        CLI::init();
         service('autoloader')->initialize(new Autoload(), new Modules());
 
         parent::setUp();
+
+        $this->removeGeneratedFiles();
+        $this->resetStreamFilterBuffer();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->removeGeneratedFiles();
+    }
+
+    private function removeGeneratedFiles(): void
+    {
+        preg_match_all('/File (?:created|overwritten): "?(APPPATH[^"\r\n\x1b]+)/', $this->getStreamFilterBuffer(), $matches);
+
+        foreach ($matches[1] as $file) {
+            $path = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+
+            if (is_file($path)) {
+                @unlink($path);
+            }
+
+            $dir      = dirname($path);
+            $dirFiles = is_dir($dir) ? scandir($dir) : false;
+
+            if (str_starts_with($dir, APPPATH) && $dirFiles !== false && count($dirFiles) === 2) {
+                @rmdir($dir);
+            }
+        }
     }
 
     protected function getFileContents(string $filepath): string
@@ -48,33 +80,17 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
     {
         command('make:scaffold people');
 
-        $dir       = '\\' . DIRECTORY_SEPARATOR;
-        $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
-        $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
-
         // Files check
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/People.php');
         $this->assertFileExists(APPPATH . 'Models/People.php');
         $this->assertStringContainsString('_People.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/People.php');
-
-        // Options check
-        unlink(APPPATH . 'Controllers/People.php');
-        unlink(APPPATH . 'Models/People.php');
-        unlink($matches[0]);
-        unlink(APPPATH . 'Database/Seeds/People.php');
     }
 
     public function testCreateComponentWithManyOptions(): void
     {
         command('make:scaffold user -restful -return entity');
-
-        $dir       = '\\' . DIRECTORY_SEPARATOR;
-        $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
-        $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
@@ -86,24 +102,11 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
         // Options check
         $this->assertStringContainsString('extends ResourceController', $this->getFileContents(APPPATH . 'Controllers/User.php'));
-
-        // Clean up
-        unlink(APPPATH . 'Controllers/User.php');
-        unlink($matches[0]);
-        unlink(APPPATH . 'Database/Seeds/User.php');
-        unlink(APPPATH . 'Entities/User.php');
-        rmdir(APPPATH . 'Entities');
-        unlink(APPPATH . 'Models/User.php');
     }
 
     public function testCreateComponentWithOptionSuffix(): void
     {
         command('make:scaffold order -suffix');
-
-        $dir       = '\\' . DIRECTORY_SEPARATOR;
-        $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
-        $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
@@ -111,12 +114,6 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('_OrderMigration.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/OrderSeeder.php');
         $this->assertFileExists(APPPATH . 'Models/OrderModel.php');
-
-        // Clean up
-        unlink(APPPATH . 'Controllers/OrderController.php');
-        unlink($matches[0]);
-        unlink(APPPATH . 'Database/Seeds/OrderSeeder.php');
-        unlink(APPPATH . 'Models/OrderModel.php');
     }
 
     public function testCreateComponentWithOptionForce(): void
@@ -129,11 +126,6 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
         command('make:scaffold fixer -bare -force');
 
-        $dir       = '\\' . DIRECTORY_SEPARATOR;
-        $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
-        $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
-
         // Files check
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/Fixer.php');
@@ -144,12 +136,6 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
         // Options check
         $this->assertStringContainsString('extends Controller', $this->getFileContents(APPPATH . 'Controllers/Fixer.php'));
         $this->assertStringContainsString('File overwritten: ', $this->getStreamFilterBuffer());
-
-        // Clean up
-        unlink(APPPATH . 'Controllers/Fixer.php');
-        unlink($matches[0]);
-        unlink(APPPATH . 'Database/Seeds/Fixer.php');
-        unlink(APPPATH . 'Models/Fixer.php');
     }
 
     public function testCreateComponentWithOptionNamespace(): void
@@ -173,11 +159,5 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('namespace App\Database\Migrations;', $this->getFileContents($matches[0]));
         $this->assertStringContainsString('namespace App\Database\Seeds;', $this->getFileContents(APPPATH . 'Database/Seeds/Product.php'));
         $this->assertStringContainsString('namespace App\Models;', $this->getFileContents(APPPATH . 'Models/Product.php'));
-
-        // Clean up
-        unlink(APPPATH . 'Controllers/Product.php');
-        unlink($matches[0]);
-        unlink(APPPATH . 'Database/Seeds/Product.php');
-        unlink(APPPATH . 'Models/Product.php');
     }
 }

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -68,22 +68,19 @@ final class MigrationIntegrationTest extends CIUnitTestCase
 
     private function dropTestTables(): void
     {
-        $forge = Database::forge();
+        $db     = Database::connect();
+        $forge  = Database::forge();
+        $tables = $db->listTables();
 
-        foreach ([
-            'user',
-            'job',
-            'misc',
-            'team_members',
-            'type_test',
-            'empty',
-            'secondary',
-            'stringifypkey',
-            'without_auto_increment',
-            'ip_table',
-            'ci_sessions',
-            'migrations_lock',
-        ] as $table) {
+        if ($tables === false) {
+            return;
+        }
+
+        foreach ($tables as $table) {
+            if ($table === $db->DBPrefix . 'migrations') {
+                continue;
+            }
+
             $forge->dropTable($table, true);
         }
     }

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use Config\Database;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -27,51 +28,63 @@ final class MigrationIntegrationTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    private string $migrationFileFrom = SUPPORTPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
-    private string $migrationFileTo   = APPPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
-
     protected function setUp(): void
     {
+        $this->resetServices();
+
         parent::setUp();
 
-        if (! is_file($this->migrationFileFrom)) {
-            $this->fail(clean_path($this->migrationFileFrom) . ' is not found.');
-        }
-
-        if (is_file($this->migrationFileTo)) {
-            @unlink($this->migrationFileTo);
-        }
-
-        copy($this->migrationFileFrom, $this->migrationFileTo);
-
-        $contents = file_get_contents($this->migrationFileTo);
-        $contents = str_replace('namespace Tests\Support\Database\Migrations;', 'namespace App\Database\Migrations;', $contents);
-        file_put_contents($this->migrationFileTo, $contents);
+        service('migrations')->clearHistory();
+        $this->dropTestTables();
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
+        service('migrations')->clearHistory();
+        $this->dropTestTables();
 
-        if (is_file($this->migrationFileTo)) {
-            @unlink($this->migrationFileTo);
-        }
+        $this->resetServices();
+
+        parent::tearDown();
     }
 
     public function testMigrationWithRollbackHasSameNameFormat(): void
     {
-        command('migrate -n App');
+        command('migrate -n Tests\\\\Support');
         $this->assertStringContainsString(
-            '(App) 20160428212500_App\Database\Migrations\Migration_Create_test_tables',
+            '(Tests\Support) 20160428212500_Tests\Support\Database\Migrations\Migration_Create_test_tables',
             $this->getStreamFilterBuffer(),
         );
 
         $this->resetStreamFilterBuffer();
+        $this->resetServices();
 
-        command('migrate:rollback -n App');
+        command('migrate:rollback');
         $this->assertStringContainsString(
-            '(App) 20160428212500_App\Database\Migrations\Migration_Create_test_tables',
+            '(Tests\Support) 20160428212500_Tests\Support\Database\Migrations\Migration_Create_test_tables',
             $this->getStreamFilterBuffer(),
         );
+    }
+
+    private function dropTestTables(): void
+    {
+        $forge = Database::forge();
+
+        foreach ([
+            'user',
+            'job',
+            'misc',
+            'team_members',
+            'type_test',
+            'empty',
+            'secondary',
+            'stringifypkey',
+            'without_auto_increment',
+            'ip_table',
+            'ci_sessions',
+            'migrations_lock',
+        ] as $table) {
+            $forge->dropTable($table, true);
+        }
     }
 }

--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -29,18 +29,36 @@ final class LocalizationFinderTest extends CIUnitTestCase
 
     private static string $locale;
     private static string $languageTestPath;
+    private string $originalLocale;
+
+    /**
+     * @var list<string>
+     */
+    private array $originalSupportedLocales;
 
     protected function setUp(): void
     {
         parent::setUp();
-        self::$locale           = Locale::getDefault();
+
+        $this->originalLocale = Locale::getDefault();
+        Locale::setDefault('en');
+
+        $appConfig                      = config(App::class);
+        $this->originalSupportedLocales = $appConfig->supportedLocales;
+        $appConfig->supportedLocales    = ['en', 'ru', 'de'];
+
+        self::$locale           = 'en';
         self::$languageTestPath = SUPPORTPATH . 'Language' . DIRECTORY_SEPARATOR;
+        $this->clearGeneratedFiles();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
         $this->clearGeneratedFiles();
+        Locale::setDefault($this->originalLocale);
+        config(App::class)->supportedLocales = $this->originalSupportedLocales;
     }
 
     public function testUpdateDefaultLocale(): void

--- a/tests/system/Commands/Translation/LocalizationSyncTest.php
+++ b/tests/system/Commands/Translation/LocalizationSyncTest.php
@@ -32,6 +32,12 @@ final class LocalizationSyncTest extends CIUnitTestCase
 
     private static string $locale;
     private static string $languageTestPath;
+    private string $originalLocale;
+
+    /**
+     * @var list<string>
+     */
+    private array $originalSupportedLocales;
 
     /**
      * @var array<string, array<string,mixed>|string|null>
@@ -56,10 +62,16 @@ final class LocalizationSyncTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        config(App::class)->supportedLocales = ['en', 'ru', 'de'];
+        $this->originalLocale = Locale::getDefault();
+        Locale::setDefault('en');
 
-        self::$locale           = Locale::getDefault();
+        $appConfig                      = config(App::class);
+        $this->originalSupportedLocales = $appConfig->supportedLocales;
+        $appConfig->supportedLocales    = ['en', 'ru', 'de'];
+
+        self::$locale           = 'en';
         self::$languageTestPath = SUPPORTPATH . 'Language/';
+        $this->clearGeneratedFiles();
         $this->makeLanguageFiles();
     }
 
@@ -68,6 +80,8 @@ final class LocalizationSyncTest extends CIUnitTestCase
         parent::tearDown();
 
         $this->clearGeneratedFiles();
+        Locale::setDefault($this->originalLocale);
+        config(App::class)->supportedLocales = $this->originalSupportedLocales;
     }
 
     public function testSyncDefaultLocale(): void
@@ -246,6 +260,9 @@ final class LocalizationSyncTest extends CIUnitTestCase
                 ],
             ];
             TEXT_WRAP;
+
+        @mkdir(self::$languageTestPath . self::$locale, 0777, true);
+        @mkdir(self::$languageTestPath . 'ru', 0777, true);
 
         file_put_contents(self::$languageTestPath . self::$locale . '/Sync.php', $lang);
         file_put_contents(self::$languageTestPath . 'ru/Sync.php', $lang);

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -42,7 +42,7 @@ final class BaseConfigTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->clearLooseEnvironmentOverrides();
+        $this->clearEnvironmentOverrides();
         $this->fixturesFolder = __DIR__ . '/fixtures';
 
         if (! class_exists('SimpleConfig', false)) {
@@ -66,16 +66,19 @@ final class BaseConfigTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        $this->clearLooseEnvironmentOverrides();
+        $this->clearEnvironmentOverrides();
         // This test modifies BaseConfig::$modules, so should reset.
         BaseConfig::reset();
         // This test modifies Services locator, so should reset.
         $this->resetServices();
     }
 
-    private function clearLooseEnvironmentOverrides(): void
+    private function clearEnvironmentOverrides(): void
     {
         foreach ([
+            'different.key',
+            'encryption.driver',
+            'encryption.key',
             'SimpleConfig.QZERO',
             'SimpleConfig.QZEROSTR',
             'SimpleConfig.QEMPTYSTR',

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -78,7 +78,7 @@ final class MetadataTest extends CIUnitTestCase
         $oldPrefix = $this->db->getPrefix();
         $this->db->setPrefix('tmp_');
 
-        Database::forge($this->DBGroup)->dropTable('widgets');
+        Database::forge($this->DBGroup)->dropTable('widgets', true);
 
         $this->db->setPrefix($oldPrefix);
     }
@@ -136,6 +136,24 @@ final class MetadataTest extends CIUnitTestCase
             $this->assertSame(['tmp_widgets'], $tables);
         } finally {
             $this->db->setPrefix($oldPrefix);
+            $this->dropExtraneousTable();
+        }
+    }
+
+    public function testListTablesReturnsListAfterCachedTableIsDropped(): void
+    {
+        try {
+            $this->createExtraneousTable();
+
+            $tables = $this->db->listTables();
+            $this->assertSame(array_values($tables), $tables);
+
+            $this->dropExtraneousTable();
+
+            $tables = $this->db->listTables();
+            $this->assertSame(array_values($tables), $tables);
+            $this->assertNotContains('tmp_widgets', $tables);
+        } finally {
             $this->dropExtraneousTable();
         }
     }

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -78,7 +78,7 @@ final class MetadataTest extends CIUnitTestCase
         $oldPrefix = $this->db->getPrefix();
         $this->db->setPrefix('tmp_');
 
-        Database::forge($this->DBGroup)->dropTable('widgets', true);
+        Database::forge($this->DBGroup)->dropTable('widgets');
 
         $this->db->setPrefix($oldPrefix);
     }
@@ -136,24 +136,6 @@ final class MetadataTest extends CIUnitTestCase
             $this->assertSame(['tmp_widgets'], $tables);
         } finally {
             $this->db->setPrefix($oldPrefix);
-            $this->dropExtraneousTable();
-        }
-    }
-
-    public function testListTablesReturnsListAfterCachedTableIsDropped(): void
-    {
-        try {
-            $this->createExtraneousTable();
-
-            $tables = $this->db->listTables();
-            $this->assertSame(array_values($tables), $tables);
-
-            $this->dropExtraneousTable();
-
-            $tables = $this->db->listTables();
-            $this->assertSame(array_values($tables), $tables);
-            $this->assertNotContains('tmp_widgets', $tables);
-        } finally {
             $this->dropExtraneousTable();
         }
     }

--- a/tests/system/HotReloader/DirectoryHasherTest.php
+++ b/tests/system/HotReloader/DirectoryHasherTest.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HotReloader;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Toolbar;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -24,20 +26,44 @@ use PHPUnit\Framework\Attributes\Group;
 final class DirectoryHasherTest extends CIUnitTestCase
 {
     private DirectoryHasher $hasher;
+    private string $fixtureDirectory;
+    private string $fixturePath;
+    private string $fixturePathAlt;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $suffix                 = str_replace('.', '', uniqid('', true));
+        $this->fixtureDirectory = 'writable/hot-reloader-test-' . $suffix;
+        $fixtureDirectoryAlt    = 'writable/hot-reloader-test-alt-' . $suffix;
+        $this->fixturePath      = ROOTPATH . $this->fixtureDirectory . '/';
+        $this->fixturePathAlt   = ROOTPATH . $fixtureDirectoryAlt . '/';
+
+        $this->createFixtureDirectory($this->fixturePath, 'test');
+        $this->createFixtureDirectory($this->fixturePathAlt, 'test-alt');
+
         $this->hasher = new DirectoryHasher();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeFixtureDirectory($this->fixturePath);
+        $this->removeFixtureDirectory($this->fixturePathAlt);
+
+        parent::tearDown();
     }
 
     public function testHashApp(): void
     {
+        $config                     = new Toolbar();
+        $config->watchedDirectories = [$this->fixtureDirectory];
+        Factories::injectMock('config', Toolbar::class, $config);
+
         $results = $this->hasher->hashApp();
 
         $this->assertIsArray($results);
-        $this->assertArrayHasKey('app', $results);
+        $this->assertArrayHasKey($this->fixtureDirectory, $results);
     }
 
     public function testHashDirectoryInvalid(): void
@@ -50,24 +76,48 @@ final class DirectoryHasherTest extends CIUnitTestCase
 
     public function testUniqueHashes(): void
     {
-        $hash1 = $this->hasher->hashDirectory(APPPATH);
-        $hash2 = $this->hasher->hashDirectory(SYSTEMPATH);
+        $hash1 = $this->hasher->hashDirectory($this->fixturePath);
+        $hash2 = $this->hasher->hashDirectory($this->fixturePathAlt);
 
         $this->assertNotSame($hash1, $hash2);
     }
 
     public function testRepeatableHashes(): void
     {
-        $hash1 = $this->hasher->hashDirectory(APPPATH);
-        $hash2 = $this->hasher->hashDirectory(APPPATH);
+        $hash1 = $this->hasher->hashDirectory($this->fixturePath);
+        $hash2 = $this->hasher->hashDirectory($this->fixturePath);
 
         $this->assertSame($hash1, $hash2);
     }
 
     public function testHash(): void
     {
+        $config                     = new Toolbar();
+        $config->watchedDirectories = [$this->fixtureDirectory];
+        Factories::injectMock('config', Toolbar::class, $config);
+
         $expected = md5(implode('', $this->hasher->hashApp()));
 
         $this->assertSame($expected, $this->hasher->hash());
+    }
+
+    private function createFixtureDirectory(string $path, string $contents): void
+    {
+        if (! is_dir($path)) {
+            mkdir($path, 0777, true);
+        }
+
+        file_put_contents($path . 'index.php', $contents);
+    }
+
+    private function removeFixtureDirectory(string $path): void
+    {
+        if (is_file($path . 'index.php')) {
+            unlink($path . 'index.php');
+        }
+
+        if (is_dir($path)) {
+            rmdir($path);
+        }
     }
 }


### PR DESCRIPTION
**Description**

Related to #9968.

This one took a few rounds: every time the `Commands` suite looked settled, another bit of shared test state quietly raised its hand. The result is a more random-order-safe `Commands` component, plus a few small shared-state hardening fixes that the parallel random component runs exposed along the way.

This enables `Commands` in the random test config and updates the affected tests so they own their setup/cleanup instead of depending on earlier tests running first.

Main changes:

- reset scaffold test CLI state and make generated command/scaffold cleanup reliable between tests
- isolate migration command tests from generated App migrations and leftover tables
- make database command tests seed and select their own expected state
- close/reset shared database connections before deleting SQLite test databases
- restore locale/config state in translation command tests
- reset mocked cache services after cache command tests
- make the `Unsuffixable` support command provide its own template data
- scope `CreateNewChangelogTest` cleanup in `AutoReview` so it no longer runs repository-wide `git restore` / `git clean` while random component jobs are running in parallel

This PR also touches a few areas outside `tests/system/Commands` because the failures were not purely local to one test class:

- `system/Commands/Database/ShowTableInfo.php` now keeps `db:table --show` display IDs sequential even when table arrays have sparse keys
- `system/HotReloader/DirectoryHasher.php` now hashes files in a stable order, which avoids filesystem traversal order differences
- `system/Cache/FactoriesCache/FileVarExportHandler.php` now guards cache writes against concurrent cleanup/recreation races
- `tests/system/HotReloader/DirectoryHasherTest.php` now uses isolated writable fixtures instead of shared app/system directories
- `system/Log/Handlers/FileHandler.php` now treats the final chmod after creating a log file as best-effort, so concurrent log cleanup cannot turn logging into a test/app error

Verified locally:

- repeated random-order `Commands` runs, including failed CI seeds
- `HotReloader`, `Cookie` random-order runs
- `composer phpstan:check`
- `vendor/bin/rector process --dry-run`
- `composer cs`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide