### PR TITLE
refactor: Query Builder `WHERE`/`HAVING` condition handling

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1120,6 +1120,7 @@ class BaseBuilder
     /**
      * @param 'QBHaving'|'QBWhere' $clause
      * @param array<string, mixed> $condition
+     * @param non-empty-string     $type
      */
     private function addWhereHavingCondition(string $clause, array $condition, string $type): void
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -855,16 +855,14 @@ class BaseBuilder
 
         $escape ??= $this->db->protectIdentifiers;
 
-        $prefix = $this->{$qbKey} === [] ? $this->groupGetType('') : $this->groupGetType($type);
-
-        $this->{$qbKey}[] = [
+        $this->addWhereHavingCondition($qbKey, [
             'columnComparison' => true,
-            'condition'        => $prefix,
+            'condition'        => '',
             'escape'           => $escape,
             'first'            => $first,
             'operator'         => $operator,
             'second'           => $second,
-        ];
+        ], $type);
 
         return $this;
     }
@@ -977,17 +975,15 @@ class BaseBuilder
         $lowerBind = $this->setBind($key, $values[0], $escape);
         $upperBind = $this->setBind($key, $values[1], $escape);
         $not       = $not ? ' NOT' : '';
-        $prefix    = $this->{$qbKey} === [] ? $this->groupGetType('') : $this->groupGetType($type);
-
-        $this->{$qbKey}[] = [
+        $this->addWhereHavingCondition($qbKey, [
             'betweenComparison' => true,
-            'condition'         => $prefix,
+            'condition'         => '',
             'escape'            => $escape,
             'key'               => $key,
             'lowerBind'         => $lowerBind,
             'not'               => $not,
             'upperBind'         => $upperBind,
-        ];
+        ], $type);
 
         return $this;
     }
@@ -1010,13 +1006,12 @@ class BaseBuilder
             throw new InvalidArgumentException(sprintf('%s() expects $subquery to be of type BaseBuilder or closure', debug_backtrace(0, 2)[1]['function']));
         }
 
-        $prefix   = $this->QBWhere === [] ? $this->groupGetType('') : $this->groupGetType($type);
         $operator = $not ? 'NOT EXISTS' : 'EXISTS';
 
-        $this->QBWhere[] = [
-            'condition' => "{$prefix}{$operator} {$this->buildSubquery($subquery, true)}",
+        $this->addWhereHavingCondition('QBWhere', [
+            'condition' => "{$operator} {$this->buildSubquery($subquery, true)}",
             'escape'    => false,
-        ];
+        ], $type);
 
         return $this;
     }
@@ -1055,8 +1050,6 @@ class BaseBuilder
         }
 
         foreach ($keyValue as $k => $v) {
-            $prefix = empty($this->{$qbKey}) ? $this->groupGetType('') : $this->groupGetType($type);
-
             if ($rawSqlOnly) {
                 $k  = '';
                 $op = '';
@@ -1104,20 +1097,40 @@ class BaseBuilder
                 $op = '';
             }
 
+            $condition = $k . $op . $v;
+
             if ($v instanceof RawSql) {
-                $this->{$qbKey}[] = [
-                    'condition' => $v->with($prefix . $k . $op . $v),
-                    'escape'    => $escape,
-                ];
-            } else {
-                $this->{$qbKey}[] = [
-                    'condition' => $prefix . $k . $op . $v,
-                    'escape'    => $escape,
-                ];
+                $condition = $v->with($condition);
             }
+
+            $this->addWhereHavingCondition($qbKey, [
+                'condition' => $condition,
+                'escape'    => $escape,
+            ], $type);
         }
 
         return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $condition
+     */
+    private function addWhereHavingCondition(string $clause, array $condition, string $type): void
+    {
+        $prefix = $this->getWhereHavingPrefix($clause, $type);
+
+        if ($condition['condition'] instanceof RawSql) {
+            $condition['condition'] = $condition['condition']->with($prefix . $condition['condition']);
+        } else {
+            $condition['condition'] = $prefix . $condition['condition'];
+        }
+
+        $this->{$clause}[] = $condition;
+    }
+
+    private function getWhereHavingPrefix(string $clause, string $type): string
+    {
+        return $this->{$clause} === [] ? $this->groupGetType('') : $this->groupGetType($type);
     }
 
     /**
@@ -1268,14 +1281,10 @@ class BaseBuilder
 
         $ok = $this->setBind($ok, $whereIn, $escape);
 
-        $prefix = empty($this->{$clause}) ? $this->groupGetType('') : $this->groupGetType($type);
-
-        $whereIn = [
-            'condition' => "{$prefix}{$key}{$not} IN :{$ok}:",
+        $this->addWhereHavingCondition($clause, [
+            'condition' => "{$key}{$not} IN :{$ok}:",
             'escape'    => false,
-        ];
-
-        $this->{$clause}[] = $whereIn;
+        ], $type);
 
         return $this;
     }
@@ -1408,7 +1417,7 @@ class BaseBuilder
             $v                 = $match;
             $insensitiveSearch = false;
 
-            $prefix = empty($this->{$clause}) ? $this->groupGetType('') : $this->groupGetType($type);
+            $prefix = $this->getWhereHavingPrefix($clause, $type);
 
             if ($side === 'none') {
                 $bind = $this->setBind($field->getBindingKey(), $v, $escape);
@@ -1442,7 +1451,7 @@ class BaseBuilder
                 $v = mb_strtolower($v, 'UTF-8');
             }
 
-            $prefix = empty($this->{$clause}) ? $this->groupGetType('') : $this->groupGetType($type);
+            $prefix = $this->getWhereHavingPrefix($clause, $type);
 
             if ($side === 'none') {
                 $bind = $this->setBind($k, $v, $escape);
@@ -3479,87 +3488,7 @@ class BaseBuilder
     {
         if (! empty($this->{$qbKey})) {
             foreach ($this->{$qbKey} as &$qbkey) {
-                // Is this condition already compiled?
-                if (is_string($qbkey)) {
-                    continue;
-                }
-
-                if ($qbkey instanceof RawSql) {
-                    continue;
-                }
-
-                if ($qbkey['condition'] instanceof RawSql) {
-                    $qbkey = $qbkey['condition'];
-
-                    continue;
-                }
-
-                if (($qbkey['columnComparison'] ?? false) === true) {
-                    $qbkey = $this->compileColumnComparison($qbkey);
-
-                    continue;
-                }
-
-                if (($qbkey['betweenComparison'] ?? false) === true) {
-                    $qbkey = $this->compileBetweenComparison($qbkey);
-
-                    continue;
-                }
-
-                if ($qbkey['escape'] === false) {
-                    $qbkey = $qbkey['condition'];
-
-                    continue;
-                }
-
-                // Split multiple conditions
-                $conditions = preg_split(
-                    '/((?:^|\s+)AND\s+|(?:^|\s+)OR\s+)/i',
-                    $qbkey['condition'],
-                    -1,
-                    PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY,
-                );
-
-                foreach ($conditions as &$condition) {
-                    $op = $this->getOperator($condition);
-                    if (
-                        $op === false
-                        || preg_match(
-                            '/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i',
-                            $condition,
-                            $matches,
-                        ) !== 1
-                    ) {
-                        continue;
-                    }
-
-                    // $matches = [
-                    //  0 => '(test <= foo)',   /* the whole thing */
-                    //  1 => '(',               /* optional */
-                    //  2 => 'test',            /* the field name */
-                    //  3 => ' <= ',            /* $op */
-                    //  4 => 'foo',	            /* optional, if $op is e.g. 'IS NULL' */
-                    //  5 => ')'                /* optional */
-                    // ];
-
-                    if ($matches[4] !== '') {
-                        $protectIdentifiers = false;
-                        if (str_contains($matches[4], '.')) {
-                            $protectIdentifiers = true;
-                        }
-
-                        if (! str_contains($matches[4], ':')) {
-                            $matches[4] = $this->db->protectIdentifiers(trim($matches[4]), false, $protectIdentifiers);
-                        }
-
-                        $matches[4] = ' ' . $matches[4];
-                    }
-
-                    $condition = $matches[1] . $this->db->protectIdentifiers(trim($matches[2]))
-                        . ' ' . trim($matches[3]) . $matches[4] . $matches[5];
-                }
-
-                $qbkey = implode('', $conditions);
+                $qbkey = $this->compileWhereHavingCondition($qbkey);
             }
 
             return ($qbKey === 'QBHaving' ? "\nHAVING " : "\nWHERE ")
