### PR TITLE
feat: add copyable error reports to detailed exception pages

### DIFF
--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -46,9 +46,16 @@ p.lead {
 .header .container {
     padding: 1rem;
 }
+.header-title {
+    align-items: flex-start;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+}
 .header h1 {
     font-size: 2.5rem;
     font-weight: 500;
+    min-width: 0;
 }
 .header p {
     font-size: 1.2rem;
@@ -65,14 +72,84 @@ p.lead {
     display: inline;
 }
 
+.error-report {
+    flex: 0 0 auto;
+    margin-top: 0.35rem;
+}
+
+.error-report-button {
+    align-items: center;
+    background: rgba(255,255,255,0.35);
+    border: 1px solid rgba(0,0,0,0.14);
+    border-radius: 5px;
+    box-sizing: border-box;
+    color: var(--main-text-color);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 0.82rem;
+    font-weight: 500;
+    gap: 0.35rem;
+    height: 1.875rem;
+    justify-content: center;
+    line-height: 1;
+    padding: 0 0.65rem;
+    transition: background-color 160ms ease-in-out, border-color 160ms ease-in-out, color 160ms ease-in-out, box-shadow 160ms ease-in-out;
+    white-space: nowrap;
+    width: 7.15rem;
+}
+
+.error-report-button:hover {
+    background: rgba(255,255,255,0.6);
+    border-color: rgba(0,0,0,0.22);
+    color: var(--dark-text-color);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+}
+
+.error-report-button:focus-visible {
+    border-color: rgba(0,0,0,0.35);
+    outline: 0;
+    box-shadow: 0 0 0 2px rgba(220,72,20,0.16);
+}
+
+.error-report-button:active {
+    background: rgba(255,255,255,0.75);
+}
+
+.error-report-icon {
+    flex: 0 0 auto;
+    height: 0.72rem;
+    width: 0.72rem;
+}
+
 .environment {
     background: var(--brand-primary-color);
+    box-sizing: border-box;
     color: var(--main-bg-color);
     text-align: center;
     padding: calc(4px + 0.2083vw);
     width: 100%;
     top: 0;
     position: fixed;
+}
+
+@media (max-width: 40rem) {
+    .header {
+        margin-top: 0;
+    }
+
+    .header p {
+        font-size: 1.1rem;
+        line-height: 1.45;
+        margin-top: 0.35rem;
+        overflow-wrap: anywhere;
+    }
+
+    .environment {
+        font-size: 0.9rem;
+        line-height: 1.25;
+        padding: 0.45rem 0.75rem;
+        position: static;
+    }
 }
 
 .source {

--- a/app/Views/errors/html/debug.js
+++ b/app/Views/errors/html/debug.js
@@ -117,41 +117,17 @@ function toggle(elem)
 
 function copyErrorReport(reportId, button)
 {
-    var report = document.getElementById(reportId);
-
-    if (navigator.clipboard && window.isSecureContext)
+    if (! navigator.clipboard || ! window.isSecureContext)
     {
-        navigator.clipboard
-            .writeText(report.value)
-            .then(() => showCopiedButton(button))
-            .catch(() => copyErrorReportWithFallback(report.value, button));
-
         return false;
     }
 
-    copyErrorReportWithFallback(report.value, button);
+    var report = document.getElementById(reportId);
+    navigator.clipboard.writeText(report.value).then(function () {
+        showCopiedButton(button);
+    });
 
     return false;
-}
-
-function copyErrorReportWithFallback(text, button)
-{
-    var textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.setAttribute('readonly', '');
-    textarea.style.position = 'fixed';
-    textarea.style.top = '-1000px';
-    textarea.style.left = '-1000px';
-
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    if (document.execCommand('copy'))
-    {
-        showCopiedButton(button);
-    }
-
-    document.body.removeChild(textarea);
 }
 
 function showCopiedButton(button)
@@ -160,7 +136,7 @@ function showCopiedButton(button)
     button.innerHTML   = 'Copied!';
 
     window.clearTimeout(button.copyResetTimer);
-    button.copyResetTimer = window.setTimeout(() => {
+    button.copyResetTimer = window.setTimeout(function () {
         button.innerHTML = button.defaultHtml;
     }, 1500);
 }

--- a/app/Views/errors/html/debug.js
+++ b/app/Views/errors/html/debug.js
@@ -114,3 +114,53 @@ function toggle(elem)
 
     return false;
 }
+
+function copyErrorReport(reportId, button)
+{
+    var report = document.getElementById(reportId);
+
+    if (navigator.clipboard && window.isSecureContext)
+    {
+        navigator.clipboard
+            .writeText(report.value)
+            .then(() => showCopiedButton(button))
+            .catch(() => copyErrorReportWithFallback(report.value, button));
+
+        return false;
+    }
+
+    copyErrorReportWithFallback(report.value, button);
+
+    return false;
+}
+
+function copyErrorReportWithFallback(text, button)
+{
+    var textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-1000px';
+    textarea.style.left = '-1000px';
+
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    if (document.execCommand('copy'))
+    {
+        showCopiedButton(button);
+    }
+
+    document.body.removeChild(textarea);
+}
+
+function showCopiedButton(button)
+{
+    button.defaultHtml = button.defaultHtml || button.innerHTML;
+    button.innerHTML   = 'Copied!';
+
+    window.clearTimeout(button.copyResetTimer);
+    button.copyResetTimer = window.setTimeout(() => {
+        button.innerHTML = button.defaultHtml;
+    }, 1500);
+}

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -3,6 +3,7 @@ use CodeIgniter\HTTP\Header;
 use CodeIgniter\CodeIgniter;
 
 $errorId = uniqid('error', true);
+$copyableErrorReportId = $errorId . 'copyableErrorReport';
 ?>
 <!doctype html>
 <html>
@@ -30,7 +31,38 @@ $errorId = uniqid('error', true);
             Environment: <?= ENVIRONMENT ?>
         </div>
         <div class="container">
-            <h1><?= esc($title), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
+            <div class="header-title">
+                <h1><?= esc($title), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
+                <div class="error-report">
+                    <button
+                        class="error-report-button"
+                        type="button"
+                        aria-live="polite"
+                        onclick="return copyErrorReport('<?= esc($copyableErrorReportId, 'attr') ?>', this);"
+                    >
+                        <svg
+                            aria-hidden="true"
+                            class="error-report-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        >
+                            <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+                            <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+                        </svg>
+                        <span class="error-report-label">Copy Details</span>
+                    </button>
+                    <textarea
+                        id="<?= esc($copyableErrorReportId, 'attr') ?>"
+                        readonly
+                        hidden
+                    ><?php include __DIR__ . '/error_report.php'; ?></textarea>
+                </div>
+            </div>
             <p>
                 <?= nl2br(esc($exception->getMessage())) ?>
                 <a href="https://www.duckduckgo.com/?q=<?= urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>"
@@ -342,8 +374,9 @@ $errorId = uniqid('error', true);
 
             <!-- Response -->
             <?php
-                $response = service('response');
-                $response->setStatusCode(http_response_code());
+                $response           = service('response');
+                $responseStatusCode = http_response_code();
+                $response->setStatusCode($responseStatusCode === false || $responseStatusCode === 0 ? $code : $responseStatusCode);
             ?>
             <div class="content" id="response">
                 <table>

--- a/app/Views/errors/html/error_report.php
+++ b/app/Views/errors/html/error_report.php
@@ -1,0 +1,128 @@
+<?php
+
+use CodeIgniter\CodeIgniter;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\URI;
+
+$reportMessage = str_replace(["\r\n", "\r"], "\n", $message);
+$reportTitle   = trim($reportMessage);
+$reportTitle   = $reportTitle === '' ? $title : explode("\n", $reportTitle, 2)[0];
+$messageLines  = str_contains($reportMessage, "\n");
+
+$reportResponse = new Response();
+$reportResponse->setStatusCode($code);
+
+$report = [
+    '# ' . $reportTitle,
+    '',
+    '## Exception',
+    '',
+    '- Type: ' . $type,
+    '- Status Code: ' . $code,
+    '- Status: ' . $reportResponse->getReasonPhrase(),
+    $messageLines ? '- Message:' : '- Message: ' . $reportMessage,
+];
+
+if ($messageLines) {
+    $report[] = '';
+    $report[] = '```text';
+    $report[] = $reportMessage;
+    $report[] = '```';
+}
+
+$report[] = '';
+$report[] = '## Environment';
+$report[] = '';
+$report[] = '- PHP: ' . PHP_VERSION;
+$report[] = '- CodeIgniter: ' . CodeIgniter::CI_VERSION;
+$report[] = '- Environment: ' . ENVIRONMENT;
+$report[] = '- SAPI: ' . PHP_SAPI;
+$report[] = '- Time: ' . date('Y-m-d H:i:s e');
+$report[] = '- Memory Usage: ' . number_format(memory_get_usage(true) / 1024 / 1024, 2) . ' MB';
+
+$reportRequest = service('request');
+
+if ($reportRequest instanceof IncomingRequest) {
+    $reportPath = '/' . ltrim($reportRequest->getPath(), '/');
+    $reportUri  = $reportRequest->getUri();
+    $reportUrl  = $reportPath;
+
+    if ($reportUri->getHost() !== '') {
+        $reportUrl = URI::createURIString(
+            $reportUri->getScheme(),
+            $reportUri->getHost() . ($reportUri->getPort() === null ? '' : ':' . $reportUri->getPort()),
+            $reportPath,
+        );
+    }
+
+    $report[] = '';
+    $report[] = '## Request';
+    $report[] = '';
+    $report[] = '- Method: ' . $reportRequest->getMethod();
+    $report[] = '- Path: ' . $reportPath;
+    $report[] = '- URL: ' . $reportUrl;
+    $report[] = '- User Agent: ' . $reportRequest->getUserAgent()->getAgentString();
+}
+
+$report[] = '';
+$report[] = '## Source';
+$report[] = '';
+$report[] = '`' . clean_path($file) . ':' . $line . '`';
+
+if (is_file($file) && is_readable($file)) {
+    $sourceLines = file($file, FILE_IGNORE_NEW_LINES);
+
+    if ($sourceLines !== false) {
+        $startLine = max($line - 5, 1);
+        $endLine   = min($line + 5, count($sourceLines));
+
+        $report[] = '';
+        $report[] = '```php';
+
+        for ($sourceLine = $startLine; $sourceLine <= $endLine; $sourceLine++) {
+            $report[] = sprintf(
+                '%s%4d %s',
+                $sourceLine === $line ? '>' : ' ',
+                $sourceLine,
+                $sourceLines[$sourceLine - 1],
+            );
+        }
+
+        $report[] = '```';
+    }
+}
+
+$previousException = $exception->getPrevious();
+
+if ($previousException instanceof Throwable) {
+    $report[] = '';
+    $report[] = '## Previous Exceptions';
+
+    while ($previousException instanceof Throwable) {
+        $report[] = '* ' . $previousException::class . ' - ' . $previousException->getMessage();
+        $report[] = '  ' . clean_path($previousException->getFile()) . ':' . $previousException->getLine();
+
+        $previousException = $previousException->getPrevious();
+    }
+}
+
+if ($trace !== []) {
+    $report[] = '';
+    $report[] = '## Stack Trace';
+    $report[] = '';
+    $report[] = '```text';
+
+    foreach (array_slice($trace, 0, 50) as $reportIndex => $reportRow) {
+        $reportLocation = isset($reportRow['file'], $reportRow['line'])
+            ? clean_path($reportRow['file']) . ':' . $reportRow['line']
+            : '{PHP internal code}';
+        $reportCall = ($reportRow['class'] ?? '') . ($reportRow['type'] ?? '') . ($reportRow['function'] ?? '');
+
+        $report[] = $reportIndex . '  ' . $reportLocation . ($reportCall === '' ? '' : '  ' . $reportCall . '()');
+    }
+
+    $report[] = '```';
+}
+
+echo esc(implode("\n", $report)) . "\n";

--- a/app/Views/errors/html/error_report.php
+++ b/app/Views/errors/html/error_report.php
@@ -2,7 +2,6 @@
 
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\URI;
 
 $reportMessage = str_replace(["\r\n", "\r"], "\n", $message);
@@ -10,7 +9,7 @@ $reportTitle   = trim($reportMessage);
 $reportTitle   = $reportTitle === '' ? $title : explode("\n", $reportTitle, 2)[0];
 $messageLines  = str_contains($reportMessage, "\n");
 
-$reportResponse = new Response();
+$reportResponse = service('response', null, false);
 $reportResponse->setStatusCode($code);
 
 $report = [

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -16,9 +16,13 @@ namespace CodeIgniter\Debug;
 use App\Controllers\Home;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Exceptions\RuntimeException;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\SiteURI;
+use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\IniTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
+use Config\App;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
@@ -104,6 +108,65 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         foreach (['title', 'type', 'code', 'message', 'file', 'line', 'trace'] as $key) {
             $this->assertArrayHasKey($key, $vars);
         }
+
+        $this->assertArrayNotHasKey('copyableErrorReport', $vars);
+    }
+
+    public function testCopyErrorReportIncludesPreviousExceptions(): void
+    {
+        $previous  = new RuntimeException('Root cause.');
+        $exception = new RuntimeException('Top level.', 0, $previous);
+
+        $report = $this->extractCopyableErrorReport($this->renderHtmlException($exception));
+
+        $this->assertStringContainsString('## Previous Exceptions', $report);
+        $this->assertStringContainsString('* CodeIgniter\Exceptions\RuntimeException - Root cause.', $report);
+    }
+
+    public function testCopyErrorReportOmitsSensitiveRequestDataAndTraceArgs(): void
+    {
+        $exception = $this->createExceptionWithSensitiveTraceArgument();
+
+        $_COOKIE['debug_cookie'] = 'cookie-secret';
+        $_POST['debug_post']     = 'post-secret';
+
+        try {
+            $report = $this->extractCopyableErrorReport($this->renderHtmlException($exception));
+
+            $this->assertStringNotContainsString('secret-token', $report);
+            $this->assertStringNotContainsString('cookie-secret', $report);
+            $this->assertStringNotContainsString('post-secret', $report);
+            $this->assertStringNotContainsString('$_COOKIE', $report);
+            $this->assertStringNotContainsString('$_POST', $report);
+        } finally {
+            unset($_COOKIE['debug_cookie'], $_POST['debug_post']);
+        }
+    }
+
+    public function testCopyErrorReportOmitsQueryStringFromUrl(): void
+    {
+        $config  = new App();
+        $secret  = 'query-secret';
+        $token   = '?token=';
+        $request = new IncomingRequest(
+            $config,
+            new SiteURI($config, '/orders?token=' . $secret, 'example.test', 'https'),
+            null,
+            new UserAgent(),
+        );
+
+        Services::injectMock('request', $request);
+
+        try {
+            $report = $this->extractCopyableErrorReport($this->renderHtmlException(new RuntimeException('Query test.')));
+
+            $this->assertStringContainsString('- Path: /orders', $report);
+            $this->assertStringContainsString('- URL: https://example.test/orders', $report);
+            $this->assertStringNotContainsString($secret, $report);
+            $this->assertStringNotContainsString($token, $report);
+        } finally {
+            $this->resetServices();
+        }
     }
 
     public function testHandleWebPageNotFoundExceptionDoNotAcceptHTML(): void
@@ -139,6 +202,27 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('<title>404 - Page Not Found</title>', (string) $output);
+    }
+
+    public function testHandleWebRuntimeExceptionAcceptHTMLIncludesCopyErrorReport(): void
+    {
+        $output = $this->renderHtmlException(new RuntimeException('Something went wrong.'));
+        $report = $this->extractCopyableErrorReport($output);
+
+        $this->assertStringContainsString('Copy Details', $output);
+        $this->assertStringContainsString('# Something went wrong.', $report);
+
+        foreach (['## Exception', '## Environment', '## Request', '## Source', '## Stack Trace'] as $section) {
+            $this->assertStringContainsString($section, $report);
+        }
+    }
+
+    public function testHandleWebRuntimeExceptionEscapesCopyErrorReport(): void
+    {
+        $output = $this->renderHtmlException(new RuntimeException('</textarea><script>alert(1)</script>'));
+
+        $this->assertStringNotContainsString('</textarea><script>alert(1)</script>', $output);
+        $this->assertStringContainsString('&lt;/textarea&gt;&lt;script&gt;alert(1)&lt;/script&gt;', $output);
     }
 
     public function testHandleCLIPageNotFoundException(): void
@@ -384,5 +468,36 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         $this->assertTrue($sanitizeData(true));
         $this->assertFalse($sanitizeData(false));
         $this->assertNull($sanitizeData(null));
+    }
+
+    private function createExceptionWithSensitiveTraceArgument(): RuntimeException
+    {
+        return new RuntimeException('Trace argument test.');
+    }
+
+    private function extractCopyableErrorReport(string $output): string
+    {
+        $this->assertSame(1, preg_match('#<textarea[^>]*>\K.*?(?=</textarea>)#s', $output, $matches));
+
+        return html_entity_decode($matches[0], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    private function renderHtmlException(RuntimeException $exception): string
+    {
+        $this->backupIniValues([
+            'highlight.comment', 'highlight.default', 'highlight.html', 'highlight.keyword', 'highlight.string',
+        ]);
+
+        $render = self::getPrivateMethodInvoker($this->handler, 'render');
+
+        ob_start();
+
+        try {
+            $render($exception, 500, APPPATH . 'Views/errors/html/error_exception.php');
+
+            return ob_get_clean();
+        } finally {
+            $this->restoreIniValues();
+        }
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -234,6 +234,11 @@ Others
 - Added ``$db->getLastException()`` which returns the typed exception even when ``DBDebug`` is ``false``. See :ref:`database-get-last-exception`.
 - Added ``DatabaseException::getDatabaseCode()`` returning the native driver error code as ``int|string``; ``getCode()`` is constrained to ``int`` by PHP's ``Throwable`` interface and cannot carry string SQLSTATE codes.
 
+Debug
+=====
+
+- Added a **Copy Details** button to detailed HTML exception pages.
+
 Model
 =====
 

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -76,6 +76,18 @@ Config
 - app/Config/Mimes.php
     - ``Config\Mimes::$mimes`` added a new key ``md`` for Markdown files.
 
+Error Views
+-----------
+
+- app/Views/errors/html/debug.css
+    - Added styles for the **Copy Details** button.
+- app/Views/errors/html/debug.js
+    - Added clipboard handling for the **Copy Details** button.
+- app/Views/errors/html/error_exception.php
+    - Added a **Copy Details** button to detailed HTML exception pages.
+- app/Views/errors/html/error_report.php
+    - Added a Markdown error report partial used by the **Copy Details** button.
+
 All Changes
 ===========
 


### PR DESCRIPTION
**Description**

This PR proposes adding a **Copy Details** button to CodeIgniter’s detailed HTML exception page.

The goal is to make debugging information easier to share from the local development error page. Instead of manually gathering the relevant debugging information, users can copy a Markdown-formatted report with one click and paste it into an issue, discussion, chat, LLM or anywhere else they need.

https://github.com/user-attachments/assets/b9e5b1aa-85b5-402a-ac59-413c1dac796f

The copied report includes the most useful debugging context:

- Exception type, status code, status text, and message
- PHP, CodeIgniter, environment, SAPI, timestamp, and memory usage
- Request method, path, safe URL without query string, and user agent
- Source file location and nearby source lines
- Previous exceptions, when available
- Stack trace

The report intentionally avoids riskful or sensitive request data. It does **NOT** include headers, cookies, query strings, request body data, session data, route params, database queries, or trace arguments.

Implementation wise, the Markdown report is rendered by a small `error_report.php` partial used by the detailed HTML error view. The button uses the Clipboard API when available and falls back to a textarea-based copy path when needed.

Tests cover rendering the button, escaping the hidden report content, including previous exceptions, and omitting sensitive request data, trace arguments, and query strings from copied output.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide