### PR TITLE
feat: support object values in array dot helpers

### DIFF
--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -469,7 +469,7 @@ final class ArrayHelper
             return isset($data[$key]);
         }
 
-        $array = self::objectToArray($data);
+        $array = self::entityToArray($data);
 
         if ($array !== null) {
             return isset($array[$key]);
@@ -495,7 +495,7 @@ final class ArrayHelper
             return $data[$key];
         }
 
-        $array = self::objectToArray($data);
+        $array = self::entityToArray($data);
 
         if ($array !== null) {
             return $array[$key];
@@ -517,7 +517,7 @@ final class ArrayHelper
     /**
      * @return array<array-key, mixed>|null
      */
-    private static function objectToArray(object $data): ?array
+    private static function entityToArray(object $data): ?array
     {
         if ($data instanceof Entity) {
             return $data->toArray();
@@ -537,14 +537,14 @@ final class ArrayHelper
      */
     private static function toIterable(object $data): array
     {
-        $array = self::objectToArray($data);
+        $array = self::entityToArray($data);
 
         if ($array !== null) {
             return $array;
         }
 
         if ($data instanceof Traversable) {
-            return iterator_to_array($data);
+            return iterator_to_array($data, false);
         }
 
         return get_object_vars($data);

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\Array;
 
+use ArrayAccess;
 use CodeIgniter\Exceptions\InvalidArgumentException;
+use ReflectionMethod;
 
 /**
  * @internal This is internal implementation for the framework.
@@ -34,11 +36,12 @@ final class ArrayHelper
      *
      * @used-by dot_array_search()
      *
-     * @param string $index The index as dot array syntax.
+     * @param string                         $index The index as dot array syntax.
+     * @param array<array-key, mixed>|object $array
      *
-     * @return array|bool|int|object|string|null
+     * @return array<array-key, mixed>|bool|int|object|string|null
      */
-    public static function dotSearch(string $index, array $array)
+    public static function dotSearch(string $index, array|object $array)
     {
         return self::arraySearchDot(self::convertToArray($index), $array);
     }
@@ -78,9 +81,12 @@ final class ArrayHelper
      *
      * @used-by dotSearch()
      *
-     * @return array|bool|float|int|object|string|null
+     * @param list<string>                   $indexes
+     * @param array<array-key, mixed>|object $array
+     *
+     * @return array<array-key, mixed>|bool|float|int|object|string|null
      */
-    private static function arraySearchDot(array $indexes, array $array)
+    private static function arraySearchDot(array $indexes, array|object $array)
     {
         // If index is empty, returns null.
         if ($indexes === []) {
@@ -90,7 +96,7 @@ final class ArrayHelper
         // Grab the current index
         $currentIndex = array_shift($indexes);
 
-        if (! isset($array[$currentIndex]) && $currentIndex !== '*') {
+        if (! self::valueExists($array, $currentIndex) && $currentIndex !== '*') {
             return null;
         }
 
@@ -99,7 +105,7 @@ final class ArrayHelper
             $answer = [];
 
             foreach ($array as $value) {
-                if (! is_array($value)) {
+                if (! is_array($value) && ! is_object($value)) {
                     return null;
                 }
 
@@ -119,12 +125,14 @@ final class ArrayHelper
         // If this is the last index, make sure to return it now,
         // and not try to recurse through things.
         if ($indexes === []) {
-            return $array[$currentIndex];
+            return self::value($array, $currentIndex);
         }
 
+        $value = self::value($array, $currentIndex);
+
         // Do we need to recursively search this value?
-        if (is_array($array[$currentIndex]) && $array[$currentIndex] !== []) {
-            return self::arraySearchDot($indexes, $array[$currentIndex]);
+        if ((is_array($value) && $value !== []) || is_object($value)) {
+            return self::arraySearchDot($indexes, $value);
         }
 
         // Otherwise, not found.
@@ -136,9 +144,9 @@ final class ArrayHelper
      *
      * If wildcard `*` is used, all items for the key after it must have the key.
      *
-     * @param array<array-key, mixed> $array
+     * @param array<array-key, mixed>|object $array
      */
-    public static function dotHas(string $index, array $array): bool
+    public static function dotHas(string $index, array|object $array): bool
     {
         self::ensureValidWildcardPattern($index);
 
@@ -154,10 +162,10 @@ final class ArrayHelper
     /**
      * Recursively check key existence by dot path, including wildcard support.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>            $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>                   $indexes
      */
-    private static function hasByDotPath(array $array, array $indexes): bool
+    private static function hasByDotPath(array|object $array, array $indexes): bool
     {
         if ($indexes === []) {
             return true;
@@ -167,7 +175,7 @@ final class ArrayHelper
 
         if ($currentIndex === '*') {
             foreach ($array as $item) {
-                if (! is_array($item) || ! self::hasByDotPath($item, $indexes)) {
+                if ((! is_array($item) && ! is_object($item)) || ! self::hasByDotPath($item, $indexes)) {
                     return false;
                 }
             }
@@ -175,7 +183,7 @@ final class ArrayHelper
             return true;
         }
 
-        if (! array_key_exists($currentIndex, $array)) {
+        if (! self::keyExists($array, $currentIndex)) {
             return false;
         }
 
@@ -183,11 +191,13 @@ final class ArrayHelper
             return true;
         }
 
-        if (! is_array($array[$currentIndex])) {
+        $value = self::value($array, $currentIndex);
+
+        if (! is_array($value) && ! is_object($value)) {
             return false;
         }
 
-        return self::hasByDotPath($array[$currentIndex], $indexes);
+        return self::hasByDotPath($value, $indexes);
     }
 
     /**
@@ -333,13 +343,16 @@ final class ArrayHelper
 
     /**
      * Recursively attach $row to the $indexes path of values found by
-     * `dot_array_search()`.
+     * dot syntax.
      *
      * @used-by groupBy()
+     *
+     * @param array<array-key, mixed>|object $row
+     * @param list<string>                   $indexes
      */
     private static function arrayAttachIndexedValue(
         array $result,
-        array $row,
+        array|object $row,
         array $indexes,
         bool $includeEmpty,
     ): array {
@@ -349,7 +362,7 @@ final class ArrayHelper
             return $result;
         }
 
-        $value = dot_array_search($index, $row);
+        $value = self::dotSearch($index, $row);
 
         if (! is_scalar($value)) {
             $value = '';
@@ -445,6 +458,118 @@ final class ArrayHelper
 
             return strnatcmp((string) $currentValue, (string) $nextValue);
         });
+    }
+
+    /**
+     * @param array<array-key, mixed>|object $data
+     */
+    private static function keyExists(array|object $data, string $key): bool
+    {
+        if (is_array($data)) {
+            return array_key_exists($key, $data);
+        }
+
+        $array = self::objectToArray($data);
+
+        if ($array !== null) {
+            return array_key_exists($key, $array);
+        }
+
+        if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
+            return true;
+        }
+
+        if (array_key_exists($key, get_object_vars($data))) {
+            return true;
+        }
+
+        return isset($data->{$key});
+    }
+
+    /**
+     * @param array<array-key, mixed>|object $data
+     */
+    private static function valueExists(array|object $data, string $key): bool
+    {
+        if (is_array($data)) {
+            return isset($data[$key]);
+        }
+
+        $array = self::objectToArray($data);
+
+        if ($array !== null) {
+            return isset($array[$key]);
+        }
+
+        if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
+            return true;
+        }
+
+        if (isset(get_object_vars($data)[$key])) {
+            return true;
+        }
+
+        return isset($data->{$key});
+    }
+
+    /**
+     * @param array<array-key, mixed>|object $data
+     */
+    private static function value(array|object $data, string $key): mixed
+    {
+        if (is_array($data)) {
+            return $data[$key];
+        }
+
+        $array = self::objectToArray($data);
+
+        if ($array !== null) {
+            return $array[$key];
+        }
+
+        if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
+            return $data->offsetGet($key);
+        }
+
+        $properties = get_object_vars($data);
+
+        if (array_key_exists($key, $properties)) {
+            return $properties[$key];
+        }
+
+        return $data->{$key};
+    }
+
+    /**
+     * @return array<array-key, mixed>|null
+     */
+    private static function objectToArray(object $data): ?array
+    {
+        if (method_exists($data, 'toRawArray')) {
+            $method = new ReflectionMethod($data, 'toRawArray');
+
+            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === 0) {
+                $array = $data->toRawArray();
+
+                if (is_array($array)) {
+                    return $array;
+                }
+            }
+        }
+
+        if (method_exists($data, 'toArray')) {
+            $method = new ReflectionMethod($data, 'toArray');
+
+            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === 0) {
+                $array = $data->toArray();
+
+                if (is_array($array)) {
+                    return $array;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -606,7 +731,7 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            if (! is_array($source)) {
+            if (! is_array($source) && ! is_object($source)) {
                 return;
             }
 
@@ -617,10 +742,10 @@ final class ArrayHelper
             return;
         }
 
-        if (! is_array($source) || ! array_key_exists($currentIndex, $source)) {
+        if ((! is_array($source) && ! is_object($source)) || ! self::keyExists($source, $currentIndex)) {
             return;
         }
 
-        self::projectByDotPath($source[$currentIndex], $indexes, $result, [...$prefix, $currentIndex]);
+        self::projectByDotPath(self::value($source, $currentIndex), $indexes, $result, [...$prefix, $currentIndex]);
     }
 }

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace CodeIgniter\Helpers\Array;
 
 use ArrayAccess;
+use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\InvalidArgumentException;
-use ReflectionMethod;
+use Traversable;
 
 /**
  * @internal This is internal implementation for the framework.
@@ -102,9 +103,10 @@ final class ArrayHelper
 
         // Handle Wildcard (*)
         if ($currentIndex === '*') {
-            $answer = [];
+            $answer   = [];
+            $iterable = is_object($array) ? self::toIterable($array) : $array;
 
-            foreach ($array as $value) {
+            foreach ($iterable as $value) {
                 if (! is_array($value) && ! is_object($value)) {
                     return null;
                 }
@@ -144,9 +146,9 @@ final class ArrayHelper
      *
      * If wildcard `*` is used, all items for the key after it must have the key.
      *
-     * @param array<array-key, mixed>|object $array
+     * @param array<array-key, mixed> $array
      */
-    public static function dotHas(string $index, array|object $array): bool
+    public static function dotHas(string $index, array $array): bool
     {
         self::ensureValidWildcardPattern($index);
 
@@ -162,10 +164,10 @@ final class ArrayHelper
     /**
      * Recursively check key existence by dot path, including wildcard support.
      *
-     * @param array<array-key, mixed>|object $array
-     * @param list<string>                   $indexes
+     * @param array<array-key, mixed> $array
+     * @param list<string>            $indexes
      */
-    private static function hasByDotPath(array|object $array, array $indexes): bool
+    private static function hasByDotPath(array $array, array $indexes): bool
     {
         if ($indexes === []) {
             return true;
@@ -175,7 +177,7 @@ final class ArrayHelper
 
         if ($currentIndex === '*') {
             foreach ($array as $item) {
-                if ((! is_array($item) && ! is_object($item)) || ! self::hasByDotPath($item, $indexes)) {
+                if (! is_array($item) || ! self::hasByDotPath($item, $indexes)) {
                     return false;
                 }
             }
@@ -183,7 +185,7 @@ final class ArrayHelper
             return true;
         }
 
-        if (! self::keyExists($array, $currentIndex)) {
+        if (! array_key_exists($currentIndex, $array)) {
             return false;
         }
 
@@ -191,13 +193,11 @@ final class ArrayHelper
             return true;
         }
 
-        $value = self::value($array, $currentIndex);
-
-        if (! is_array($value) && ! is_object($value)) {
+        if (! is_array($array[$currentIndex])) {
             return false;
         }
 
-        return self::hasByDotPath($value, $indexes);
+        return self::hasByDotPath($array[$currentIndex], $indexes);
     }
 
     /**
@@ -463,32 +463,6 @@ final class ArrayHelper
     /**
      * @param array<array-key, mixed>|object $data
      */
-    private static function keyExists(array|object $data, string $key): bool
-    {
-        if (is_array($data)) {
-            return array_key_exists($key, $data);
-        }
-
-        $array = self::objectToArray($data);
-
-        if ($array !== null) {
-            return array_key_exists($key, $array);
-        }
-
-        if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
-            return true;
-        }
-
-        if (array_key_exists($key, get_object_vars($data))) {
-            return true;
-        }
-
-        return isset($data->{$key});
-    }
-
-    /**
-     * @param array<array-key, mixed>|object $data
-     */
     private static function valueExists(array|object $data, string $key): bool
     {
         if (is_array($data)) {
@@ -545,31 +519,35 @@ final class ArrayHelper
      */
     private static function objectToArray(object $data): ?array
     {
-        if (method_exists($data, 'toRawArray')) {
-            $method = new ReflectionMethod($data, 'toRawArray');
-
-            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === 0) {
-                $array = $data->toRawArray();
-
-                if (is_array($array)) {
-                    return $array;
-                }
-            }
-        }
-
-        if (method_exists($data, 'toArray')) {
-            $method = new ReflectionMethod($data, 'toArray');
-
-            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === 0) {
-                $array = $data->toArray();
-
-                if (is_array($array)) {
-                    return $array;
-                }
-            }
+        if ($data instanceof Entity) {
+            return $data->toArray();
         }
 
         return null;
+    }
+
+    /**
+     * Normalize an object to an array safe to iterate with foreach.
+     *
+     * Entities are converted via toArray() so internal properties like
+     * `_options` or `_cast` are not exposed. Other Traversable objects are
+     * materialized; plain objects fall back to their public properties.
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function toIterable(object $data): array
+    {
+        $array = self::objectToArray($data);
+
+        if ($array !== null) {
+            return $array;
+        }
+
+        if ($data instanceof Traversable) {
+            return iterator_to_array($data);
+        }
+
+        return get_object_vars($data);
     }
 
     /**
@@ -731,7 +709,7 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            if (! is_array($source) && ! is_object($source)) {
+            if (! is_array($source)) {
                 return;
             }
 
@@ -742,10 +720,10 @@ final class ArrayHelper
             return;
         }
 
-        if ((! is_array($source) && ! is_object($source)) || ! self::keyExists($source, $currentIndex)) {
+        if (! is_array($source) || ! array_key_exists($currentIndex, $source)) {
             return;
         }
 
-        self::projectByDotPath(self::value($source, $currentIndex), $indexes, $result, [...$prefix, $currentIndex]);
+        self::projectByDotPath($source[$currentIndex], $indexes, $result, [...$prefix, $currentIndex]);
     }
 }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -34,9 +34,9 @@ if (! function_exists('dot_array_has')) {
     /**
      * Checks if an array key exists using dot syntax.
      *
-     * @param array<array-key, mixed>|object $array
+     * @param array<array-key, mixed> $array
      */
-    function dot_array_has(string $index, array|object $array): bool
+    function dot_array_has(string $index, array $array): bool
     {
         return ArrayHelper::dotHas($index, $array);
     }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -20,9 +20,11 @@ if (! function_exists('dot_array_search')) {
      * Searches an array through dot syntax. Supports
      * wildcard searches, like foo.*.bar
      *
-     * @return array|bool|int|object|string|null
+     * @param array<array-key, mixed>|object $array
+     *
+     * @return array<array-key, mixed>|bool|int|object|string|null
      */
-    function dot_array_search(string $index, array $array)
+    function dot_array_search(string $index, array|object $array)
     {
         return ArrayHelper::dotSearch($index, $array);
     }
@@ -32,9 +34,9 @@ if (! function_exists('dot_array_has')) {
     /**
      * Checks if an array key exists using dot syntax.
      *
-     * @param array<array-key, mixed> $array
+     * @param array<array-key, mixed>|object $array
      */
-    function dot_array_has(string $index, array $array): bool
+    function dot_array_has(string $index, array|object $array): bool
     {
         return ArrayHelper::dotHas($index, $array);
     }

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -19,7 +19,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
-use Tests\Support\Entity\ArrayObjectWithToArray;
+use Tests\Support\SomeEntity;
 use ValueError;
 
 /**
@@ -395,8 +395,6 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame('Jane', dot_array_search('user.profile.name', $data));
-        $this->assertTrue(dot_array_has('user.profile.name', $data));
-        $this->assertFalse(dot_array_has('user.profile.email', $data));
     }
 
     public function testArrayDotWithMagicObjectValues(): void
@@ -425,7 +423,6 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame('Jane', dot_array_search('user.profile.name', $data));
-        $this->assertTrue(dot_array_has('user.profile.name', $data));
     }
 
     public function testArrayDotWithArrayAccessValues(): void
@@ -439,51 +436,14 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame('Jane', dot_array_search('user.profile.name', $data));
-        $this->assertTrue(dot_array_has('user.profile.name', $data));
     }
 
-    public function testArrayDotWithObjectToRawArrayValues(): void
+    public function testArrayDotWithEntityValues(): void
     {
-        $data = [
-            'user' => new class () {
-                /**
-                 * @return array<string, array<string, string>>
-                 */
-                public function toRawArray(): array
-                {
-                    return [
-                        'profile' => [
-                            'name' => 'Raw',
-                        ],
-                    ];
-                }
+        $entity = new SomeEntity();
+        $entity->foo = 'value';
 
-                /**
-                 * @return array<string, array<string, string>>
-                 */
-                public function toArray(): array
-                {
-                    return [
-                        'profile' => [
-                            'name' => 'Array',
-                        ],
-                    ];
-                }
-            },
-        ];
-
-        $this->assertSame('Raw', dot_array_search('user.profile.name', $data));
-        $this->assertTrue(dot_array_has('user.profile.name', $data));
-    }
-
-    public function testArrayDotWithObjectToArrayValues(): void
-    {
-        $data = [
-            'user' => new ArrayObjectWithToArray(),
-        ];
-
-        $this->assertSame('same', dot_array_search('user.array', $data));
-        $this->assertTrue(dot_array_has('user.array', $data));
+        $this->assertSame('value', dot_array_search('user.foo', ['user' => $entity]));
     }
 
     public function testArrayDotWildcardWithObjectValues(): void
@@ -496,32 +456,6 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame(['John', 'Maria'], dot_array_search('users.*.name', $data));
-        $this->assertTrue(dot_array_has('users.*.name', $data));
-    }
-
-    public function testArrayDotOnlyWithObjectValues(): void
-    {
-        $data = [
-            'users' => [
-                (object) [
-                    'id'   => 1,
-                    'name' => 'John',
-                ],
-                (object) [
-                    'id'   => 2,
-                    'name' => 'Maria',
-                ],
-            ],
-        ];
-
-        $expected = [
-            'users' => [
-                ['id' => 1],
-                ['id' => 2],
-            ],
-        ];
-
-        $this->assertSame($expected, dot_array_only($data, 'users.*.id'));
     }
 
     /**
@@ -1705,5 +1639,31 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
             $actual,
         );
+    }
+
+    public function testArrayGroupByWithEntityRows(): void
+    {
+        $a      = new SomeEntity();
+        $a->foo = 'A';
+        $a->bar = 'x';
+
+        $b      = new SomeEntity();
+        $b->foo = 'B';
+        $b->bar = 'y';
+
+        $c      = new SomeEntity();
+        $c->foo = 'A';
+        $c->bar = 'z';
+
+        $actual = array_group_by([$a, $b, $c], ['foo']);
+
+        $this->assertSame(
+            [
+                'A' => [$a, $c],
+                'B' => [$b],
+            ],
+            $actual,
+        );
+        $this->assertSame($a, $actual['A'][0]);
     }
 }

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
+use ArrayObject;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use stdClass;
+use Tests\Support\Entity\ArrayObjectWithToArray;
 use ValueError;
 
 /**
@@ -379,6 +382,146 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame(['baz' => 23], dot_array_search('foo.bar.*', $data));
+    }
+
+    public function testArrayDotWithObjectValues(): void
+    {
+        $data = [
+            'user' => (object) [
+                'profile' => (object) [
+                    'name' => 'Jane',
+                ],
+            ],
+        ];
+
+        $this->assertSame('Jane', dot_array_search('user.profile.name', $data));
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+        $this->assertFalse(dot_array_has('user.profile.email', $data));
+    }
+
+    public function testArrayDotWithMagicObjectValues(): void
+    {
+        $data = [
+            'user' => new class () {
+                /**
+                 * @var array<string, array<string, string>>
+                 */
+                private array $values = [
+                    'profile' => [
+                        'name' => 'Jane',
+                    ],
+                ];
+
+                public function __isset(string $key): bool
+                {
+                    return array_key_exists($key, $this->values);
+                }
+
+                public function __get(string $key): mixed
+                {
+                    return $this->values[$key];
+                }
+            },
+        ];
+
+        $this->assertSame('Jane', dot_array_search('user.profile.name', $data));
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testArrayDotWithArrayAccessValues(): void
+    {
+        $data = [
+            'user' => new ArrayObject([
+                'profile' => [
+                    'name' => 'Jane',
+                ],
+            ]),
+        ];
+
+        $this->assertSame('Jane', dot_array_search('user.profile.name', $data));
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testArrayDotWithObjectToRawArrayValues(): void
+    {
+        $data = [
+            'user' => new class () {
+                /**
+                 * @return array<string, array<string, string>>
+                 */
+                public function toRawArray(): array
+                {
+                    return [
+                        'profile' => [
+                            'name' => 'Raw',
+                        ],
+                    ];
+                }
+
+                /**
+                 * @return array<string, array<string, string>>
+                 */
+                public function toArray(): array
+                {
+                    return [
+                        'profile' => [
+                            'name' => 'Array',
+                        ],
+                    ];
+                }
+            },
+        ];
+
+        $this->assertSame('Raw', dot_array_search('user.profile.name', $data));
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testArrayDotWithObjectToArrayValues(): void
+    {
+        $data = [
+            'user' => new ArrayObjectWithToArray(),
+        ];
+
+        $this->assertSame('same', dot_array_search('user.array', $data));
+        $this->assertTrue(dot_array_has('user.array', $data));
+    }
+
+    public function testArrayDotWildcardWithObjectValues(): void
+    {
+        $data = [
+            'users' => [
+                (object) ['name' => 'John'],
+                (object) ['name' => 'Maria'],
+            ],
+        ];
+
+        $this->assertSame(['John', 'Maria'], dot_array_search('users.*.name', $data));
+        $this->assertTrue(dot_array_has('users.*.name', $data));
+    }
+
+    public function testArrayDotOnlyWithObjectValues(): void
+    {
+        $data = [
+            'users' => [
+                (object) [
+                    'id'   => 1,
+                    'name' => 'John',
+                ],
+                (object) [
+                    'id'   => 2,
+                    'name' => 'Maria',
+                ],
+            ],
+        ];
+
+        $expected = [
+            'users' => [
+                ['id' => 1],
+                ['id' => 2],
+            ],
+        ];
+
+        $this->assertSame($expected, dot_array_only($data, 'users.*.id'));
     }
 
     /**
@@ -1500,5 +1643,67 @@ final class ArrayHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/10225
+     */
+    public function testArrayGroupByWithObjectRows(): void
+    {
+        $json = <<<'JSON'
+            [
+                { "id": 1, "name": "Giraffe", "group": "Mammals" },
+                { "id": 2, "name": "Zebra", "group": "Mammals" },
+                { "id": 3, "name": "Crow", "group": "Birds" }
+            ]
+            JSON;
+        $data = json_decode($json);
+
+        $this->assertIsArray($data);
+
+        $actual = array_group_by($data, ['group']);
+
+        $this->assertSame(
+            [
+                'Mammals' => [$data[0], $data[1]],
+                'Birds'   => [$data[2]],
+            ],
+            $actual,
+        );
+        $this->assertInstanceOf(stdClass::class, $actual['Mammals'][0]);
+    }
+
+    public function testArrayGroupByWithNestedObjectRows(): void
+    {
+        $data = [
+            (object) [
+                'id' => 1,
+                'hr' => (object) [
+                    'department' => 'Engineering',
+                ],
+            ],
+            (object) [
+                'id' => 2,
+                'hr' => (object) [
+                    'department' => 'Marketing',
+                ],
+            ],
+            (object) [
+                'id' => 3,
+                'hr' => (object) [
+                    'department' => 'Engineering',
+                ],
+            ],
+        ];
+
+        $actual = array_group_by($data, ['hr.department']);
+
+        $this->assertSame(
+            [
+                'Engineering' => [$data[0], $data[2]],
+                'Marketing'   => [$data[1]],
+            ],
+            $actual,
+        );
     }
 }

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -440,7 +440,7 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     public function testArrayDotWithEntityValues(): void
     {
-        $entity = new SomeEntity();
+        $entity      = new SomeEntity();
         $entity->foo = 'value';
 
         $this->assertSame('value', dot_array_search('user.foo', ['user' => $entity]));

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -264,9 +264,9 @@ Helpers and Functions
 - :doc:`Array Helper </helpers/array_helper>` gained five new dot-path functions:
   :php:func:`dot_array_has()`, :php:func:`dot_array_set()`, :php:func:`dot_array_unset()`,
   :php:func:`dot_array_only()`, and :php:func:`dot_array_except()`.
-- :doc:`Array Helper </helpers/array_helper>` dot-path read operations now support object properties
-  in :php:func:`dot_array_search()`, :php:func:`dot_array_has()`, :php:func:`dot_array_only()`,
-  and :php:func:`array_group_by()`.
+- :doc:`Array Helper </helpers/array_helper>` dot-path read operations now support
+  object rows (including ``Entity``) in :php:func:`dot_array_search()` and
+  :php:func:`array_group_by()`.
 
 HTTP
 ====

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -264,6 +264,9 @@ Helpers and Functions
 - :doc:`Array Helper </helpers/array_helper>` gained five new dot-path functions:
   :php:func:`dot_array_has()`, :php:func:`dot_array_set()`, :php:func:`dot_array_unset()`,
   :php:func:`dot_array_only()`, and :php:func:`dot_array_except()`.
+- :doc:`Array Helper </helpers/array_helper>` dot-path read operations now support object properties
+  in :php:func:`dot_array_search()`, :php:func:`dot_array_has()`, :php:func:`dot_array_only()`,
+  and :php:func:`array_group_by()`.
 
 HTTP
 ====

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -218,6 +218,8 @@ The following functions are available:
     The depth of returned array equals the number of indexes passed as parameter.
     Data rows may be arrays or objects, and dot syntax can read nested array keys or object properties.
 
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
+
     The example shows some data (i.e. loaded from an API) with nested arrays.
 
     .. literalinclude:: array_helper/012.php

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -58,16 +58,16 @@ The following functions are available:
 
 .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
-..  php:function:: dot_array_has(string $search, array|object $values): bool
+..  php:function:: dot_array_has(string $search, array $values): bool
 
     :param  string  $search: The dot-notation string describing how to search the array
-    :param  array|object $values: The array or object to check
+    :param  array   $values: The array to check
     :returns: ``true`` if the key exists, otherwise ``false``
     :rtype: bool
 
     .. versionadded:: 4.8.0
 
-    Checks if an array key or object property exists using dot syntax.
+    Checks if an array key exists using dot syntax.
     This method supports wildcard ``*`` in the same way as ``dot_array_search()``.
 
     .. literalinclude:: array_helper/015.php
@@ -115,7 +115,6 @@ The following functions are available:
     .. versionadded:: 4.8.0
 
     Gets only the specified keys using dot syntax while preserving nested structure.
-    Nested object properties can be selected in the same way as array keys.
 
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -22,15 +22,15 @@ Available Functions
 
 The following functions are available:
 
-..  php:function:: dot_array_search(string $search, array $values)
+..  php:function:: dot_array_search(string $search, array|object $values)
 
     :param  string  $search: The dot-notation string describing how to search the array
-    :param  array   $values: The array to search
+    :param  array|object $values: The array or object to search
     :returns: The value found within the array, or null
     :rtype: mixed
 
-    This method allows you to use dot-notation to search through an array for a specific-key,
-    and allows the use of a the ``*`` wildcard. Given the following array:
+    This method allows you to use dot-notation to search through arrays and objects for a specific
+    key or property, and allows the use of the ``*`` wildcard. Given the following array:
 
     .. literalinclude:: array_helper/002.php
         :lines: 2-
@@ -56,16 +56,18 @@ The following functions are available:
 .. note:: Prior to v4.2.0, ``dot_array_search('foo.bar.baz', ['foo' => ['bar' => 23]])`` returned ``23``
     due to a bug. v4.2.0 and later returns ``null``.
 
-..  php:function:: dot_array_has(string $search, array $values): bool
+.. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
+
+..  php:function:: dot_array_has(string $search, array|object $values): bool
 
     :param  string  $search: The dot-notation string describing how to search the array
-    :param  array   $values: The array to check
+    :param  array|object $values: The array or object to check
     :returns: ``true`` if the key exists, otherwise ``false``
     :rtype: bool
 
     .. versionadded:: 4.8.0
 
-    Checks if an array key exists using dot syntax.
+    Checks if an array key or object property exists using dot syntax.
     This method supports wildcard ``*`` in the same way as ``dot_array_search()``.
 
     .. literalinclude:: array_helper/015.php
@@ -113,6 +115,7 @@ The following functions are available:
     .. versionadded:: 4.8.0
 
     Gets only the specified keys using dot syntax while preserving nested structure.
+    Nested object properties can be selected in the same way as array keys.
 
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
@@ -214,6 +217,7 @@ The following functions are available:
 
     This function allows you to group data rows together by index values.
     The depth of returned array equals the number of indexes passed as parameter.
+    Data rows may be arrays or objects, and dot syntax can read nested array keys or object properties.
 
     The example shows some data (i.e. loaded from an API) with nested arrays.
 

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -2943,47 +2943,12 @@ parameters:
             path: ../../system/HTTP/URI.php
 
         -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arrayAttachIndexedValue\(\) has parameter \$indexes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
             message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arrayAttachIndexedValue\(\) has parameter \$result with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/Array/ArrayHelper.php
 
         -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arrayAttachIndexedValue\(\) has parameter \$row with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
             message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arrayAttachIndexedValue\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arraySearchDot\(\) has parameter \$array with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arraySearchDot\(\) has parameter \$indexes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arraySearchDot\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:dotSearch\(\) has parameter \$array with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:dotSearch\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/Array/ArrayHelper.php
 
@@ -3064,16 +3029,6 @@ parameters:
 
         -
             message: '#^Function array_sort_by_multiple_keys\(\) has parameter \$sortColumns with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/array_helper.php
-
-        -
-            message: '#^Function dot_array_search\(\) has parameter \$array with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/array_helper.php
-
-        -
-            message: '#^Function dot_array_search\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/array_helper.php
 


### PR DESCRIPTION
**Description**

Fixes codeigniter4/CodeIgniter4#10225.

This PR updates `array_group_by()` so it can group rows that are objects, such as rows returned by `json_decode()` or object-based result sets.

Previously, the internal grouping helper required each row to be an array and used `dot_array_search()`, which also only accepts arrays. That caused a type error when grouping an array of `stdClass` objects.

The change keeps the public helper API unchanged and adds internal dot-path lookup support for array/object rows. Grouped rows are preserved as their original type, so object rows remain objects in the result.

Regression tests were added for:
- Grouping `stdClass` rows by a direct property.
- Grouping object rows by a nested dot path.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide