### PR TITLE
fix: preserve cached table list shape

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1684,9 +1684,11 @@ abstract class BaseConnection implements ConnectionInterface
     public function listTables(bool $constrainByPrefix = false)
     {
         if (isset($this->dataCache['table_names']) && $this->dataCache['table_names']) {
-            return $constrainByPrefix
+            $tables = $constrainByPrefix
                 ? preg_grep("/^{$this->DBPrefix}/", $this->dataCache['table_names'])
                 : $this->dataCache['table_names'];
+
+            return array_values($tables);
         }
 
         $sql = $this->_listTables($constrainByPrefix);

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -78,7 +78,7 @@ final class MetadataTest extends CIUnitTestCase
         $oldPrefix = $this->db->getPrefix();
         $this->db->setPrefix('tmp_');
 
-        Database::forge($this->DBGroup)->dropTable('widgets');
+        Database::forge($this->DBGroup)->dropTable('widgets', true);
 
         $this->db->setPrefix($oldPrefix);
     }
@@ -136,6 +136,24 @@ final class MetadataTest extends CIUnitTestCase
             $this->assertSame(['tmp_widgets'], $tables);
         } finally {
             $this->db->setPrefix($oldPrefix);
+            $this->dropExtraneousTable();
+        }
+    }
+
+    public function testListTablesReturnsListAfterCachedTableIsDropped(): void
+    {
+        try {
+            $this->createExtraneousTable();
+
+            $tables = $this->db->listTables();
+            $this->assertSame(array_values($tables), $tables);
+
+            $this->dropExtraneousTable();
+
+            $tables = $this->db->listTables();
+            $this->assertSame(array_values($tables), $tables);
+            $this->assertNotContains('tmp_widgets', $tables);
+        } finally {
             $this->dropExtraneousTable();
         }
     }

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -41,8 +41,9 @@ Bugs Fixed
 - **CLI:** Fixed a bug where ``CLI::generateDimensions()`` leaked ``tput`` error output (``tput: No value for $TERM and no -T specified``) to stderr when the ``stty`` fallback was reached and the ``TERM`` environment variable was not set.
 - **Commands:** Fixed a bug in the ``env`` command where passing options only would cause the command to throw a ``TypeError`` instead of showing the current environment.
 - **Common:** Fixed a bug where the ``command()`` helper function did not properly clean up output buffers, which could lead to risky tests when exceptions were thrown.
-- **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
+- **Database:** Fixed a bug where ``BaseConnection::listTables()`` could return a sparse array when using cached table names after a table was dropped.
 - **Database:** Fixed a bug where the PostgreSQL driver's ``increment()`` and ``decrement()`` methods were not working for numeric columns.
+- **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Toolbar:** Fixed a bug where the Logs collector raised an undefined property error when using a third-party PSR-3 logger.
 - **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.


### PR DESCRIPTION
**Description**

Preserves the documented `list<string>` return shape of `BaseConnection::listTables()` when returning cached table names.

When a table is dropped, the cached table-name array may become sparse. Returning `array_values()` from the cached path keeps the result as a proper list, matching the method PHPDoc and the fresh-query path.

This was split out from #10169 after review because it is a small database metadata fix with its own regression coverage.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide