### PR TITLE
fix: restore deep dot-notation traversal in `Language::getLine()`

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -134,7 +134,7 @@ class Language
     }
 
     /**
-     * @return list<string>|string|null
+     * @return array<array-key, mixed>|string|null
      */
     protected function getTranslationOutput(string $locale, string $file, string $parsedLine)
     {
@@ -160,7 +160,7 @@ class Language
                 }
             }
 
-            if ($output !== null && ! is_array($output)) {
+            if ($output !== null) {
                 return $output;
             }
         }

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -381,6 +381,19 @@ final class LanguageTest extends CIUnitTestCase
         $this->assertSame('e', $lang->getLine('Nested.a.b.c.d'));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/10187
+     */
+    public function testLanguageNestedArrayDefinitionReturnsIntermediateArrays(): void
+    {
+        $lang = new SecondMockLanguage('en');
+        $lang->loadem('Nested', 'en');
+
+        $this->assertSame(['b' => ['c' => ['d' => 'e']]], $lang->getLine('Nested.a'));
+        $this->assertSame(['c' => ['d' => 'e']], $lang->getLine('Nested.a.b'));
+        $this->assertSame(['d' => 'e'], $lang->getLine('Nested.a.b.c'));
+    }
+
     public function testLanguageKeySeparatedByDot(): void
     {
         $lang = new SecondMockLanguage('en');

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -46,6 +46,7 @@ Bugs Fixed
 - **Database:** Fixed a bug where the PostgreSQL driver's ``increment()`` and ``decrement()`` methods were not working for numeric columns.
 - **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
+- **Language:** Fixed a bug where ``Language::getLine()`` returned the literal dot-notation key instead of the nested array value when the requested key resolved to an intermediate array three or more levels deep.
 - **Toolbar:** Fixed a bug where the Logs collector raised an undefined property error when using a third-party PSR-3 logger.
 - **Time:** Fixed a bug where ``Time::createFromTimestamp()`` could fail for microsecond timestamps when ``LC_NUMERIC`` used a comma decimal separator.
 - **Validation:** Fixed a bug where ``Validation::getValidated()`` dropped fields whose validated value was explicitly ``null``.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Fixes #10187 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
