### PR TITLE
fix: recognize off zlib output compression value

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -25,7 +25,9 @@ use CodeIgniter\HotReloader\HotReloader;
 
 Events::on('pre_system', static function (): void {
     if (ENVIRONMENT !== 'testing') {
-        if (ini_get('zlib.output_compression')) {
+        $value = ini_get('zlib.output_compression');
+
+        if (filter_var($value, FILTER_VALIDATE_BOOLEAN) || (int) $value > 0) {
             throw FrameworkException::forEnabledZlibOutputCompression();
         }
 

--- a/user_guide_src/source/changelogs/v4.7.3.rst
+++ b/user_guide_src/source/changelogs/v4.7.3.rst
@@ -45,6 +45,7 @@ Bugs Fixed
 - **Database:** Fixed a bug where ``BaseConnection::listTables()`` could return a sparse array when using cached table names after a table was dropped.
 - **Database:** Fixed a bug where the PostgreSQL driver's ``increment()`` and ``decrement()`` methods were not working for numeric columns.
 - **Database:** Fixed a bug where the SQLSRV driver's decrement method was adding instead of subtracting the decrement value when ``$castTextToInt`` was false.
+- **Config:** Fixed a bug where the app starter's ``zlib.output_compression`` guard rejected the valid disabled value ``Off``.
 - **Entity:** Fixed a bug where ``Entity::normalizeValue()`` did not handle ``UnitEnum`` before checking for ``toArray()``, causing enums implementing ``toArray()`` to be incorrectly normalized as generic objects instead of enums.
 - **Kint:** Fixed a bug where stale Content Security Policy nonces were reused in worker mode, causing browser CSP violations for Debug Toolbar assets.
 - **Language:** Fixed a bug where ``Language::getLine()`` returned the literal dot-notation key instead of the nested array value when the requested key resolved to an intermediate array three or more levels deep.


### PR DESCRIPTION
**Description**

Fixes #10192

This PR updates the app starter’s `zlib.output_compression` guard to recognize valid disabled ini values. The previous guard used a loose truthiness check:

```php
if (ini_get('zlib.output_compression')) {
    throw FrameworkException::forEnabledZlibOutputCompression();
}
```

This can reject valid disabled values such as `"Off"` because PHP treats non-empty strings as truthy.

The guard now allows disabled values:

```php
'', '0', 'off'
```

and still rejects enabled values. This keeps the output-buffer protection in place while avoiding false failures when PHP reports `zlib.output_compression` as `"Off"`.

The 4.7.3 changelog is updated.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide