### PR TITLE
fix: prevent subdomain-only route from overwriting hostname route

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1475,23 +1475,29 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         // Hostname limiting?
+        $matchedByHostname = false;
+
         if (! empty($options['hostname'])) {
             // @todo determine if there's a way to whitelist hosts?
             if (! $this->checkHostname($options['hostname'])) {
                 return;
             }
 
-            $overwrite = true;
+            $overwrite         = true;
+            $matchedByHostname = true;
         }
         // Limiting to subdomains?
-        elseif (! empty($options['subdomain'])) {
+        $matchedBySubdomain = false;
+
+        if (! empty($options['subdomain'])) {
             // If we don't match the current subdomain, then
             // we don't need to add the route.
             if (! $this->checkSubdomains($options['subdomain'])) {
                 return;
             }
 
-            $overwrite = true;
+            $overwrite          = true;
+            $matchedBySubdomain = true;
         }
 
         // Are we offsetting the binds?
@@ -1541,6 +1547,17 @@ class RouteCollection implements RouteCollectionInterface
         // this works only because discovered routes are added just prior
         // to attempting to route the request.
         $routeKeyExists = isset($this->routes[$verb][$routeKey]);
+
+        // Prevent a subdomain-only route from overwriting a hostname-matched route,
+        // since hostname is more specific than subdomain.
+        if ($routeKeyExists && $matchedBySubdomain && ! $matchedByHostname) {
+            $existingOptions = $this->routesOptions[$verb][$routeKey] ?? [];
+
+            if (! empty($existingOptions['hostname'])) {
+                return;
+            }
+        }
+
         if ((isset($this->routesNames[$verb][$name]) || $routeKeyExists) && ! $overwrite) {
             return;
         }


### PR DESCRIPTION
## Description

Fixes #7214 - Inconsistent hostname/subdomain limitation in Routing

## Problem

When using `hostname` and `subdomain` route options, the precedence was inconsistent depending on whether they were on the same route or separate routes:

### Case 1: Same route (hostname took precedence - correct)
```php
$routes->get('/', 'Home::index');
$routes->get('/', 'Media::index', ['hostname' => 'media.example.com', 'subdomain' => '*']);
```
media.example.com → Media::index ✓

### Case 2: Separate routes (subdomain incorrectly won)
```php
$routes->get('/', 'Home::index');
$routes->get('/', 'Media::index', ['hostname' => 'media.example.com']);
$routes->get('/', 'All::index', ['subdomain' => '*']);
```
media.example.com → All::index ✗ (should be Media::index)

### Root Cause

Two issues:
1. `elseif` meant routes with both `hostname` and `subdomain` only validated hostname
2. No protection against subdomain-only routes overwriting hostname routes

## Solution

1. Change `elseif` to `if` — both `hostname` and `subdomain` are validated independently
2. Track `matchedByHostname`/`matchedBySubdomain` flags during registration
3. Add guard: routes matched only by subdomain cannot overwrite existing hostname routes

## Changes

One file: `system/Router/RouteCollection.php`
- Independent hostname/subdomain validation
- Hostname route protection from subdomain-only overwrite

Ref: https://github.com/codeigniter4/CodeIgniter4/issues/7214
Closes #7214
