### PR TITLE
refactor: form request

### DIFF
--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -178,7 +178,7 @@ abstract class FormRequest
      *
      * @return array<string, mixed>
      */
-    public function validated(): array
+    public function getValidated(): array
     {
         return $this->validatedData;
     }
@@ -186,39 +186,9 @@ abstract class FormRequest
     /**
      * Returns the validated data as a typed input object.
      */
-    public function validatedInput(): ValidatedInput
+    public function getValidatedInput(): ValidatedInput
     {
         return service('inputdatafactory')->createValidated($this->validatedData);
-    }
-
-    /**
-     * Returns a single validated field value by name, or the default value
-     * if the field is not present in the validated data.
-     *
-     * Supports dot-array syntax for nested validated data.
-     */
-    public function getValidated(string $key, mixed $default = null): mixed
-    {
-        helper('array');
-
-        if (! dot_array_has($key, $this->validatedData)) {
-            return $default;
-        }
-
-        return dot_array_search($key, $this->validatedData);
-    }
-
-    /**
-     * Returns true when the named field exists in the validated data, even if
-     * its value is null.
-     *
-     * Supports dot-array syntax for nested validated data.
-     */
-    public function hasValidated(string $key): bool
-    {
-        helper('array');
-
-        return dot_array_has($key, $this->validatedData);
     }
 
     /**

--- a/tests/_support/Controllers/FormRequestController.php
+++ b/tests/_support/Controllers/FormRequestController.php
@@ -28,7 +28,7 @@ class FormRequestController extends Controller
      */
     public function index(string $id, ValidPostFormRequest $request, string $format = 'json'): string
     {
-        return json_encode(['id' => $id, 'format' => $format, 'data' => $request->validated()]);
+        return json_encode(['id' => $id, 'format' => $format, 'data' => $request->getValidated()]);
     }
 
     /**
@@ -36,7 +36,7 @@ class FormRequestController extends Controller
      */
     public function store(ValidPostFormRequest $request): string
     {
-        return json_encode($request->validated());
+        return json_encode($request->getValidated());
     }
 
     /**
@@ -44,7 +44,7 @@ class FormRequestController extends Controller
      */
     public function update(string $id, ValidPostFormRequest $request): string
     {
-        return json_encode(['id' => $id, 'data' => $request->validated()]);
+        return json_encode(['id' => $id, 'data' => $request->getValidated()]);
     }
 
     /**
@@ -61,7 +61,7 @@ class FormRequestController extends Controller
      */
     public function search(ValidPostFormRequest $request, string ...$tags): string
     {
-        return json_encode(['tags' => $tags, 'data' => $request->validated()]);
+        return json_encode(['tags' => $tags, 'data' => $request->getValidated()]);
     }
 
     /**

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -146,11 +146,11 @@ final class FormRequestTest extends CIUnitTestCase
         };
     }
 
-    public function testValidatedReturnsEmptyArrayBeforeResolution(): void
+    public function testGetValidatedReturnsEmptyArrayBeforeResolution(): void
     {
         $formRequest = $this->makeFormRequest($this->makeRequest());
 
-        $this->assertSame([], $formRequest->validated());
+        $this->assertSame([], $formRequest->getValidated());
     }
 
     // -------------------------------------------------------------------------
@@ -167,11 +167,11 @@ final class FormRequestTest extends CIUnitTestCase
 
         $this->assertSame(
             ['title' => 'Hello World', 'body' => 'Some body text'],
-            $formRequest->validated(),
+            $formRequest->getValidated(),
         );
     }
 
-    public function testValidatedReturnsOnlyFieldsCoveredByRules(): void
+    public function testGetValidatedReturnsOnlyFieldsCoveredByRules(): void
     {
         service('superglobals')->setPost('title', 'Hello World');
         service('superglobals')->setPost('body', 'Some body text');
@@ -180,81 +180,14 @@ final class FormRequestTest extends CIUnitTestCase
         $formRequest = $this->makeFormRequest($this->makeRequest());
         $formRequest->resolveRequest();
 
-        $validated = $formRequest->validated();
+        $validated = $formRequest->getValidated();
 
         $this->assertArrayHasKey('title', $validated);
         $this->assertArrayHasKey('body', $validated);
         $this->assertArrayNotHasKey('extra_field', $validated);
     }
 
-    // -------------------------------------------------------------------------
-    // Explicit access to validated fields
-    // -------------------------------------------------------------------------
-
-    public function testGetValidatedReturnsValidatedFieldValue(): void
-    {
-        service('superglobals')->setPost('title', 'Hello World');
-        service('superglobals')->setPost('body', 'Some body text');
-
-        $formRequest = new ValidPostFormRequest($this->makeRequest());
-        $formRequest->resolveRequest();
-
-        $this->assertSame('Hello World', $formRequest->getValidated('title'));
-        $this->assertSame('Some body text', $formRequest->getValidated('body'));
-    }
-
-    public function testGetValidatedReturnsNullForMissingField(): void
-    {
-        service('superglobals')->setPost('title', 'Hello World');
-        service('superglobals')->setPost('body', 'Some body text');
-
-        $formRequest = new ValidPostFormRequest($this->makeRequest());
-        $formRequest->resolveRequest();
-
-        $this->assertNull($formRequest->getValidated('nonexistent'));
-    }
-
-    public function testGetValidatedReturnsDefaultForMissingField(): void
-    {
-        service('superglobals')->setPost('title', 'Hello World');
-        service('superglobals')->setPost('body', 'Some body text');
-
-        $formRequest = new ValidPostFormRequest($this->makeRequest());
-        $formRequest->resolveRequest();
-
-        $this->assertSame('fallback', $formRequest->getValidated('nonexistent', 'fallback'));
-    }
-
-    public function testGetValidatedReturnsNullBeforeValidationRuns(): void
-    {
-        $formRequest = new ValidPostFormRequest($this->makeRequest());
-
-        $this->assertNull($formRequest->getValidated('title'));
-    }
-
-    public function testHasValidatedReturnsTrueForValidatedField(): void
-    {
-        service('superglobals')->setPost('title', 'Hello World');
-        service('superglobals')->setPost('body', 'Some body text');
-
-        $formRequest = new ValidPostFormRequest($this->makeRequest());
-        $formRequest->resolveRequest();
-
-        $this->assertTrue($formRequest->hasValidated('title'));
-    }
-
-    public function testHasValidatedReturnsFalseForMissingField(): void
-    {
-        service('superglobals')->setPost('title', 'Hello World');
-        service('superglobals')->setPost('body', 'Some body text');
-
-        $formRequest = new ValidPostFormRequest($this->makeRequest());
-        $formRequest->resolveRequest();
-
-        $this->assertFalse($formRequest->hasValidated('nonexistent'));
-    }
-
-    public function testGetValidatedAndHasValidatedSupportDotSyntax(): void
+    public function testGetValidatedReturnsNestedValidatedData(): void
     {
         service('superglobals')->setPost('post', [
             'title' => 'Hello World',
@@ -275,12 +208,20 @@ final class FormRequestTest extends CIUnitTestCase
 
         $formRequest->resolveRequest();
 
-        $this->assertSame('Hello World', $formRequest->getValidated('post.title'));
-        $this->assertSame('hello-world', $formRequest->getValidated('post.meta.slug'));
-        $this->assertTrue($formRequest->hasValidated('post.meta.slug'));
+        $this->assertSame(
+            [
+                'post' => [
+                    'title' => 'Hello World',
+                    'meta'  => [
+                        'slug' => 'hello-world',
+                    ],
+                ],
+            ],
+            $formRequest->getValidated(),
+        );
     }
 
-    public function testHasValidatedReturnsTrueForNullValidatedField(): void
+    public function testGetValidatedReturnsNullValidatedField(): void
     {
         service('superglobals')->setServer('CONTENT_TYPE', 'application/json');
 
@@ -293,13 +234,10 @@ final class FormRequestTest extends CIUnitTestCase
 
         $formRequest->resolveRequest();
 
-        $this->assertSame(['note' => null], $formRequest->validated());
-        $this->assertNull($formRequest->getValidated('note'));
-        $this->assertNull($formRequest->getValidated('note', 'fallback'));
-        $this->assertTrue($formRequest->hasValidated('note'));
+        $this->assertSame(['note' => null], $formRequest->getValidated());
     }
 
-    public function testValidatedInputReturnsValidatedInputObject(): void
+    public function testGetValidatedInputReturnsValidatedInputObject(): void
     {
         service('superglobals')->setPost('title', 'Hello World');
         service('superglobals')->setPost('body', 'Some body text');
@@ -307,7 +245,7 @@ final class FormRequestTest extends CIUnitTestCase
         $formRequest = new ValidPostFormRequest($this->makeRequest());
         $formRequest->resolveRequest();
 
-        $input = $formRequest->validatedInput();
+        $input = $formRequest->getValidatedInput();
 
         $this->assertInstanceOf(ValidatedInput::class, $input);
         $this->assertSame('Hello World', $input->get('title'));
@@ -343,7 +281,7 @@ final class FormRequestTest extends CIUnitTestCase
         $this->assertNotInstanceOf(ResponseInterface::class, $formRequest->resolveRequest());
 
         $this->assertTrue($formRequest::$prepareCalled);
-        $this->assertSame('Hi extended', $formRequest->validated()['title']);
+        $this->assertSame('Hi extended', $formRequest->getValidated()['title']);
     }
 
     // -------------------------------------------------------------------------
@@ -499,7 +437,7 @@ final class FormRequestTest extends CIUnitTestCase
 
         $this->assertNotInstanceOf(ResponseInterface::class, $formRequest->resolveRequest());
 
-        $this->assertSame('Injected Title', $formRequest->validated()['title']);
+        $this->assertSame('Injected Title', $formRequest->getValidated()['title']);
     }
 
     public function testCustomFailedValidationIsRespected(): void
@@ -708,7 +646,7 @@ final class FormRequestTest extends CIUnitTestCase
 
         $routes = service('routes');
         $routes->setAutoRoute(false);
-        $routes->add('closure/(:segment)', static fn (string $id, ValidPostFormRequest $request): string => json_encode(['id' => $id, 'data' => $request->validated()]));
+        $routes->add('closure/(:segment)', static fn (string $id, ValidPostFormRequest $request): string => json_encode(['id' => $id, 'data' => $request->getValidated()]));
 
         $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
@@ -781,7 +719,7 @@ final class FormRequestTest extends CIUnitTestCase
     }
 
     // -------------------------------------------------------------------------
-    // Integration: validated() only returns fields declared in rules()
+    // Integration: getValidated() only returns fields declared in rules()
     // -------------------------------------------------------------------------
 
     #[RunInSeparateProcess]

--- a/user_guide_src/source/incoming/form_requests.rst
+++ b/user_guide_src/source/incoming/form_requests.rst
@@ -49,16 +49,16 @@ JSON/AJAX requests - the method body is never reached.
 Accessing Validated Data
 ************************
 
-``validated()`` returns an array containing only the fields that were declared
+``getValidated()`` returns an array containing only the fields that were declared
 in ``rules()``. Fields submitted by the client that are not covered by a rule
 are silently discarded, protecting against mass-assignment.
 
 .. literalinclude:: form_requests/009.php
    :lines: 2-
 
-Use ``getValidated()`` to read a single validated field and ``hasValidated()``
-to check whether a validated key exists, including keys whose value is
-``null``. Both methods support dot-array syntax for nested validated data:
+Use ``getValidatedInput()`` when you want to read a single validated field or
+check whether a validated key exists, including keys whose value is ``null``.
+The input object supports dot-array syntax for nested validated data:
 
 .. literalinclude:: form_requests/014.php
    :lines: 2-
@@ -66,9 +66,9 @@ to check whether a validated key exists, including keys whose value is
 Typed Validated Input
 =====================
 
-``validatedInput()`` returns the same validated data as a typed input object.
-This keeps the array-based APIs unchanged while making common controller values
-easier to read after validation has succeeded.
+``getValidatedInput()`` returns the same validated data as a typed input object.
+This complements ``getValidated()`` by making common controller values easier
+to read after validation has succeeded.
 
 After the FormRequest has been validated, read the successful values in the
 controller:
@@ -83,7 +83,7 @@ for the full behavior of the typed input methods.
 Accessing Other Request Data
 ============================
 
-For anything not covered by ``validated()`` - uploaded files, request headers,
+For anything not covered by ``getValidated()`` - uploaded files, request headers,
 the client IP address, raw input, and so on - use ``$this->request`` as usual.
 It is the same :doc:`IncomingRequest </incoming/incomingrequest>` instance that
 the FormRequest uses internally:
@@ -171,7 +171,7 @@ normalized phone numbers, or trimmed strings.
    :lines: 2-
 
 .. note:: ``old()`` returns the original submitted input, not the normalized
-    values. Use ``validated()`` to access the processed data after a successful
+    values. Use ``getValidated()`` to access the processed data after a successful
     request. If you need ``old()`` to reflect normalized values, see
     :ref:`form-request-flash-normalized`.
 
@@ -245,8 +245,8 @@ whose type extends ``FormRequest``:
    rules are applied.
 #. ``run()`` executes the validation rules. If it fails, ``failedValidation()``
    is called, and its response is returned to the client.
-#. The validated data is stored internally and available via ``validated()``,
-   ``validatedInput()``, ``getValidated()``, and ``hasValidated()``.
+#. The validated data is stored internally and available via ``getValidated()``
+   and ``getValidatedInput()``.
 #. The resolved FormRequest object is injected into the controller method or
    closure.
 

--- a/user_guide_src/source/incoming/form_requests/002.php
+++ b/user_guide_src/source/incoming/form_requests/002.php
@@ -8,8 +8,8 @@ class Posts extends BaseController
 {
     public function store(StorePostRequest $request): string
     {
-        // $request->validated() returns only the fields declared in rules().
-        $data = $request->validated();
+        // $request->getValidated() returns only the fields declared in rules().
+        $data = $request->getValidated();
 
         // save to database
 

--- a/user_guide_src/source/incoming/form_requests/003.php
+++ b/user_guide_src/source/incoming/form_requests/003.php
@@ -9,7 +9,7 @@ class Posts extends BaseController
     // Route parameters come first; FormRequest follows.
     public function update(int $id, UpdatePostRequest $request): string
     {
-        $data = $request->validated();
+        $data = $request->getValidated();
 
         // update post $id with $data
 

--- a/user_guide_src/source/incoming/form_requests/009.php
+++ b/user_guide_src/source/incoming/form_requests/009.php
@@ -1,4 +1,4 @@
 <?php
 
-$data = $request->validated();
+$data = $request->getValidated();
 // ['title' => 'My post title', 'body' => 'Body text']

--- a/user_guide_src/source/incoming/form_requests/010.php
+++ b/user_guide_src/source/incoming/form_requests/010.php
@@ -8,7 +8,7 @@ class Posts extends BaseController
 {
     public function store(StorePostRequest $request): string
     {
-        $data  = $request->validated();
+        $data  = $request->getValidated();
         $files = $this->request->getFiles();
 
         // ...

--- a/user_guide_src/source/incoming/form_requests/011.php
+++ b/user_guide_src/source/incoming/form_requests/011.php
@@ -7,7 +7,7 @@ use App\Requests\UpdatePostRequest;
 
 // FormRequest only - no route parameters.
 $routes->post('posts', static function (StorePostRequest $request): string {
-    $data = $request->validated();
+    $data = $request->getValidated();
 
     // save to database
 
@@ -16,7 +16,7 @@ $routes->post('posts', static function (StorePostRequest $request): string {
 
 // Route parameter before a FormRequest - same convention as controller methods.
 $routes->post('posts/(:num)', static function (int $id, UpdatePostRequest $request): string {
-    $data = $request->validated();
+    $data = $request->getValidated();
 
     // update post $id with $data
 

--- a/user_guide_src/source/incoming/form_requests/012.php
+++ b/user_guide_src/source/incoming/form_requests/012.php
@@ -28,7 +28,7 @@ class Posts extends BaseController
 
     private function update(UpdatePostRequest $request, string $id): string
     {
-        $data = $request->validated();
+        $data = $request->getValidated();
 
         // update post $id with $data
 

--- a/user_guide_src/source/incoming/form_requests/014.php
+++ b/user_guide_src/source/incoming/form_requests/014.php
@@ -1,8 +1,10 @@
 <?php
 
-$title = $request->getValidated('title');
-$slug  = $request->getValidated('post.meta.slug', 'draft');
+$input = $request->getValidatedInput();
 
-if ($request->hasValidated('note')) {
+$title = $input->get('title');
+$slug  = $input->get('post.meta.slug', 'draft');
+
+if ($input->has('note')) {
     // 'note' was validated, even if its value is null
 }

--- a/user_guide_src/source/incoming/form_requests/015.php
+++ b/user_guide_src/source/incoming/form_requests/015.php
@@ -2,7 +2,7 @@
 
 use App\Enums\PostStatus;
 
-$input = $request->validatedInput();
+$input = $request->getValidatedInput();
 
 $page        = $input->integer('page', 1);
 $rating      = $input->float('rating', 0.0);


### PR DESCRIPTION
**Description**
The main reason for this PR is to align `FormRequest` with the existing `Validation` API by using `getValidated()` and `getValidatedInput()` methods. It also removes the Individual field access, which is still available through `getValidatedInput()->get()` and `getValidatedInput()->has()`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
