### PR TITLE
chore: bump phpstan to ^2.1.55 and fix callable docblock notice

### DIFF
--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -39,7 +39,7 @@ class View extends BaseView
      * by the core Parser by creating aliases that will be replaced with
      * any callable. Can be single or tag pair.
      *
-     * @var array<string, (callable(mixed): mixed)|((callable(mixed): mixed)&string)|list<(callable(mixed): mixed)&string>>
+     * @var array<string, (callable(mixed...): mixed)|((callable(mixed...): mixed)&string)|list<(callable(mixed...): mixed)&string>>
      */
     public $plugins = [];
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "mikey179/vfsstream": "^1.6.12",
         "nexusphp/tachycardia": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.1.36",
+        "phpstan/phpstan": "^2.1.55",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpcov": "^9.0.2 || ^10.0",
         "phpunit/phpunit": "^10.5.16 || ^11.2",

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -48,7 +48,7 @@ class View extends BaseConfig
      *
      * @psalm-suppress UndefinedDocblockClass
      *
-     * @var array<string, (callable(mixed): mixed)|((callable(mixed): mixed)&string)|list<(callable(mixed): mixed)&string>>
+     * @var array<string, (callable(mixed...): mixed)|((callable(mixed...): mixed)&string)|list<(callable(mixed...): mixed)&string>>
      */
     public $plugins = [];
 
@@ -84,7 +84,7 @@ class View extends BaseConfig
     /**
      * Built-in View plugins.
      *
-     * @var array<string, (callable(mixed): mixed)|((callable(mixed): mixed)&string)|list<(callable(mixed): mixed)&string>>
+     * @var array<string, (callable(mixed...): mixed)|((callable(mixed...): mixed)&string)|list<(callable(mixed...): mixed)&string>>
      */
     protected $corePlugins = [
         'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -60,7 +60,7 @@ class Parser extends View
     /**
      * Stores any plugins registered at run-time.
      *
-     * @var array<string, (callable(mixed): mixed)|((callable(mixed): mixed)&string)|list<(callable(mixed): mixed)&string>>
+     * @var array<string, (callable(mixed...): mixed)|((callable(mixed...): mixed)&string)|list<(callable(mixed...): mixed)&string>>
      */
     protected $plugins = [];
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

Fix notice on phpstan 2.1.55

```
➜  CodeIgniter4 git:(develop) ✗ composer analyze
Note: Using configuration file /Users/samsonasik/www/CodeIgniter4/phpstan.neon.dist.
 913/913 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 10 secs

 ------ ------------------------------------------------------------------------ 
  Line   system/View/Parser.php                                                  
 ------ ------------------------------------------------------------------------ 
  :713   Callable callable(mixed): mixed invoked with 2 parameters, 1 required.  
         🪪  arguments.count                                                     
 ------ ------------------------------------------------------------------------ 


                                                                                                                        
 [ERROR] Found 1 error                                                                                                                                                                                                                   
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
