### PR TITLE
feat: add Fetch Metadata CSRF protection

### DIFF
--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -24,17 +24,17 @@ class Security extends BaseConfig
      *
      * Whether to use Fetch Metadata request headers as a first-line CSRF check.
      */
-    public bool $csrfUseFetchMetadata = true;
+    public bool $csrfFetchMetadata = true;
 
     /**
      * --------------------------------------------------------------------------
-     * CSRF Allow Same Site
+     * CSRF Fetch Metadata Reject Same Site
      * --------------------------------------------------------------------------
      *
-     * Whether requests with the Sec-Fetch-Site: same-site header should pass
-     * Fetch Metadata verification.
+     * Whether requests with the Sec-Fetch-Site: same-site header should be
+     * rejected instead of falling back to token verification.
      */
-    public bool $csrfAllowSameSite = false;
+    public bool $csrfFetchMetadataRejectSameSite = false;
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -19,6 +19,25 @@ class Security extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
+     * CSRF Fetch Metadata
+     * --------------------------------------------------------------------------
+     *
+     * Whether to use Fetch Metadata request headers as a first-line CSRF check.
+     */
+    public bool $csrfUseFetchMetadata = true;
+
+    /**
+     * --------------------------------------------------------------------------
+     * CSRF Allow Same Site
+     * --------------------------------------------------------------------------
+     *
+     * Whether requests with the Sec-Fetch-Site: same-site header should pass
+     * Fetch Metadata verification.
+     */
+    public bool $csrfAllowSameSite = false;
+
+    /**
+     * --------------------------------------------------------------------------
      * CSRF Token Randomization
      * --------------------------------------------------------------------------
      *

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -20,7 +20,6 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Security\Security;
-use Config\Security as SecurityConfig;
 
 /**
  * CSRF filter.
@@ -55,17 +54,17 @@ class CSRF implements FilterInterface
         } catch (SecurityException $e) {
             if ($security->shouldRedirect() && ! $request->isAJAX()) {
                 $response = redirect()->back()->with('error', $e->getMessage());
-                $this->addFetchMetadataVaryHeader($request, $response);
+                $this->addFetchMetadataVaryHeader($request, $response, $security);
 
                 return $response;
             }
 
-            $this->addFetchMetadataVaryHeader($request, service('response'));
+            $this->addFetchMetadataVaryHeader($request, service('response'), $security);
 
             throw $e;
         }
 
-        $this->addFetchMetadataVaryHeader($request, service('response'));
+        $this->addFetchMetadataVaryHeader($request, service('response'), $security);
 
         return null;
     }
@@ -80,13 +79,11 @@ class CSRF implements FilterInterface
         return null;
     }
 
-    private function addFetchMetadataVaryHeader(IncomingRequest $request, ResponseInterface $response): void
+    private function addFetchMetadataVaryHeader(IncomingRequest $request, ResponseInterface $response, Security $security): void
     {
-        $config           = config(SecurityConfig::class);
-        $useFetchMetadata = ($config->csrfUseFetchMetadata ?? false) === true; // @phpstan-ignore nullCoalesce.property
-        $isUnsafeMethod   = in_array($request->getMethod(), [Method::POST, Method::PUT, Method::DELETE, Method::PATCH], true);
+        $isUnsafeMethod = in_array($request->getMethod(), [Method::POST, Method::PUT, Method::DELETE, Method::PATCH], true);
 
-        if ($useFetchMetadata && $isUnsafeMethod) {
+        if ($security->shouldUseFetchMetadata() && $isUnsafeMethod) {
             $response->appendHeader('Vary', 'Sec-Fetch-Site');
         }
     }

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Security\Security;
+use Config\Security as SecurityConfig;
 
 /**
  * CSRF filter.
@@ -52,11 +54,18 @@ class CSRF implements FilterInterface
             $security->verify($request);
         } catch (SecurityException $e) {
             if ($security->shouldRedirect() && ! $request->isAJAX()) {
-                return redirect()->back()->with('error', $e->getMessage());
+                $response = redirect()->back()->with('error', $e->getMessage());
+                $this->addFetchMetadataVaryHeader($request, $response);
+
+                return $response;
             }
+
+            $this->addFetchMetadataVaryHeader($request, service('response'));
 
             throw $e;
         }
+
+        $this->addFetchMetadataVaryHeader($request, service('response'));
 
         return null;
     }
@@ -69,5 +78,16 @@ class CSRF implements FilterInterface
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
         return null;
+    }
+
+    private function addFetchMetadataVaryHeader(IncomingRequest $request, ResponseInterface $response): void
+    {
+        $config           = get_object_vars(config(SecurityConfig::class));
+        $useFetchMetadata = ($config['csrfUseFetchMetadata'] ?? false) === true;
+        $isUnsafeMethod   = in_array($request->getMethod(), [Method::POST, Method::PUT, Method::DELETE, Method::PATCH], true);
+
+        if ($useFetchMetadata && $isUnsafeMethod) {
+            $response->appendHeader('Vary', 'Sec-Fetch-Site');
+        }
     }
 }

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -82,8 +82,8 @@ class CSRF implements FilterInterface
 
     private function addFetchMetadataVaryHeader(IncomingRequest $request, ResponseInterface $response): void
     {
-        $config           = get_object_vars(config(SecurityConfig::class));
-        $useFetchMetadata = ($config['csrfUseFetchMetadata'] ?? false) === true;
+        $config           = config(SecurityConfig::class);
+        $useFetchMetadata = ($config->csrfUseFetchMetadata ?? false) === true; // @phpstan-ignore nullCoalesce.property
         $isUnsafeMethod   = in_array($request->getMethod(), [Method::POST, Method::PUT, Method::DELETE, Method::PATCH], true);
 
         if ($useFetchMetadata && $isUnsafeMethod) {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -256,9 +256,7 @@ class Security implements SecurityInterface
      */
     private function fetchMetadataDecision(IncomingRequest $request): string
     {
-        $config = get_object_vars($this->config);
-
-        if (($config['csrfUseFetchMetadata'] ?? false) !== true) {
+        if (! ($this->config->csrfUseFetchMetadata ?? false)) { // @phpstan-ignore nullCoalesce.initializedProperty
             return self::FETCH_METADATA_FALLBACK;
         }
 
@@ -273,7 +271,7 @@ class Security implements SecurityInterface
         }
 
         if ($fetchSite === 'same-site') {
-            return ($config['csrfAllowSameSite'] ?? false) === true
+            return $this->config->csrfAllowSameSite ?? false // @phpstan-ignore nullCoalesce.initializedProperty
                 ? self::FETCH_METADATA_ALLOW
                 : self::FETCH_METADATA_REJECT;
         }

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -192,6 +192,11 @@ class Security implements SecurityInterface
         return $this->config->redirect;
     }
 
+    public function shouldUseFetchMetadata(): bool
+    {
+        return $this->config->csrfFetchMetadata ?? false; // @phpstan-ignore nullCoalesce.initializedProperty
+    }
+
     /**
      * @phpstan-assert string $this->hash
      */
@@ -256,7 +261,7 @@ class Security implements SecurityInterface
      */
     private function fetchMetadataDecision(IncomingRequest $request): string
     {
-        if (! ($this->config->csrfUseFetchMetadata ?? false)) { // @phpstan-ignore nullCoalesce.initializedProperty
+        if (! $this->shouldUseFetchMetadata()) {
             return self::FETCH_METADATA_FALLBACK;
         }
 
@@ -271,9 +276,9 @@ class Security implements SecurityInterface
         }
 
         if ($fetchSite === 'same-site') {
-            return $this->config->csrfAllowSameSite ?? false // @phpstan-ignore nullCoalesce.initializedProperty
-                ? self::FETCH_METADATA_ALLOW
-                : self::FETCH_METADATA_REJECT;
+            return ($this->config->csrfFetchMetadataRejectSameSite ?? false) // @phpstan-ignore nullCoalesce.initializedProperty
+                ? self::FETCH_METADATA_REJECT
+                : self::FETCH_METADATA_FALLBACK;
         }
 
         return self::FETCH_METADATA_FALLBACK;

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -35,8 +35,11 @@ use SensitiveParameter;
  */
 class Security implements SecurityInterface
 {
-    public const CSRF_PROTECTION_COOKIE  = 'cookie';
-    public const CSRF_PROTECTION_SESSION = 'session';
+    public const CSRF_PROTECTION_COOKIE   = 'cookie';
+    public const CSRF_PROTECTION_SESSION  = 'session';
+    private const FETCH_METADATA_ALLOW    = 'allow';
+    private const FETCH_METADATA_FALLBACK = 'fallback';
+    private const FETCH_METADATA_REJECT   = 'reject';
 
     /**
      * CSRF hash length in bytes.
@@ -118,6 +121,27 @@ class Security implements SecurityInterface
 
         assert($request instanceof IncomingRequest);
 
+        $decision = $this->fetchMetadataDecision($request);
+
+        if ($decision === self::FETCH_METADATA_ALLOW) {
+            $this->removeTokenInRequest($request);
+
+            log_message('info', 'CSRF Fetch Metadata verified.');
+
+            return $this;
+        }
+
+        if ($decision === self::FETCH_METADATA_REJECT) {
+            throw SecurityException::forDisallowedAction();
+        }
+
+        $this->verifyToken($request);
+
+        return $this;
+    }
+
+    private function verifyToken(IncomingRequest $request): void
+    {
         $postedToken = $this->getPostedToken($request);
 
         try {
@@ -139,8 +163,6 @@ class Security implements SecurityInterface
         }
 
         log_message('info', 'CSRF token verified.');
-
-        return $this;
     }
 
     public function getHash(): ?string
@@ -230,6 +252,36 @@ class Security implements SecurityInterface
     }
 
     /**
+     * @return self::FETCH_METADATA_*
+     */
+    private function fetchMetadataDecision(IncomingRequest $request): string
+    {
+        $config = get_object_vars($this->config);
+
+        if (($config['csrfUseFetchMetadata'] ?? false) !== true) {
+            return self::FETCH_METADATA_FALLBACK;
+        }
+
+        $fetchSite = strtolower($request->getHeaderLine('Sec-Fetch-Site'));
+
+        if ($fetchSite === 'same-origin') {
+            return self::FETCH_METADATA_ALLOW;
+        }
+
+        if ($fetchSite === 'cross-site') {
+            return self::FETCH_METADATA_REJECT;
+        }
+
+        if ($fetchSite === 'same-site') {
+            return ($config['csrfAllowSameSite'] ?? false) === true
+                ? self::FETCH_METADATA_ALLOW
+                : self::FETCH_METADATA_REJECT;
+        }
+
+        return self::FETCH_METADATA_FALLBACK;
+    }
+
+    /**
      * @phpstan-assert SessionInterface $this->session
      */
     private function configureSession(): void
@@ -284,6 +336,10 @@ class Security implements SecurityInterface
 
         // If the token is found in form-encoded data, we can safely remove it.
         parse_str($body, $result);
+
+        if (! array_key_exists($tokenName, $result)) {
+            return;
+        }
 
         unset($result[$tokenName]);
         $request->setBody(http_build_query($result));

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -14,12 +14,14 @@ declare(strict_types=1);
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\Factories;
+use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;
@@ -144,16 +146,16 @@ final class CSRFTest extends CIUnitTestCase
         }
     }
 
