### PR TITLE
feat: add Query Builder lockForUpdate()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -116,6 +116,11 @@ class BaseBuilder
     protected bool $QBLockForUpdate = false;
 
     /**
+     * QB SELECT aggregate helper flag
+     */
+    protected bool $QBSelectUsesAggregate = false;
+
+    /**
      * QB ORDER BY data
      *
      * @var array|string|null
@@ -547,8 +552,9 @@ class BaseBuilder
 
         $sql = $type . '(' . $this->db->protectIdentifiers(trim($select)) . ') AS ' . $this->db->escapeIdentifiers(trim($alias));
 
-        $this->QBSelect[]   = $sql;
-        $this->QBNoEscape[] = null;
+        $this->QBSelect[]            = $sql;
+        $this->QBNoEscape[]          = null;
+        $this->QBSelectUsesAggregate = true;
 
         return $this;
     }
@@ -3254,6 +3260,10 @@ class BaseBuilder
      */
     protected function compileLockForUpdate(): string
     {
+        if ($this->QBLockForUpdate && $this->QBUnion !== []) {
+            throw new DatabaseException('Query Builder does not support lockForUpdate() with union() or unionAll().');
+        }
+
         return $this->QBLockForUpdate ? "\nFOR UPDATE" : '';
     }
 
@@ -3564,18 +3574,19 @@ class BaseBuilder
     protected function resetSelect()
     {
         $this->resetRun([
-            'QBSelect'        => [],
-            'QBJoin'          => [],
-            'QBWhere'         => [],
-            'QBGroupBy'       => [],
-            'QBHaving'        => [],
-            'QBOrderBy'       => [],
-            'QBNoEscape'      => [],
-            'QBDistinct'      => false,
-            'QBLimit'         => false,
-            'QBOffset'        => false,
-            'QBLockForUpdate' => false,
-            'QBUnion'         => [],
+            'QBSelect'              => [],
+            'QBJoin'                => [],
+            'QBWhere'               => [],
+            'QBGroupBy'             => [],
+            'QBHaving'              => [],
+            'QBOrderBy'             => [],
+            'QBNoEscape'            => [],
+            'QBDistinct'            => false,
+            'QBLimit'               => false,
+            'QBOffset'              => false,
+            'QBLockForUpdate'       => false,
+            'QBSelectUsesAggregate' => false,
+            'QBUnion'               => [],
         ]);
 
         if ($this->db instanceof BaseConnection) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -111,6 +111,13 @@ class BaseBuilder
     protected $QBOffset = false;
 
     /**
+     * QB FOR UPDATE flag
+     *
+     * @var bool
+     */
+    protected $QBLockForUpdate = false;
+
+    /**
      * QB ORDER BY data
      *
      * @var array|string|null
@@ -1621,6 +1628,16 @@ class BaseBuilder
     }
 
     /**
+     * Locks the selected rows for update.
+     */
+    public function lockForUpdate(): static
+    {
+        $this->QBLockForUpdate = true;
+
+        return $this;
+    }
+
+    /**
      * Sets the OFFSET value
      *
      * @return $this
@@ -1801,20 +1818,26 @@ class BaseBuilder
         }
 
         // We cannot use a LIMIT when getting the single row COUNT(*) result
-        $limit = $this->QBLimit;
+        $limit         = $this->QBLimit;
+        $lockForUpdate = $this->QBLockForUpdate;
 
-        $this->QBLimit = false;
+        $this->QBLimit         = false;
+        $this->QBLockForUpdate = false;
 
-        if ($this->QBDistinct === true || ! empty($this->QBGroupBy)) {
-            // We need to backup the original SELECT in case DBPrefix is used
-            $select = $this->QBSelect;
-            $sql    = $this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results";
+        try {
+            if ($this->QBDistinct === true || ! empty($this->QBGroupBy)) {
+                // We need to backup the original SELECT in case DBPrefix is used
+                $select = $this->QBSelect;
+                $sql    = $this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results";
 
-            // Restore SELECT part
-            $this->QBSelect = $select;
-            unset($select);
-        } else {
-            $sql = $this->compileSelect($this->countString . $this->db->protectIdentifiers('numrows'));
+                // Restore SELECT part
+                $this->QBSelect = $select;
+                unset($select);
+            } else {
+                $sql = $this->compileSelect($this->countString . $this->db->protectIdentifiers('numrows'));
+            }
+        } finally {
+            $this->QBLockForUpdate = $lockForUpdate;
         }
 
         if ($this->testMode) {
@@ -3223,7 +3246,17 @@ class BaseBuilder
             $sql = $this->_limit($sql . "\n");
         }
 
+        $sql .= $this->compileLockForUpdate();
+
         return $this->unionInjection($sql);
+    }
+
+    /**
+     * Compile the SELECT lock clause.
+     */
+    protected function compileLockForUpdate(): string
+    {
+        return $this->QBLockForUpdate ? "\nFOR UPDATE" : '';
     }
 
     /**
@@ -3533,17 +3566,18 @@ class BaseBuilder
     protected function resetSelect()
     {
         $this->resetRun([
-            'QBSelect'   => [],
-            'QBJoin'     => [],
-            'QBWhere'    => [],
-            'QBGroupBy'  => [],
-            'QBHaving'   => [],
-            'QBOrderBy'  => [],
-            'QBNoEscape' => [],
-            'QBDistinct' => false,
-            'QBLimit'    => false,
-            'QBOffset'   => false,
-            'QBUnion'    => [],
+            'QBSelect'        => [],
+            'QBJoin'          => [],
+            'QBWhere'         => [],
+            'QBGroupBy'       => [],
+            'QBHaving'        => [],
+            'QBOrderBy'       => [],
+            'QBNoEscape'      => [],
+            'QBDistinct'      => false,
+            'QBLimit'         => false,
+            'QBOffset'        => false,
+            'QBLockForUpdate' => false,
+            'QBUnion'         => [],
         ]);
 
         if ($this->db instanceof BaseConnection) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -112,10 +112,8 @@ class BaseBuilder
 
     /**
      * QB FOR UPDATE flag
-     *
-     * @var bool
      */
-    protected $QBLockForUpdate = false;
+    protected bool $QBLockForUpdate = false;
 
     /**
      * QB ORDER BY data

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -59,6 +59,24 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Compile the SELECT lock clause.
+     */
+    protected function compileLockForUpdate(): string
+    {
+        if (! $this->QBLockForUpdate) {
+            return '';
+        }
+
+        foreach ($this->QBFrom as $value) {
+            if (str_starts_with($value, '(SELECT')) {
+                throw new DatabaseException('MySQLi does not support lockForUpdate() with fromSubquery().');
+            }
+        }
+
+        return parent::compileLockForUpdate();
+    }
+
+    /**
      * Generates a platform-specific batch update string from the supplied data
      */
     protected function _updateBatch(string $table, array $keys, array $values): string

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -214,6 +214,18 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Compile the SELECT lock clause.
+     */
+    protected function compileLockForUpdate(): string
+    {
+        if ($this->QBLockForUpdate && ($this->QBLimit !== false || $this->QBOffset)) {
+            throw new DatabaseException('OCI8 does not support lockForUpdate() with limit() or offset().');
+        }
+
+        return parent::compileLockForUpdate();
+    }
+
+    /**
      * Generates a platform-specific batch update string from the supplied data
      */
     protected function _updateBatch(string $table, array $keys, array $values): string

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -218,8 +218,16 @@ class Builder extends BaseBuilder
      */
     protected function compileLockForUpdate(): string
     {
-        if ($this->QBLockForUpdate && ($this->QBLimit !== false || $this->QBOffset)) {
+        if (! $this->QBLockForUpdate) {
+            return '';
+        }
+
+        if ($this->QBLimit !== false || $this->QBOffset) {
             throw new DatabaseException('OCI8 does not support lockForUpdate() with limit() or offset().');
+        }
+
+        if ($this->QBDistinct || $this->QBGroupBy !== [] || $this->QBHaving !== [] || $this->QBSelectUsesAggregate) {
+            throw new DatabaseException('OCI8 does not support lockForUpdate() with distinct(), groupBy(), having(), or aggregate helper selections.');
         }
 
         return parent::compileLockForUpdate();

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -63,6 +63,22 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Compile the SELECT lock clause.
+     */
+    protected function compileLockForUpdate(): string
+    {
+        if (! $this->QBLockForUpdate) {
+            return '';
+        }
+
+        if ($this->QBDistinct || $this->QBGroupBy !== [] || $this->QBHaving !== [] || $this->QBSelectUsesAggregate) {
+            throw new DatabaseException('Postgre does not support lockForUpdate() with distinct(), groupBy(), having(), or aggregate helper selections.');
+        }
+
+        return parent::compileLockForUpdate();
+    }
+
+    /**
      * ORDER BY
      *
      * @param string $direction ASC, DESC or RANDOM

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -703,6 +703,10 @@ class Builder extends BaseBuilder
             throw new DatabaseException('SQLSRV does not support lockForUpdate() without a FROM table.');
         }
 
+        if ($this->QBUnion !== []) {
+            throw new DatabaseException('Query Builder does not support lockForUpdate() with union() or unionAll().');
+        }
+
         foreach ($this->QBFrom as $value) {
             if (str_starts_with($value, '(SELECT')) {
                 throw new DatabaseException('SQLSRV does not support lockForUpdate() on subqueries.');

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -79,10 +79,6 @@ class Builder extends BaseBuilder
 
         foreach ($this->QBFrom as $value) {
             if (str_starts_with($value, '(SELECT')) {
-                if ($this->QBLockForUpdate) {
-                    throw new DatabaseException('SQLSRV does not support lockForUpdate() on subqueries.');
-                }
-
                 $from[] = $value;
 
                 continue;
@@ -699,8 +695,18 @@ class Builder extends BaseBuilder
      */
     protected function compileLockForUpdate(): string
     {
-        if ($this->QBLockForUpdate && $this->QBFrom === []) {
+        if (! $this->QBLockForUpdate) {
+            return '';
+        }
+
+        if ($this->QBFrom === []) {
             throw new DatabaseException('SQLSRV does not support lockForUpdate() without a FROM table.');
+        }
+
+        foreach ($this->QBFrom as $value) {
+            if (str_starts_with($value, '(SELECT')) {
+                throw new DatabaseException('SQLSRV does not support lockForUpdate() on subqueries.');
+            }
         }
 
         return '';

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -33,6 +33,8 @@ use TypeError;
  */
 class Builder extends BaseBuilder
 {
+    private const LOCK_FOR_UPDATE_HINT = ' WITH (UPDLOCK, ROWLOCK)';
+
     /**
      * ORDER BY random keyword
      *
@@ -76,7 +78,17 @@ class Builder extends BaseBuilder
         $from = [];
 
         foreach ($this->QBFrom as $value) {
-            $from[] = str_starts_with($value, '(SELECT') ? $value : $this->getFullName($value);
+            if (str_starts_with($value, '(SELECT')) {
+                if ($this->QBLockForUpdate) {
+                    throw new DatabaseException('SQLSRV does not support lockForUpdate() on subqueries.');
+                }
+
+                $from[] = $value;
+
+                continue;
+            }
+
+            $from[] = $this->getFullName($value) . ($this->QBLockForUpdate ? self::LOCK_FOR_UPDATE_HINT : '');
         }
 
         return implode(', ', $from);
@@ -677,7 +689,21 @@ class Builder extends BaseBuilder
             $sql = $this->_limit($sql . "\n");
         }
 
+        $sql .= $this->compileLockForUpdate();
+
         return $this->unionInjection($sql);
+    }
+
+    /**
+     * Compile the SELECT lock clause.
+     */
+    protected function compileLockForUpdate(): string
+    {
+        if ($this->QBLockForUpdate && $this->QBFrom === []) {
+            throw new DatabaseException('SQLSRV does not support lockForUpdate() without a FROM table.');
+        }
+
+        return '';
     }
 
     /**

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -56,6 +56,18 @@ class Builder extends BaseBuilder
     ];
 
     /**
+     * Compile the SELECT lock clause.
+     */
+    protected function compileLockForUpdate(): string
+    {
+        if ($this->QBLockForUpdate) {
+            throw new DatabaseException('SQLite3 does not support lockForUpdate().');
+        }
+
+        return '';
+    }
+
+    /**
      * Replace statement
      *
      * Generates a platform-specific replace string from the supplied data

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use PHPUnit\Framework\Attributes\Group;
@@ -53,6 +54,34 @@ final class CountTest extends CIUnitTestCase
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id:';
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+    }
+
+    public function testCountAllResultsDoesNotUseLockForUpdate(): void
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+        $builder->testMode();
+
+        $answer = $builder->where('id >', 3)->lockForUpdate()->countAllResults(false);
+
+        $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id:';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSame('SELECT * FROM "jobs" WHERE "id" > 3 FOR UPDATE', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+    }
+
+    public function testCountAllResultsWithSQLSRVDoesNotUseLockForUpdate(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = new SQLSRVBuilder('jobs', $this->db);
+        $builder->testMode();
+
+        $answer = $builder->where('id >', 3)->lockForUpdate()->countAllResults(false);
+
+        $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "test"."dbo"."jobs" WHERE "id" > :id:';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSame('SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) WHERE "id" > 3', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
     }
 
     public function testCountAllResultsWithGroupBy(): void

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\OCI8\Builder as OCI8Builder;
+use CodeIgniter\Database\Postgre\Builder as PostgreBuilder;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Database\SQLite3\Builder as SQLite3Builder;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
@@ -417,6 +418,28 @@ final class SelectTest extends CIUnitTestCase
         $this->assertSame('SELECT * FROM "users"', str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    public function testLockForUpdateThrowsExceptionWithUnion(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Query Builder does not support lockForUpdate() with union() or unionAll().');
+
+        $builder->union(new BaseBuilder('jobs', $this->db))->lockForUpdate()->getCompiledSelect();
+    }
+
+    public function testLockForUpdateThrowsExceptionWithSQLSRVUnion(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = new SQLSRVBuilder('users', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Query Builder does not support lockForUpdate() with union() or unionAll().');
+
+        $builder->union(new SQLSRVBuilder('jobs', $this->db))->lockForUpdate()->getCompiledSelect();
+    }
+
     public function testLockForUpdateWithOCI8(): void
     {
         $builder = new OCI8Builder('users', $this->db);
@@ -434,6 +457,66 @@ final class SelectTest extends CIUnitTestCase
         $this->expectExceptionMessage('OCI8 does not support lockForUpdate() with limit() or offset().');
 
         $builder->limit(1)->lockForUpdate()->getCompiledSelect();
+    }
+
+    #[DataProvider('provideLockForUpdateUnsupportedSelectClauses')]
+    public function testLockForUpdateThrowsExceptionWithOCI8SelectClause(string $clause): void
+    {
+        $builder = new OCI8Builder('users', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('OCI8 does not support lockForUpdate() with distinct(), groupBy(), having(), or aggregate helper selections.');
+
+        $this->applyLockForUpdateUnsupportedClause($builder, $clause)
+            ->lockForUpdate()
+            ->getCompiledSelect();
+    }
+
+    public function testLockForUpdateWithPostgre(): void
+    {
+        $builder = new PostgreBuilder('users', $this->db);
+
+        $expected = 'SELECT * FROM "users" FOR UPDATE';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+    }
+
+    #[DataProvider('provideLockForUpdateUnsupportedSelectClauses')]
+    public function testLockForUpdateThrowsExceptionWithPostgreSelectClause(string $clause): void
+    {
+        $builder = new PostgreBuilder('users', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Postgre does not support lockForUpdate() with distinct(), groupBy(), having(), or aggregate helper selections.');
+
+        $this->applyLockForUpdateUnsupportedClause($builder, $clause)
+            ->lockForUpdate()
+            ->getCompiledSelect();
+    }
+
+    /**
+     * @return iterable<string, list<string>>
+     */
+    public static function provideLockForUpdateUnsupportedSelectClauses(): iterable
+    {
+        yield 'distinct' => ['distinct'];
+
+        yield 'groupBy' => ['groupBy'];
+
+        yield 'having' => ['having'];
+
+        yield 'aggregate selection' => ['aggregate'];
+    }
+
+    private function applyLockForUpdateUnsupportedClause(BaseBuilder $builder, string $clause): BaseBuilder
+    {
+        return match ($clause) {
+            'distinct'  => $builder->distinct(),
+            'groupBy'   => $builder->groupBy('role'),
+            'having'    => $builder->having('COUNT(id) >', 1, false),
+            'aggregate' => $builder->selectCount('id'),
+            default     => throw new DatabaseException('Unsupported clause: ' . $clause),
+        };
     }
 
     public function testLockForUpdateThrowsExceptionOnSQLite3(): void

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\OCI8\Builder as OCI8Builder;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\Database\SQLite3\Builder as SQLite3Builder;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
@@ -379,6 +382,145 @@ final class SelectTest extends CIUnitTestCase
         $expected = 'SELECT * FROM "test"."dbo"."users"';
 
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testLockForUpdate(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->where('id', 1)->orderBy('id', 'ASC')->limit(1)->lockForUpdate();
+
+        $expected = 'SELECT * FROM "users" WHERE "id" = 1 ORDER BY "id" ASC  LIMIT 1 FOR UPDATE';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testLockForUpdatePersistsWhenSelectIsNotReset(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->lockForUpdate();
+
+        $expected = 'SELECT * FROM "users" FOR UPDATE';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+    }
+
+    public function testLockForUpdateResetsWithSelect(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->lockForUpdate();
+
+        $this->assertSame('SELECT * FROM "users" FOR UPDATE', str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame('SELECT * FROM "users"', str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testLockForUpdateWithOCI8(): void
+    {
+        $builder = new OCI8Builder('users', $this->db);
+
+        $expected = 'SELECT * FROM "users" FOR UPDATE';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+    }
+
+    public function testLockForUpdateThrowsExceptionWithOCI8Limit(): void
+    {
+        $builder = new OCI8Builder('users', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('OCI8 does not support lockForUpdate() with limit() or offset().');
+
+        $builder->limit(1)->lockForUpdate()->getCompiledSelect();
+    }
+
+    public function testLockForUpdateThrowsExceptionOnSQLite3(): void
+    {
+        $builder = new SQLite3Builder('users', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('SQLite3 does not support lockForUpdate().');
+
+        $builder->lockForUpdate()->getCompiledSelect();
+    }
+
+    public function testLockForUpdateWithSQLSRV(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = new SQLSRVBuilder('users', $this->db);
+
+        $expected = 'SELECT * FROM "test"."dbo"."users" WITH (UPDLOCK, ROWLOCK)';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+    }
+
+    public function testLockForUpdateWithSQLSRVAlias(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = new SQLSRVBuilder('users u', $this->db);
+
+        $expected = 'SELECT * FROM "test"."dbo"."users" "u" WITH (UPDLOCK, ROWLOCK)';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+    }
+
+    public function testLockForUpdateWithSQLSRVLimit(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = new SQLSRVBuilder('users', $this->db);
+
+        $builder->where('id', 1)->orderBy('id', 'ASC')->limit(1)->lockForUpdate();
+
+        $expected = 'SELECT * FROM "test"."dbo"."users" WITH (UPDLOCK, ROWLOCK) WHERE "id" = 1 ORDER BY "id" ASC  OFFSET 0  ROWS FETCH NEXT 1 ROWS ONLY';
+
+        $this->assertSame($expected, trim(str_replace("\n", ' ', $builder->getCompiledSelect())));
+    }
+
+    public function testLockForUpdateWithSQLSRVJoin(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = new SQLSRVBuilder('jobs', $this->db);
+
+        $builder->join('users u', 'u.id = jobs.id', 'LEFT')->lockForUpdate();
+
+        $expected = 'SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) LEFT JOIN "test"."dbo"."users" "u" ON "u"."id" = "jobs"."id"';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testLockForUpdateThrowsExceptionOnSQLSRVWithoutFromTable(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = (new SQLSRVBuilder('users', $this->db))
+            ->from([], true)
+            ->select('1', false);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('SQLSRV does not support lockForUpdate() without a FROM table.');
+
+        $builder->lockForUpdate()->getCompiledSelect();
+    }
+
+    public function testLockForUpdateThrowsExceptionOnSQLSRVSubquery(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $subquery = new SQLSRVBuilder('users', $this->db);
+        $builder  = new SQLSRVBuilder('jobs', $this->db);
+
+        $builder->fromSubquery($subquery, 'users_1');
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('SQLSRV does not support lockForUpdate() on subqueries.');
+
+        $builder->lockForUpdate()->getCompiledSelect();
     }
 
     public function testSelectSubquery(): void

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\Builder;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\MySQLi\Builder as MySQLiBuilder;
 use CodeIgniter\Database\OCI8\Builder as OCI8Builder;
 use CodeIgniter\Database\Postgre\Builder as PostgreBuilder;
 use CodeIgniter\Database\RawSql;
@@ -438,6 +439,21 @@ final class SelectTest extends CIUnitTestCase
         $this->expectExceptionMessage('Query Builder does not support lockForUpdate() with union() or unionAll().');
 
         $builder->union(new SQLSRVBuilder('jobs', $this->db))->lockForUpdate()->getCompiledSelect();
+    }
+
+    public function testLockForUpdateThrowsExceptionOnMySQLiSubquery(): void
+    {
+        $this->db = new MockConnection(['DBDriver' => 'MySQLi']);
+
+        $subquery = new MySQLiBuilder('users', $this->db);
+        $builder  = new MySQLiBuilder('jobs', $this->db);
+
+        $builder->fromSubquery($subquery, 'users_1');
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('MySQLi does not support lockForUpdate() with fromSubquery().');
+
+        $builder->lockForUpdate()->getCompiledSelect();
     }
 
     public function testLockForUpdateWithOCI8(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -214,6 +214,7 @@ Query Builder
 
 - Added ``whereColumn()`` and ``orWhereColumn()`` to compare one column to another column while protecting identifiers by default. See :ref:`query-builder-where-column`.
 - Added new ``incrementMany()`` and ``decrementMany()`` methods to ``CodeIgniter\Database\BaseBuilder`` for performing bulk increment/decrement operations.
+- Added ``lockForUpdate()`` to add pessimistic write locks to ``SELECT`` queries on supported drivers. See :ref:`query-builder-lock-for-update`.
 
 Forge
 -----

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -753,6 +753,38 @@ As is in ``countAllResult()`` method, this method resets any field values that y
 to ``select()`` as well. If you need to keep them, you can pass ``false`` as the
 first parameter.
 
+.. _query-builder-lock-for-update:
+
+********************
+Pessimistic Locking
+********************
+
+$builder->lockForUpdate()
+-------------------------
+
+.. versionadded:: 4.8.0
+
+Adds a pessimistic write lock to a ``SELECT`` query. This is useful when a row
+must be read and then updated safely while other transactions are prevented
+from modifying it first.
+
+.. literalinclude:: query_builder/124.php
+
+Use this method inside a database transaction. The exact locking behavior is
+determined by the database server and transaction isolation level.
+
+This method is supported by the **MySQLi**, **Postgre**, **OCI8**, and
+**SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``.
+
+SQLSRV uses SQL Server table hints instead of a trailing ``FOR UPDATE`` clause.
+The hint is applied to table references in the ``FROM`` clause; joined tables
+are not hinted. Its exact lock granularity depends on SQL Server's execution
+plan and transaction isolation level. SQLSRV does not support
+``lockForUpdate()`` without a ``FROM`` table or on subqueries.
+
+OCI8 does not support ``lockForUpdate()`` together with ``limit()`` or
+``offset()`` because Oracle does not allow ``FOR UPDATE`` with row limiting.
+
 .. _query-builder-union:
 
 *************
@@ -1428,6 +1460,13 @@ Class Reference
         :rtype:     ``\CodeIgniter\Database\ResultInterface``
 
         Same as ``get()``, but also allows the WHERE to be added directly.
+
+    .. php:method:: lockForUpdate()
+
+        :returns: ``BaseBuilder`` instance (method chaining)
+        :rtype:   ``BaseBuilder``
+
+        Adds a pessimistic write lock to a ``SELECT`` query. See :ref:`query-builder-lock-for-update`.
 
     .. php:method:: select([$select = '*'[, $escape = null]])
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -759,6 +759,9 @@ first parameter.
 Pessimistic Locking
 ********************
 
+Lock for Update
+===============
+
 $builder->lockForUpdate()
 -------------------------
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -780,13 +780,13 @@ This method is supported by the **MySQLi**, **Postgre**, **OCI8**, and
 **SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``. See the
 following notes for OCI8 and SQLSRV driver-specific behavior.
 
-.. note:: SQLSRV uses SQL Server table hints instead of a trailing ``FOR UPDATE``
+.. warning:: SQLSRV uses SQL Server table hints instead of a trailing ``FOR UPDATE``
     clause. The hint is applied to table references in the ``FROM`` clause;
     joined tables are not hinted. Its exact lock granularity depends on SQL
     Server's execution plan and transaction isolation level. SQLSRV does not
     support ``lockForUpdate()`` without a ``FROM`` table or on subqueries.
 
-.. note:: OCI8 does not support ``lockForUpdate()`` together with ``limit()`` or
+.. warning:: OCI8 does not support ``lockForUpdate()`` together with ``limit()`` or
     ``offset()`` because Oracle does not allow ``FOR UPDATE`` with row
     limiting.
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -773,8 +773,10 @@ from modifying it first.
 
 .. literalinclude:: query_builder/124.php
 
-Use this method inside a database transaction. The exact locking behavior is
-determined by the database server and transaction isolation level.
+Use this method inside a database transaction. Without an explicit transaction,
+the lock is typically released when the ``SELECT`` statement finishes. The exact
+locking behavior is determined by the database server and transaction isolation
+level.
 
 This method is supported by the **MySQLi**, **Postgre**, **OCI8**, and
 **SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -777,16 +777,18 @@ Use this method inside a database transaction. The exact locking behavior is
 determined by the database server and transaction isolation level.
 
 This method is supported by the **MySQLi**, **Postgre**, **OCI8**, and
-**SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``.
+**SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``. See the
+following notes for OCI8 and SQLSRV driver-specific behavior.
 
-SQLSRV uses SQL Server table hints instead of a trailing ``FOR UPDATE`` clause.
-The hint is applied to table references in the ``FROM`` clause; joined tables
-are not hinted. Its exact lock granularity depends on SQL Server's execution
-plan and transaction isolation level. SQLSRV does not support
-``lockForUpdate()`` without a ``FROM`` table or on subqueries.
+.. note:: SQLSRV uses SQL Server table hints instead of a trailing ``FOR UPDATE``
+    clause. The hint is applied to table references in the ``FROM`` clause;
+    joined tables are not hinted. Its exact lock granularity depends on SQL
+    Server's execution plan and transaction isolation level. SQLSRV does not
+    support ``lockForUpdate()`` without a ``FROM`` table or on subqueries.
 
-OCI8 does not support ``lockForUpdate()`` together with ``limit()`` or
-``offset()`` because Oracle does not allow ``FOR UPDATE`` with row limiting.
+.. note:: OCI8 does not support ``lockForUpdate()`` together with ``limit()`` or
+    ``offset()`` because Oracle does not allow ``FOR UPDATE`` with row
+    limiting.
 
 .. _query-builder-union:
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -783,6 +783,10 @@ Some databases restrict which query shapes can be used with row locking. When
 CodeIgniter can detect an unsupported combination, it throws a
 ``DatabaseException``. See the following warnings for driver-specific behavior.
 
+.. warning:: MySQLi does not support ``lockForUpdate()`` with ``fromSubquery()``
+    because an outer locking read on a derived table does not lock the underlying
+    rows as users may expect.
+
 .. warning:: Postgre does not support ``lockForUpdate()`` with ``distinct()``,
     ``groupBy()``, ``having()``, or aggregate helper selections such as
     ``selectCount()``.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -777,8 +777,15 @@ Use this method inside a database transaction. The exact locking behavior is
 determined by the database server and transaction isolation level.
 
 This method is supported by the **MySQLi**, **Postgre**, **OCI8**, and
-**SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``. See the
-following notes for OCI8 and SQLSRV driver-specific behavior.
+**SQLSRV** drivers. Unsupported drivers throw a ``DatabaseException``.
+``lockForUpdate()`` is not supported with ``union()`` or ``unionAll()``.
+Some databases restrict which query shapes can be used with row locking. When
+CodeIgniter can detect an unsupported combination, it throws a
+``DatabaseException``. See the following warnings for driver-specific behavior.
+
+.. warning:: Postgre does not support ``lockForUpdate()`` with ``distinct()``,
+    ``groupBy()``, ``having()``, or aggregate helper selections such as
+    ``selectCount()``.
 
 .. warning:: SQLSRV uses SQL Server table hints instead of a trailing ``FOR UPDATE``
     clause. The hint is applied to table references in the ``FROM`` clause;
@@ -786,9 +793,9 @@ following notes for OCI8 and SQLSRV driver-specific behavior.
     Server's execution plan and transaction isolation level. SQLSRV does not
     support ``lockForUpdate()`` without a ``FROM`` table or on subqueries.
 
-.. warning:: OCI8 does not support ``lockForUpdate()`` together with ``limit()`` or
-    ``offset()`` because Oracle does not allow ``FOR UPDATE`` with row
-    limiting.
+.. warning:: OCI8 does not support ``lockForUpdate()`` together with
+    ``limit()``, ``offset()``, ``distinct()``, ``groupBy()``, ``having()``, or
+    aggregate helper selections such as ``selectCount()``.
 
 .. _query-builder-union:
 

--- a/user_guide_src/source/database/query_builder/124.php
+++ b/user_guide_src/source/database/query_builder/124.php
@@ -1,0 +1,11 @@
+<?php
+
+$db->transaction(static function ($db) use ($accountId): void {
+    $account = $db->table('accounts')
+        ->where('id', $accountId)
+        ->lockForUpdate()
+        ->get()
+        ->getRow();
+
+    // Use $account to update the locked row safely...
+});


### PR DESCRIPTION
**Description**

This PR proposes adding `lockForUpdate()` to the Query Builder for pessimistic write locking on supported database drivers.

The goal is to provide a small framework-native API for code that needs to read rows and then safely update them inside the same transaction.

Example:

```php
$db->transaction(static function ($db) use ($accountId): void {
    $account = $db->table('accounts')
        ->where('id', $accountId)
        ->lockForUpdate()
        ->get()
        ->getRow();

    // Use $account to update the locked row safely...
});
```

**Why**

Some application workflows need to prevent concurrent writes around the same row while a transaction is deciding what to do next.

Common examples include:

- checking and updating account balances
- assigning the next pending job or record
- preventing two workers from processing the same row
- updating counters or limited-capacity resources
- safely reading a row before applying a state transition

Without a Query Builder method, users either need raw SQL per database driver or custom helper code around otherwise builder-based queries.

**Behavior**

For drivers that support a trailing `FOR UPDATE` clause, `lockForUpdate()` appends it to the compiled `SELECT`.

SQLSRV is handled separately because SQL Server does not use trailing `FOR UPDATE`. Instead, it applies `WITH (UPDLOCK, ROWLOCK)` table hints to table references in the `FROM` clause.

Supported drivers in this PR:

- MySQLi
- Postgre
- OCI8
- SQLSRV

Unsupported or constrained behavior:

- SQLite3 throws `DatabaseException` because SQLite does not support row-level `SELECT ... FOR UPDATE`.
- OCI8 throws `DatabaseException` when `lockForUpdate()` is combined with `limit()` or `offset()`, because Oracle does not allow `FOR UPDATE` with row limiting.
- SQLSRV throws `DatabaseException` when used without a `FROM` table or on subqueries.
- SQLSRV does not hint joined tables in this implementation because joins are already stored as compiled SQL strings.

**Notes**

This PR intentionally keeps the first implementation narrow. It does not add `sharedLock()`, `skipLocked()`, `nowait()` or SQLSRV joined-table hinting.

Those could be considered later, but this PR focuses only on the most common pessimistic write-lock use case.

**Testing**

Added Query Builder coverage for:

- generic `FOR UPDATE` compilation
- reset and `$reset = false` behavior
- `countAllResults()` suppressing lock clauses
- OCI8 support and limit/offset restriction
- SQLite3 unsupported-driver behavior
- SQLSRV table hints
- SQLSRV aliases, limits, joins, subqueries, and no-`FROM` queries

**Checklist**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide