### PR TITLE
fix: sync $_REQUEST after modifying $_GET in SiteURIFactory

### DIFF
--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -173,6 +173,9 @@ final readonly class SiteURIFactory
         parse_str($this->superglobals->server('QUERY_STRING'), $get);
         $this->superglobals->setGetArray($get);
 
+        // Sync $_REQUEST so that getVar() works correctly
+        $this->superglobals->syncRequest();
+
         return URI::removeDotSegments($path);
     }
 
@@ -204,6 +207,9 @@ final readonly class SiteURIFactory
         // Update our global GET for values likely to have been changed
         parse_str($this->superglobals->server('QUERY_STRING'), $get);
         $this->superglobals->setGetArray($get);
+
+        // Sync $_REQUEST so that getVar() works correctly
+        $this->superglobals->syncRequest();
 
         return URI::removeDotSegments($path);
     }

--- a/system/Superglobals.php
+++ b/system/Superglobals.php
@@ -456,4 +456,34 @@ final class Superglobals
             ),
         };
     }
+
+    /**
+     * Rebuilds $_REQUEST from $_GET, $_POST, and $_COOKIE according to PHP's
+     * request_order / variables_order ini setting.
+     *
+     * This is necessary when superglobals like $_GET are modified after the
+     * initial request population, since PHP does not automatically keep
+     * $_REQUEST in sync.
+     *
+     * @see https://www.php.net/manual/en/ini.core.php#ini.request-order
+     */
+    public function syncRequest(): self
+    {
+        $requestOrder = ini_get('request_order') ?: ini_get('variables_order');
+
+        $this->request = [];
+
+        foreach (str_split($requestOrder) as $type) {
+            match ($type) {
+                'G'     => $this->request = array_replace($this->request, $this->get),
+                'P'     => $this->request = array_replace($this->request, $this->post),
+                'C'     => $this->request = array_replace($this->request, $this->cookie),
+                default => null,
+            };
+        }
+
+        $_REQUEST = $this->request;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## Description

Fixes #9872 - getVar() behaves inconsistently with GET parameters

## Problem

When SiteURIFactory modifies $_GET via setGetArray() during request URI parsing, it does not update $_REQUEST. Since IncomingRequest::getVar() reads from $_REQUEST, validation methods like $validator->withRequest() receive stale data.

## Solution

1. Add Superglobals::syncRequest() method that rebuilds $_REQUEST from $_GET, $_POST, and $_COOKIE respecting PHP request_order
2. Call syncRequest() in SiteURIFactory after each setGetArray() call

## Changes
- system/Superglobals.php: Add syncRequest() method
- system/HTTP/SiteURIFactory.php: Call syncRequest() after setGetArray()

## Testing
- All existing tests pass (no regressions)
- Manual verification confirms $_REQUEST syncs correctly

Ref: https://github.com/codeigniter4/CodeIgniter4/issues/9872
Closes #9872