### PR TITLE
fix: add missing methods to RendererInterface and RouteCollectionInterface

### DIFF
--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -264,4 +264,16 @@ interface RouteCollectionInterface
      * @return list<string> filter_name or filter_name:arguments like 'role:admin,manager'
      */
     public function getFiltersForRoute(string $search, ?string $verb = null): array;
+
+    /**
+     * Get all controllers in Route Handlers
+     *
+     * @param string|null $verb HTTP verb like `GET`,`POST` or `*` or `CLI`.
+     *                          `'*'` returns all controllers in any verb.
+     *
+     * @return list<string> controller name list
+     *
+     * @internal
+     */
+    public function getRegisteredControllers(?string $verb = '*'): array;
 }

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -71,4 +71,19 @@ interface RendererInterface
      * @return RendererInterface
      */
     public function resetData();
+
+    /**
+     * Returns the rendered data from all views, organized by view name.
+     *
+     * @return array<string, array>
+     */
+    public function getData(): array;
+
+    /**
+     * Returns the performance data that might have been collected
+     * during the execution. Used by the Debug Toolbar.
+     *
+     * @return array<int, array>
+     */
+    public function getPerformanceData(): array;
 }


### PR DESCRIPTION
## Description

Addresses #6814 - Missing Interfaces (PHPStan errors)

## Problem

PHPStan reports 22 errors when the baseline suppressions for interface-related issues are removed. These occur because methods/properties are called on interfaces but not declared in the interface definition.

## Analysis of current state

Of the 22 original errors reported in #6814 (v4.3), several were already fixed:

| Item | Status |
|------|--------|
| QueryInterface::getOriginalQuery() | Already fixed ✓ |
| ConnectionInterface::$connID/$DBDriver | @property tags added ✓ |
| RouteCollectionInterface::setHTTPVerb() | Already fixed ✓ |
| RouteCollectionInterface::isFiltered() | Already fixed ✓ |
| RouteCollectionInterface::getFiltersForRoute() | Already fixed ✓ |
| RouteCollectionInterface::getRoutesOptions() | Already fixed ✓ |
| RouteCollectionInterface::getDefaultNamespace() | Already fixed ✓ |
| Cell::$cache empty() issue | Already fixed ✓ |

## Remaining issues fixed

| Interface | Missing method | Implementing class |
|-----------|---------------|-------------------|
| RendererInterface | `getData()` | View (already has it) |
| RendererInterface | `getPerformanceData()` | View (already has it) |
| RouteCollectionInterface | `getRegisteredControllers()` | RouteCollection (already has it) |

## Changes

- `system/View/RendererInterface.php` - add getData(), getPerformanceData()
- `system/Router/RouteCollectionInterface.php` - add getRegisteredControllers()

Ref: https://github.com/codeigniter4/CodeIgniter4/issues/6814