@@ -3571,6 +3500,92 @@ class BaseBuilder
 
     /**
      * @used-by compileWhereHaving()
+     *
+     * @param array<string, mixed>|RawSql|string $condition
+     */
+    private function compileWhereHavingCondition(array|RawSql|string $condition): RawSql|string
+    {
+        // Is this condition already compiled?
+        if (is_string($condition) || $condition instanceof RawSql) {
+            return $condition;
+        }
+
+        if ($condition['condition'] instanceof RawSql) {
+            return $condition['condition'];
+        }
+
+        if (($condition['columnComparison'] ?? false) === true) {
+            return $this->compileColumnComparison($condition);
+        }
+
+        if (($condition['betweenComparison'] ?? false) === true) {
+            return $this->compileBetweenComparison($condition);
+        }
+
+        if ($condition['escape'] === false) {
+            return $condition['condition'];
+        }
+
+        return $this->compileEscapedCondition($condition['condition']);
+    }
+
+    /**
+     * @used-by compileWhereHavingCondition()
+     */
+    private function compileEscapedCondition(string $condition): string
+    {
+        // Split multiple conditions
+        $conditions = preg_split(
+            '/((?:^|\s+)AND\s+|(?:^|\s+)OR\s+)/i',
+            $condition,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY,
+        );
+
+        foreach ($conditions as &$condition) {
+            $op = $this->getOperator($condition);
+            if (
+                $op === false
+                || preg_match(
+                    '/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i',
+                    $condition,
+                    $matches,
+                ) !== 1
+            ) {
+                continue;
+            }
+
+            // $matches = [
+            //  0 => '(test <= foo)',   /* the whole thing */
+            //  1 => '(',               /* optional */
+            //  2 => 'test',            /* the field name */
+            //  3 => ' <= ',            /* $op */
+            //  4 => 'foo',             /* optional, if $op is e.g. 'IS NULL' */
+            //  5 => ')'                /* optional */
+            // ];
+
+            if ($matches[4] !== '') {
+                $protectIdentifiers = false;
+                if (str_contains($matches[4], '.')) {
+                    $protectIdentifiers = true;
+                }
+
+                if (! str_contains($matches[4], ':')) {
+                    $matches[4] = $this->db->protectIdentifiers(trim($matches[4]), false, $protectIdentifiers);
+                }
+
+                $matches[4] = ' ' . $matches[4];
+            }
+
+            $condition = $matches[1] . $this->db->protectIdentifiers(trim($matches[2]))
+                . ' ' . trim($matches[3]) . $matches[4] . $matches[5];
+        }
+
+        return implode('', $conditions);
+    }
+
+    /**
+     * @used-by compileWhereHavingCondition()
      *
      * @param array{columnComparison: true, condition: string, escape: bool, first: string, operator: string, second: string} $condition
      */
@@ -3585,7 +3600,7 @@ class BaseBuilder
     }
 
     /**
-     * @used-by compileWhereHaving()
+     * @used-by compileWhereHavingCondition()
      *
      * @param array{betweenComparison: true, condition: string, escape: bool, key: string, lowerBind: string, not: string, upperBind: string} $condition
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1100,7 +1100,12 @@ class BaseBuilder
             $condition = $k . $op . $v;
 
             if ($v instanceof RawSql) {
-                $condition = $v->with($condition);
+                $this->{$qbKey}[] = [
+                    'condition' => $v->with($this->getWhereHavingPrefix($qbKey, $type) . $condition),
+                    'escape'    => $escape,
+                ];
+
+                continue;
             }
 
             $this->addWhereHavingCondition($qbKey, [
@@ -1113,21 +1118,19 @@ class BaseBuilder
     }
 
     /**
+     * @param 'QBHaving'|'QBWhere' $clause
      * @param array<string, mixed> $condition
      */
     private function addWhereHavingCondition(string $clause, array $condition, string $type): void
     {
-        $prefix = $this->getWhereHavingPrefix($clause, $type);
-
-        if ($condition['condition'] instanceof RawSql) {
-            $condition['condition'] = $condition['condition']->with($prefix . $condition['condition']);
-        } else {
-            $condition['condition'] = $prefix . $condition['condition'];
-        }
+        $condition['condition'] = $this->getWhereHavingPrefix($clause, $type) . $condition['condition'];
 
         $this->{$clause}[] = $condition;
     }
 
+    /**
+     * @param 'QBHaving'|'QBWhere' $clause
+     */
     private function getWhereHavingPrefix(string $clause, string $type): string
     {
         return $this->{$clause} === [] ? $this->groupGetType('') : $this->groupGetType($type);

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -151,6 +151,43 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * @param mixed $value
+     */
+    #[DataProvider('provideWhereOperatorRegressionCases')]
+    public function testWhereOperatorRegressionCases(string $key, $value, string $expectedSQL): void
+    {
+        $builder = $this->db->table('jobs job');
+
+        $builder->where($key, $value);
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, string}>
+     */
+    public static function provideWhereOperatorRegressionCases(): iterable
+    {
+        return [
+            'like operator with value' => [
+                'job.status LIKE',
+                'p%',
+                'SELECT * FROM "jobs" "job" WHERE "job"."status" LIKE \'p%\'',
+            ],
+            'equals operator with null' => [
+                'job.deleted_at =',
+                null,
+                'SELECT * FROM "jobs" "job" WHERE "job"."deleted_at" IS NULL',
+            ],
+            'not equals operator with null' => [
+                'job.deleted_at !=',
+                null,
+                'SELECT * FROM "jobs" "job" WHERE "job"."deleted_at" IS NOT NULL',
+            ],
+        ];
+    }
+
     public function testWhereCustomString(): void
     {
         $builder = $this->db->table('jobs');

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -152,20 +152,22 @@ final class WhereTest extends CIUnitTestCase
     }
 
     /**
-     * @param mixed $value
+     * @param mixed                             $value
+     * @param array<string, array{mixed, bool}> $expectedBinds
      */
     #[DataProvider('provideWhereOperatorRegressionCases')]
-    public function testWhereOperatorRegressionCases(string $key, $value, string $expectedSQL): void
+    public function testWhereOperatorRegressionCases(string $key, $value, string $expectedSQL, array $expectedBinds): void
     {
         $builder = $this->db->table('jobs job');
 
         $builder->where($key, $value);
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
     /**
-     * @return iterable<string, array{string, mixed, string}>
+     * @return iterable<string, array{string, mixed, string, array<string, array{mixed, bool}>}>
      */
     public static function provideWhereOperatorRegressionCases(): iterable
     {
@@ -174,16 +176,24 @@ final class WhereTest extends CIUnitTestCase
                 'job.status LIKE',
                 'p%',
                 'SELECT * FROM "jobs" "job" WHERE "job"."status" LIKE \'p%\'',
+                [
+                    'job.status' => [
+                        'p%',
+                        true,
+                    ],
+                ],
             ],
             'equals operator with null' => [
                 'job.deleted_at =',
                 null,
                 'SELECT * FROM "jobs" "job" WHERE "job"."deleted_at" IS NULL',
+                [],
             ],
             'not equals operator with null' => [
                 'job.deleted_at !=',
                 null,
                 'SELECT * FROM "jobs" "job" WHERE "job"."deleted_at" IS NOT NULL',
+                [],
             ],
         ];
     }

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -34,7 +34,7 @@ parameters:
 
         -
             message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-            count: 28
+            count: 24
             path: ../../system/Database/BaseBuilder.php
 
         -


### PR DESCRIPTION
**Description**

This PR proposes refactoring the internal Query Builder handling for `WHERE` and `HAVING` conditions without changing public APIs or expected SQL output.

The existing condition-building paths each handled parts of prefixing, grouping, and compilation themselves. This centralizes those pieces into small private helpers so the behavior is easier to follow and safer to maintain.

It also adds regression coverage for a few important condition cases:

- `LIKE` with a bound value
- `= null` compiling to `IS NULL`
- `!= null` compiling to `IS NOT NULL`

This is intentionally a behavior-preserving cleanup. No new user-facing API is added, so there is no user guide or changelog entry.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide