### PR TITLE
fix: support third-party loggers in toolbar logs collector

### DIFF
--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -92,9 +92,13 @@ class Logs extends BaseCollector
             return $this->data;
         }
 
-        $cache = service('logger')->logCache;
+        $logger = service('logger');
 
-        $this->data = $cache ?? [];
+        if (! property_exists($logger, 'logCache')) {
+            return $this->data;
+        }
+
+        $this->data = $logger->logCache;
 
         return $this->data;
     }

--- a/tests/system/Debug/Toolbar/Collectors/LogsTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/LogsTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\Logger as LoggerConfig;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
+use Psr\Log\AbstractLogger;
+use Stringable;
 
 /**
  * @internal
@@ -67,5 +69,19 @@ final class LogsTest extends CIUnitTestCase
 
         $collector = new Logs();
         $this->assertFalse($collector->isEmpty());
+    }
+
+    public function testEmptyWithThirdPartyLogger(): void
+    {
+        Services::injectMock('logger', new class () extends AbstractLogger {
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+            }
+        });
+
+        $collector = new Logs();
+
+        $this->assertTrue($collector->isEmpty());
+        $this->assertSame(['logs' => []], $collector->display());
     }
 }

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -42,6 +42,7 @@ Bugs Fixed
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
 - **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
+- **Toolbar:** Fixed a bug where the Logs collector raised an undefined property error when using a third-party PSR-3 logger.
 - **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.
 


### PR DESCRIPTION
**Description**
This PR fixes a bug where the Debug Toolbar Logs collector could raise an undefined-property error when the application uses a third-party PSR-3 logger.

Before 4.6.4 `Collectors\Logs::isEmpty()` had buggy behavior, see: #9724

Fixes #10170

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
