### PR TITLE
refactor: improve UX on `cache:clear`, `cache:info`, and `debugbar:clear` commands

### DIFF
--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -48,12 +48,12 @@ class ClearCache extends AbstractCommand
         $config->handler = $driver;
 
         if (! service('cache', $config)->clean()) {
-            CLI::error('Error occurred while clearing the cache.');
+            CLI::error(sprintf('Error occurred while clearing the cache using the "%s" driver.', $driver));
 
             return EXIT_ERROR;
         }
 
-        CLI::write('Cache cleared.', 'green');
+        CLI::write(sprintf('Cache cleared using the "%s" driver.', $driver), 'green');
 
         return EXIT_SUCCESS;
     }

--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -30,7 +30,10 @@ class InfoCache extends AbstractCommand
         $config = config(Cache::class);
 
         if ($config->handler !== 'file') {
-            CLI::error('This command only supports the file cache handler.');
+            CLI::error(sprintf(
+                'This command only supports the file cache handler. The configured handler is "%s".',
+                $config->handler,
+            ));
 
             return EXIT_ERROR;
         }

--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -27,13 +27,15 @@ class ClearDebugbar extends AbstractCommand
     {
         helper('filesystem');
 
+        $path = clean_path(WRITEPATH . 'debugbar');
+
         if (! delete_files(WRITEPATH . 'debugbar', htdocs: true)) {
-            CLI::error('Error deleting the debugbar JSON files.');
+            CLI::error(sprintf('Error deleting the debugbar JSON files in "%s".', $path));
 
             return EXIT_ERROR;
         }
 
-        CLI::write('Debugbar cleared.', 'green');
+        CLI::write(sprintf('Cleared debugbar JSON files in "%s".', $path), 'green');
 
         return EXIT_SUCCESS;
     }

--- a/tests/system/Commands/Cache/ClearCacheTest.php
+++ b/tests/system/Commands/Cache/ClearCacheTest.php
@@ -66,7 +66,10 @@ final class ClearCacheTest extends CIUnitTestCase
         command('cache:clear');
 
         $this->assertNull(cache('foo'));
-        $this->assertStringContainsString('Cache cleared.', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString(
+            sprintf('Cache cleared using the "%s" driver.', config('Cache')->handler),
+            $this->getStreamFilterBuffer(),
+        );
     }
 
     public function testClearCacheFails(): void
@@ -82,7 +85,7 @@ final class ClearCacheTest extends CIUnitTestCase
         command('cache:clear');
 
         $this->assertSame(
-            "\nError occurred while clearing the cache.\n",
+            sprintf("\nError occurred while clearing the cache using the \"%s\" driver.\n", config('Cache')->handler),
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }

--- a/tests/system/Commands/Cache/InfoCacheTest.php
+++ b/tests/system/Commands/Cache/InfoCacheTest.php
@@ -60,7 +60,7 @@ final class InfoCacheTest extends CIUnitTestCase
         $this->assertSame(
             <<<'EOT'
 
-                This command only supports the file cache handler.
+                This command only supports the file cache handler. The configured handler is "redis".
 
                 EOT,
             $this->getUndecoratedBuffer(),

--- a/tests/system/Commands/Housekeeping/ClearDebugbarTest.php
+++ b/tests/system/Commands/Housekeeping/ClearDebugbarTest.php
@@ -75,7 +75,7 @@ final class ClearDebugbarTest extends CIUnitTestCase
         $this->assertFileDoesNotExist(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
         $this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . 'index.html');
         $this->assertSame(
-            "\nDebugbar cleared.\n",
+            sprintf("\nCleared debugbar JSON files in \"%s\".\n", clean_path(WRITEPATH . 'debugbar')),
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }
@@ -95,7 +95,7 @@ final class ClearDebugbarTest extends CIUnitTestCase
 
         $this->assertFileExists($path);
         $this->assertSame(
-            "\nError deleting the debugbar JSON files.\n",
+            sprintf("\nError deleting the debugbar JSON files in \"%s\".\n", clean_path(WRITEPATH . 'debugbar')),
             preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()),
         );
     }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -30,6 +30,7 @@ Behavior Changes
 - **Commands:** The ``filter:check`` command now requires the HTTP method argument to be uppercase (e.g., ``spark filter:check GET /`` instead of ``spark filter:check get /``).
 - **Commands:** Several built-in commands have been migrated from ``BaseCommand`` to the modern ``AbstractCommand`` style. Applications that extend a built-in command to override
   behaviour may need to re-implement against the modern API (``configure()`` + ``execute()`` and the ``#[Command]`` attribute) once the class it extends is migrated, or, preferably, compose instead of extending. Invocations on the command line are unaffected.
+- **Commands:** The success and error messages from ``debugbar:clear``, ``cache:clear``, and ``cache:info`` now include the affected path or cache driver/handler so the user can see which resource was acted on (or rejected). Scripts asserting on the prior literal text will need to be updated.
 - **Database:** The Postgre driver's ``$db->error()['code']`` previously always returned ``''``. It now returns the 5-character SQLSTATE string for query and transaction failures (e.g., ``'42P01'``), or ``'08006'`` for connection-level failures. Code that relied on ``$db->error()['code'] === ''`` will need updating.
 - **Filters:** HTTP method matching for method-based filters is now case-sensitive. The keys in ``Config\Filters::$methods`` must exactly match the request method
   (e.g., ``GET``, ``POST``). Lowercase method names (e.g., ``post``) will no longer match.


### PR DESCRIPTION
**Description**

Aligns the success/error messages of three migrated commands with the existing `key:rotate` / `logs:clear` UX so the user sees *what* was acted on (or rejected) rather than a generic line.

- `debugbar:clear` — names the path:
  - `Cleared debugbar JSON files in "ROOTPATH/writable/debugbar".`
  - `Error deleting the debugbar JSON files in "ROOTPATH/writable/debugbar".`
- `cache:clear` — names the driver:
  - `Cache cleared using the "file" driver.`
  - `Error occurred while clearing the cache using the "file" driver.`
- `cache:info` — names the configured handler so the user sees what's wrong without re-checking config:
  - `This command only supports the file cache handler. The configured handler is "redis".`

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conform to PSR-12 coding style