-    public function testBeforeDoesNotAddVaryHeaderForTokenVerification(): void
+    public function testBeforeUsesSecurityServiceConfigForVaryHeader(): void
     {
         service('superglobals')
             ->setServer('REQUEST_METHOD', 'POST')
             ->setPost('csrf_test_name', '8b9218a55906f9dcc1dc263dce7f005a')
             ->setCookie('csrf_cookie_name', '8b9218a55906f9dcc1dc263dce7f005a');
 
-        $config                       = new SecurityConfig();
-        $config->csrfUseFetchMetadata = false;
-        Factories::injectMock('config', 'Security', $config);
+        $config                    = new SecurityConfig();
+        $config->csrfFetchMetadata = false;
+        Services::injectMock('security', new MockSecurity($config));
 
         $filter  = new CSRF();
         $request = single_service('incomingrequest', null)

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -13,10 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
+use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Security as SecurityConfig;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -35,6 +39,14 @@ final class CSRFTest extends CIUnitTestCase
     {
         parent::setUp();
         $this->config = new \Config\Filters();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->resetServices();
+        Factories::reset('config');
     }
 
     public function testDoNotCheckCliRequest(): void
@@ -72,5 +84,84 @@ final class CSRFTest extends CIUnitTestCase
 
         // GET request is not protected, so no SecurityException will be thrown.
         $this->assertSame($this->request, $request);
+    }
+
+    public function testBeforeAddsVaryHeaderForFetchMetadataVerification(): void
+    {
+        $filter  = new CSRF();
+        $request = single_service('incomingrequest', null)
+            ->withMethod('POST')
+            ->setHeader('Sec-Fetch-Site', 'same-origin');
+
+        $filter->before($request);
+
+        $this->assertSame('Sec-Fetch-Site', service('response')->getHeaderLine('Vary'));
+    }
+
+    public function testBeforeAppendsVaryHeaderForFetchMetadataVerification(): void
+    {
+        $filter  = new CSRF();
+        $request = single_service('incomingrequest', null)
+            ->withMethod('POST')
+            ->setHeader('Sec-Fetch-Site', 'same-origin');
+        service('response')->setHeader('Vary', 'Accept-Language');
+
+        $filter->before($request);
+
+        $this->assertSame('Accept-Language, Sec-Fetch-Site', service('response')->getHeaderLine('Vary'));
+    }
+
+    public function testBeforeAddsVaryHeaderToRedirectResponseForFetchMetadataVerification(): void
+    {
+        $config           = new SecurityConfig();
+        $config->redirect = true;
+        Factories::injectMock('config', 'Security', $config);
+
+        $filter  = new CSRF();
+        $request = single_service('incomingrequest', null)
+            ->withMethod('POST')
+            ->setHeader('Sec-Fetch-Site', 'cross-site');
+
+        $response = $filter->before($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('Sec-Fetch-Site', $response->getHeaderLine('Vary'));
+    }
+
+    public function testBeforeThrowsExceptionForRejectedFetchMetadataVerification(): void
+    {
+        $filter  = new CSRF();
+        $request = single_service('incomingrequest', null)
+            ->withMethod('POST')
+            ->setHeader('Sec-Fetch-Site', 'cross-site');
+
+        try {
+            $filter->before($request);
+
+            $this->fail('Expected SecurityException was not thrown.');
+        } catch (SecurityException) {
+            $this->assertSame('Sec-Fetch-Site', service('response')->getHeaderLine('Vary'));
+        }
+    }
+
+    public function testBeforeDoesNotAddVaryHeaderForTokenVerification(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', '8b9218a55906f9dcc1dc263dce7f005a')
+            ->setCookie('csrf_cookie_name', '8b9218a55906f9dcc1dc263dce7f005a');
+
+        $config                       = new SecurityConfig();
+        $config->csrfUseFetchMetadata = false;
+        Factories::injectMock('config', 'Security', $config);
+
+        $filter  = new CSRF();
+        $request = single_service('incomingrequest', null)
+            ->withMethod('POST')
+            ->setHeader('Sec-Fetch-Site', 'same-origin');
+
+        $filter->before($request);
+
+        $this->assertSame('', service('response')->getHeaderLine('Vary'));
     }
 }

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -100,6 +100,22 @@ final class CSRFTest extends CIUnitTestCase
         $this->assertSame('Sec-Fetch-Site', service('response')->getHeaderLine('Vary'));
     }
 
+    public function testBeforeAddsVaryHeaderWhenFetchMetadataFallsBackToToken(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', '8b9218a55906f9dcc1dc263dce7f005a')
+            ->setCookie('csrf_cookie_name', '8b9218a55906f9dcc1dc263dce7f005a');
+
+        $filter  = new CSRF();
+        $request = single_service('incomingrequest', null)
+            ->withMethod('POST');
+
+        $filter->before($request);
+
+        $this->assertSame('Sec-Fetch-Site', service('response')->getHeaderLine('Vary'));
+    }
+
     public function testBeforeAppendsVaryHeaderForFetchMetadataVerification(): void
     {
         $filter  = new CSRF();

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -281,7 +281,7 @@ final class SecurityTest extends CIUnitTestCase
         $this->assertSame('<payload><value>unchanged</value></payload>', $request->getBody());
     }
 
-    public function testCsrfVerifyFetchMetadataSameSiteThrowsExceptionByDefault(): void
+    public function testCsrfVerifyFetchMetadataSameSiteFallsBackToTokenByDefault(): void
     {
         service('superglobals')
             ->setServer('REQUEST_METHOD', 'POST')
@@ -291,20 +291,54 @@ final class SecurityTest extends CIUnitTestCase
         $security = $this->createMockSecurity();
         $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-site');
 
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+    }
+
+    #[DataProvider('provideCsrfVerifyFetchMetadataSameSiteFallsBackToTokenFailureByDefault')]
+    public function testCsrfVerifyFetchMetadataSameSiteFallsBackToTokenFailureByDefault(?string $token, ?string $cookie): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+
+        if ($token !== null) {
+            service('superglobals')->setPost('csrf_test_name', $token);
+        }
+
+        if ($cookie !== null) {
+            service('superglobals')->setCookie('csrf_cookie_name', $cookie);
+        }
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-site');
+
         $this->expectException(SecurityException::class);
         $security->verify($request);
     }
 
-    public function testCsrfVerifyFetchMetadataSameSiteReturnsSelfWhenAllowed(): void
+    /**
+     * @return iterable<string, array{string|null, string|null}>
+     */
+    public static function provideCsrfVerifyFetchMetadataSameSiteFallsBackToTokenFailureByDefault(): iterable
     {
-        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+        yield 'missing' => [null, null];
 
-        $config                    = new SecurityConfig();
-        $config->csrfAllowSameSite = true;
-        $security                  = $this->createMockSecurity($config);
-        $request                   = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-site');
+        yield 'invalid' => [self::INVALID_CSRF_HASH, self::CORRECT_CSRF_HASH];
+    }
 
-        $this->assertInstanceOf(Security::class, $security->verify($request));
+    public function testCsrfVerifyFetchMetadataSameSiteThrowsExceptionWhenRejected(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $config                                  = new SecurityConfig();
+        $config->csrfFetchMetadataRejectSameSite = true;
+        $security                                = $this->createMockSecurity($config);
+        $request                                 = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-site');
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
     }
 
     public function testCsrfVerifyFetchMetadataCrossSiteThrowsExceptionEvenWithValidToken(): void
@@ -359,10 +393,10 @@ final class SecurityTest extends CIUnitTestCase
             ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
             ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
 
-        $config                       = new SecurityConfig();
-        $config->csrfUseFetchMetadata = false;
-        $security                     = $this->createMockSecurity($config);
-        $request                      = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'cross-site');
+        $config                    = new SecurityConfig();
+        $config->csrfFetchMetadata = false;
+        $security                  = $this->createMockSecurity($config);
+        $request                   = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'cross-site');
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
         $this->assertLogged('info', 'CSRF token verified.');
@@ -376,7 +410,7 @@ final class SecurityTest extends CIUnitTestCase
             ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
 
         $config = new SecurityConfig();
-        unset($config->csrfUseFetchMetadata);
+        unset($config->csrfFetchMetadata);
 
         $security = $this->createMockSecurity($config);
         $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'cross-site');

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -237,6 +237,154 @@ final class SecurityTest extends CIUnitTestCase
         $this->assertSame('{"foo":"bar"}', $request->getBody());
     }
 
+    public function testCsrfVerifyFetchMetadataSameOriginReturnsSelf(): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-origin');
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF Fetch Metadata verified.');
+    }
+
+    public function testCsrfVerifyFetchMetadataRemovesTokenButDoesNotRegenerate(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('foo', 'bar')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-origin');
+
+        $oldHash = $security->getHash();
+        $security->verify($request);
+        $newHash = $security->getHash();
+
+        $this->assertSame($oldHash, $newHash);
+        $this->assertSame(['foo' => 'bar'], service('superglobals')->getPostArray());
+    }
+
+    public function testCsrfVerifyFetchMetadataPreservesRawBodyWithoutToken(): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest()
+            ->setHeader('Sec-Fetch-Site', 'same-origin')
+            ->setBody('<payload><value>unchanged</value></payload>');
+
+        $security->verify($request);
+
+        $this->assertSame('<payload><value>unchanged</value></payload>', $request->getBody());
+    }
+
+    public function testCsrfVerifyFetchMetadataSameSiteThrowsExceptionByDefault(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-site');
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    public function testCsrfVerifyFetchMetadataSameSiteReturnsSelfWhenAllowed(): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', 'POST');
+
+        $config                    = new SecurityConfig();
+        $config->csrfAllowSameSite = true;
+        $security                  = $this->createMockSecurity($config);
+        $request                   = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'same-site');
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+    }
+
+    public function testCsrfVerifyFetchMetadataCrossSiteThrowsExceptionEvenWithValidToken(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'cross-site');
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    #[DataProvider('provideCsrfVerifyFetchMetadataFallsBackToToken')]
+    public function testCsrfVerifyFetchMetadataFallsBackToToken(?string $fetchSite): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        if ($fetchSite !== null) {
+            $request->setHeader('Sec-Fetch-Site', $fetchSite);
+        }
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+    }
+
+    /**
+     * @return iterable<string, array{string|null}>
+     */
+    public static function provideCsrfVerifyFetchMetadataFallsBackToToken(): iterable
+    {
+        yield 'missing' => [null];
+
+        yield 'none' => ['none'];
+
+        yield 'unknown' => ['future-value'];
+    }
+
+    public function testCsrfVerifyTokenOnlyIgnoresFetchMetadata(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $config                       = new SecurityConfig();
+        $config->csrfUseFetchMetadata = false;
+        $security                     = $this->createMockSecurity($config);
+        $request                      = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'cross-site');
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+    }
+
+    public function testCsrfVerifyMissingFetchMetadataConfigFallsBackToTokenOnly(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', self::CORRECT_CSRF_HASH)
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $config = new SecurityConfig();
+        unset($config->csrfUseFetchMetadata);
+
+        $security = $this->createMockSecurity($config);
+        $request  = $this->createIncomingRequest()->setHeader('Sec-Fetch-Site', 'cross-site');
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+    }
+
     public function testCsrfVerifyPutBodyThrowsExceptionOnNoMatch(): void
     {
         service('superglobals')

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -248,6 +248,7 @@ Libraries
 - **Locks:** Added :doc:`Atomic Locks </libraries/locks>` for owner-aware, cross-process mutual exclusion backed by supported cache handlers: **File**, **Redis**, **Predis**, and **Memcached**. Memcached support has driver-specific release limitations because Memcached has no atomic compare-and-delete command.
 - **Logging:** Log handlers now receive the full context array as a third argument to ``handle()``. When ``$logGlobalContext`` is enabled, the CI global context is available under the ``HandlerInterface::GLOBAL_CONTEXT_KEY`` key. Built-in handlers append it to the log output; custom handlers can use it for structured logging.
 - **Logging:** Added :ref:`per-call context logging <logging-per-call-context>` with three new ``Config\Logger`` options (``$logContext``, ``$logContextTrace``, ``$logContextUsedKeys``). Per PSR-3, a ``Throwable`` in the ``exception`` context key is automatically normalized to a meaningful array. All options default to ``false``.
+- **Security:** Added :ref:`Fetch Metadata based CSRF protection <csrf-fetch-metadata>` with token fallback.
 
 Helpers and Functions
 =====================

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -76,7 +76,7 @@ Config
 - app/Config/Mimes.php
     - ``Config\Mimes::$mimes`` added a new key ``md`` for Markdown files.
 - app/Config/Security.php
-    - ``Config\Security::$csrfUseFetchMetadata`` and ``Config\Security::$csrfAllowSameSite`` were added for Fetch Metadata based CSRF protection.
+    - ``Config\Security::$csrfFetchMetadata`` and ``Config\Security::$csrfFetchMetadataRejectSameSite`` were added for Fetch Metadata based CSRF protection.
 
 All Changes
 ===========

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -75,6 +75,8 @@ Config
 
 - app/Config/Mimes.php
     - ``Config\Mimes::$mimes`` added a new key ``md`` for Markdown files.
+- app/Config/Security.php
+    - ``Config\Security::$csrfUseFetchMetadata`` and ``Config\Security::$csrfAllowSameSite`` were added for Fetch Metadata based CSRF protection.
 
 All Changes
 ===========

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -89,6 +89,47 @@ You can set to use the Session based CSRF protection by editing the following co
 
 .. literalinclude:: security/002.php
 
+.. _csrf-fetch-metadata:
+
+Fetch Metadata CSRF Protection
+------------------------------
+
+.. versionadded:: 4.8.0
+
+CodeIgniter can use Fetch Metadata request headers as a first-line CSRF check for unsafe browser requests.
+Fetch Metadata is a browser-supplied signal that helps the framework allow same-origin requests and reject
+cross-site requests before checking the CSRF token.
+
+When CSRF protection is enabled, new applications use Fetch Metadata first by default. You can configure
+this behavior in **app/Config/Security.php**:
+
+.. literalinclude:: security/011.php
+
+When it is enabled, unsafe requests with ``Sec-Fetch-Site: same-origin`` are allowed without a token.
+Requests with ``Sec-Fetch-Site: cross-site`` are rejected. Requests with a missing ``Sec-Fetch-Site`` header,
+``Sec-Fetch-Site: none``, or an unknown value fall back to token verification. This keeps protection working
+for browsers or clients that do not send Fetch Metadata headers. Requests with ``Sec-Fetch-Site: same-site``
+are rejected unless same-site requests are explicitly allowed.
+
+Upgraded applications without this config value continue to use token verification. You may also disable
+Fetch Metadata protection by setting ``$csrfUseFetchMetadata`` to ``false``.
+
+When an unsafe request passes with Fetch Metadata, the CSRF token is not regenerated. Token regeneration only
+runs when token verification is used.
+
+.. warning:: Fetch Metadata protects browser-based requests. Browsers only send these headers for
+    potentially trustworthy URLs, and non-browser clients can send their own headers. It is not API
+    authentication.
+
+.. warning:: Same-site is not the same as same-origin, because sibling subdomains are considered same-site.
+    Same-site requests are rejected by default. If all same-site origins are trusted, you may allow them
+    in **app/Config/Security.php**:
+
+    .. literalinclude:: security/012.php
+
+If your application receives legitimate cross-origin POST requests, such as webhooks, callbacks, or
+OAuth/SAML responses, use :ref:`CSRF route exclusions <csrf-exclude-uris>` and verify those routes another way.
+
 Token Randomization
 -------------------
 
@@ -161,6 +202,8 @@ You can enable CSRF protection by altering your **app/Config/Filters.php**
 and enabling the `csrf` filter globally:
 
 .. literalinclude:: security/006.php
+
+.. _csrf-exclude-uris:
 
 Select URIs can be whitelisted from CSRF protection (for example API
 endpoints expecting externally POSTed content). You can add these URIs

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -105,7 +105,8 @@ this behavior in **app/Config/Security.php**:
 
 .. literalinclude:: security/011.php
 
-When it is enabled, unsafe requests with ``Sec-Fetch-Site: same-origin`` are allowed without a token.
+When it is enabled, requests using unsafe HTTP methods with ``Sec-Fetch-Site: same-origin`` are allowed
+without a token.
 Requests with ``Sec-Fetch-Site: cross-site`` are rejected. Requests with a missing ``Sec-Fetch-Site`` header,
 ``Sec-Fetch-Site: none``, or an unknown value fall back to token verification. This keeps protection working
 for browsers or clients that do not send Fetch Metadata headers. Requests with ``Sec-Fetch-Site: same-site``

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -109,10 +109,10 @@ When it is enabled, unsafe requests with ``Sec-Fetch-Site: same-origin`` are all
 Requests with ``Sec-Fetch-Site: cross-site`` are rejected. Requests with a missing ``Sec-Fetch-Site`` header,
 ``Sec-Fetch-Site: none``, or an unknown value fall back to token verification. This keeps protection working
 for browsers or clients that do not send Fetch Metadata headers. Requests with ``Sec-Fetch-Site: same-site``
-are rejected unless same-site requests are explicitly allowed.
+also fall back to token verification by default.
 
 Upgraded applications without this config value continue to use token verification. You may also disable
-Fetch Metadata protection by setting ``$csrfUseFetchMetadata`` to ``false``.
+Fetch Metadata protection by setting ``$csrfFetchMetadata`` to ``false``.
 
 When an unsafe request passes with Fetch Metadata, the CSRF token is not regenerated. Token regeneration only
 runs when token verification is used.
@@ -122,8 +122,8 @@ runs when token verification is used.
     authentication.
 
 .. warning:: Same-site is not the same as same-origin, because sibling subdomains are considered same-site.
-    Same-site requests are rejected by default. If all same-site origins are trusted, you may allow them
-    in **app/Config/Security.php**:
+    Same-site requests fall back to token verification by default. If sibling subdomains are not trusted,
+    you may reject same-site requests before token verification in **app/Config/Security.php**:
 
     .. literalinclude:: security/012.php
 

--- a/user_guide_src/source/libraries/security/011.php
+++ b/user_guide_src/source/libraries/security/011.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class Security extends BaseConfig
+{
+    public bool $csrfUseFetchMetadata = true;
+
+    // ...
+}

--- a/user_guide_src/source/libraries/security/011.php
+++ b/user_guide_src/source/libraries/security/011.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 
 class Security extends BaseConfig
 {
-    public bool $csrfUseFetchMetadata = true;
+    public bool $csrfFetchMetadata = true;
 
     // ...
 }

--- a/user_guide_src/source/libraries/security/012.php
+++ b/user_guide_src/source/libraries/security/012.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class Security extends BaseConfig
+{
+    public bool $csrfAllowSameSite = true;
+
+    // ...
+}

--- a/user_guide_src/source/libraries/security/012.php
+++ b/user_guide_src/source/libraries/security/012.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 
 class Security extends BaseConfig
 {
-    public bool $csrfAllowSameSite = true;
+    public bool $csrfFetchMetadataRejectSameSite = true;
 
     // ...
 }


### PR DESCRIPTION
**Description**

This PR proposes adding Fetch Metadata-based CSRF protection to CodeIgniter.

CSRF tokens work, and this PR keeps them as the compatibility fallback. But the web platform and modern frameworks are clearly moving toward browser-provided request context as the better default for browser CSRF protection. Other frameworks have already moved in this direction, or have active work around the same idea, and OWASP documents Fetch Metadata as a defense-in-depth layer for CSRF protection.

The reason is pretty simple: token-based CSRF protection has always been awkward and a source of headaches for many developers. Forms need hidden fields, JavaScript requests need special headers, JSON requests need special handling, cached pages and long-lived tabs can produce stale-token failures, token regeneration can surprise users, and teams regularly end up debugging "why did this normal request fail?" instead of working on the application.

Fetch Metadata gives the framework a cleaner browser-native signal. Modern browsers send the `Sec-Fetch-Site` header, which tells the server whether an unsafe request came from the same origin, the same site, or another site. That lets CodeIgniter ask a simpler question before touching token verification:

> Is this unsafe browser request clearly coming from this application?

If yes, same-origin browser requests can pass without token plumbing. If it is clearly cross-site, it can be rejected before token verification. If the browser does not provide enough information, CodeIgniter falls back to the existing token check.

This keeps the change conservative while still moving new applications in the right direction:

- New applications use Fetch Metadata first, with token fallback.
- Upgraded applications without the new config value continue using token-only verification.
- Missing, `none`, unknown, or `same-site` `Sec-Fetch-Site` values fall back to token verification.
- `cross-site` requests are rejected before token verification.
- Apps can opt back into token-only behavior with `$csrfFetchMetadata = false`.
- Apps that do not trust sibling subdomains can reject `same-site` requests before token verification with `$csrfFetchMetadataRejectSameSite = true`.

```php
public bool $csrfFetchMetadata = true;
public bool $csrfFetchMetadataRejectSameSite = false;
```

With Fetch Metadata enabled:

- `Sec-Fetch-Site: same-origin` passes without a token.
- `Sec-Fetch-Site: cross-site` is rejected.
- `Sec-Fetch-Site: same-site` falls back to token verification by default.
- Missing, `none`, or unknown values fall back to token verification.

So this PR does not remove CSRF tokens. They remain supported and useful as the migration fallback, especially for upgraded applications. But the direction is intentional: new CodeIgniter applications should get a more modern, browser-native CSRF protection path by default, and token-heavy CSRF handling can gradually become the legacy compatibility path rather than the everyday developer experience.

The CSRF filter also adds `Vary: Sec-Fetch-Site` to normal shared responses, CSRF redirect responses, and CSRF exception responses for unsafe requests when Fetch Metadata protection is enabled, so caches do not mix responses across request contexts.

Tests cover same-origin, same-site, cross-site, token fallback, token-only compatibility, upgraded config compatibility, redirect responses, `Vary` behavior, and request body preservation.

**References**

- MDN Fetch Metadata guide: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Fetch_metadata
- MDN `Sec-Fetch-Site`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site
- W3C Fetch Metadata Request Headers: https://www.w3.org/TR/fetch-metadata/
- OWASP CSRF Cheat Sheet, Fetch Metadata section: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#fetch-metadata-headers
- Browser support: https://caniuse.com/mdn-http_headers_sec-fetch-site
- A Modern Approach to Preventing CSRF in Go: https://www.alexedwards.net/blog/preventing-csrf-in-go

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide