### PR TITLE
fix: normalize directory separators in route file paths for Windows

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -297,7 +297,7 @@ class RouteCollection implements RouteCollectionInterface
         // Normalize the path string in routeFiles array.
         foreach ($this->routeFiles as $routeKey => $routesFile) {
             $realpath                    = realpath($routesFile);
-            $this->routeFiles[$routeKey] = ($realpath === false) ? $routesFile : $realpath;
+            $this->routeFiles[$routeKey] = ($realpath === false) ? $routesFile : str_replace('\\', '/', $realpath);
         }
     }
 
@@ -316,7 +316,7 @@ class RouteCollection implements RouteCollectionInterface
 
         // Normalize the path string in routesFile
         $realpath   = realpath($routesFile);
-        $routesFile = ($realpath === false) ? $routesFile : $realpath;
+        $routesFile = ($realpath === false) ? $routesFile : str_replace('\\', '/', $realpath);
 
         // Include the passed in routesFile if it doesn't exist.
         // Only keeping that around for BC purposes for now.


### PR DESCRIPTION
## Description

Fixes #7474 - [4.4] Failed tests on Windows

## Problem

On Windows, `realpath()` returns paths with backslashes (e.g., `D:\path\to\file.php`) while `routeFiles` paths use forward slashes (`App/Config/Routes.php`). This caused `in_array()` comparison in `loadRoutes()` to fail, preventing route files from being recognized as already loaded.

This led to tests like `testRun404Override` failing because the 404 override routes from test support files weren't properly recognized.

## Solution

Normalize all `realpath()` results in RouteCollection to use forward slashes by replacing `\` with `/`. Applied in two locations:

1. `loadRoutes()` - when normalizing the routeFiles array
2. `loadRoutes()` - when normalizing the passed routesFile parameter

This makes path comparisons consistent across Windows and Unix platforms.

## Changes

One file: `system/Router/RouteCollection.php`
- `loadRoutes()`: normalize `realpath()` results with `str_replace('\\', '/', ...)`

Ref: https://github.com/codeigniter4/CodeIgniter4/issues/7474
Closes #7474
