### PR TITLE
feat: Add `isAvailable()` method to AbstractCommand

### DIFF
--- a/system/CLI/AbstractCommand.php
+++ b/system/CLI/AbstractCommand.php
@@ -457,7 +457,7 @@ abstract class AbstractCommand
     }
 
     /**
-     * Check whether this command is available to execute in the current environment
+     * Checks whether this command is available to execute in the current environment
      */
     protected function isAvailable(): bool
     {

--- a/system/CLI/AbstractCommand.php
+++ b/system/CLI/AbstractCommand.php
@@ -391,7 +391,7 @@ abstract class AbstractCommand
      *
      * The lifecycle is:
      *
-     *   1. Run `isAvailable()` to check if the command can be run in the current state.
+     *   1. Run `isAvailable()` to check if the command can be run in the current environment.
      *   2. `initialize()` and `interact()` are handed the raw parsed input by reference, in that order.
      *      Both can mutate the tokens before the framework interprets them against the declared definitions.
      *      Note: the per-run interactive state is captured from `$options` before `initialize()` runs, so
@@ -457,7 +457,7 @@ abstract class AbstractCommand
     }
 
     /**
-     * Check whether this command is available to execute in the current system state
+     * Check whether this command is available to execute in the current environment
      */
     protected function isAvailable(): bool
     {

--- a/system/CLI/AbstractCommand.php
+++ b/system/CLI/AbstractCommand.php
@@ -457,7 +457,7 @@ abstract class AbstractCommand
     }
 
     /**
-     * Checks whether this command is available to execute in the current environment
+     * Checks whether this command is available to execute in the current environment.
      */
     protected function isAvailable(): bool
     {

--- a/system/CLI/AbstractCommand.php
+++ b/system/CLI/AbstractCommand.php
@@ -411,10 +411,10 @@ abstract class AbstractCommand
      * @param array<string, list<string|null>|string|null> $options   Parsed options from command line.
      *
      * @throws ArgumentCountMismatchException
+     * @throws CommandNotAvailableException
      * @throws LogicException
      * @throws OptionValueMismatchException
      * @throws UnknownOptionException
-     * @throws CommandNotAvailableException
      */
     final public function run(array $arguments, array $options): int
     {

--- a/system/CLI/AbstractCommand.php
+++ b/system/CLI/AbstractCommand.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\CLI;
 
 use CodeIgniter\CLI\Attributes\Command;
 use CodeIgniter\CLI\Exceptions\ArgumentCountMismatchException;
+use CodeIgniter\CLI\Exceptions\CommandNotAvailableException;
 use CodeIgniter\CLI\Exceptions\InvalidArgumentDefinitionException;
 use CodeIgniter\CLI\Exceptions\InvalidOptionDefinitionException;
 use CodeIgniter\CLI\Exceptions\OptionValueMismatchException;
@@ -390,19 +391,20 @@ abstract class AbstractCommand
      *
      * The lifecycle is:
      *
-     *   1. `initialize()` and `interact()` are handed the raw parsed input by reference, in that order.
+     *   1. Run `isAvailable()` to check if the command can be run in the current state.
+     *   2. `initialize()` and `interact()` are handed the raw parsed input by reference, in that order.
      *      Both can mutate the tokens before the framework interprets them against the declared definitions.
      *      Note: the per-run interactive state is captured from `$options` before `initialize()` runs, so
      *      mutating `--no-interaction` from within `initialize()` will not affect this invocation. Use
      *      `setInteractive()` instead.
-     *   2. The post-hook input is snapshotted into `$unboundArguments` and `$unboundOptions` so the unbound
+     *   3. The post-hook input is snapshotted into `$unboundArguments` and `$unboundOptions` so the unbound
      *      accessors can report the tokens carried into binding (as opposed to what defaults resolved to).
      *      Any mutations performed in `initialize()` or `interact()` are therefore reflected in the snapshot.
-     *   3. `bind()` maps the raw tokens onto the declared arguments and options, applying defaults and
+     *   4. `bind()` maps the raw tokens onto the declared arguments and options, applying defaults and
      *      coercing flag/negation values.
-     *   4. `validate()` rejects the bound result if it violates any of the declarations — missing required
+     *   5. `validate()` rejects the bound result if it violates any of the declarations — missing required
      *      argument, unknown option, value/flag mismatches, and so on.
-     *   5. The bound-and-validated values are snapshotted into `$validatedArguments` / `$validatedOptions`
+     *   6. The bound-and-validated values are snapshotted into `$validatedArguments` / `$validatedOptions`
      *      and then passed to `execute()`, whose integer return is the command's exit code.
      *
      * @param list<string>                                 $arguments Parsed arguments from command line.
@@ -412,9 +414,14 @@ abstract class AbstractCommand
      * @throws LogicException
      * @throws OptionValueMismatchException
      * @throws UnknownOptionException
+     * @throws CommandNotAvailableException
      */
     final public function run(array $arguments, array $options): int
     {
+        if (! $this->isAvailable()) {
+            throw new CommandNotAvailableException(lang('Commands.notAvailable', [$this->name]));
+        }
+
         // Reset per-run interactive state from the current options.
         $this->runtimeInteractive = $this->hasUnboundOption('no-interaction', $options) ? false : null;
 
@@ -447,6 +454,14 @@ abstract class AbstractCommand
      */
     protected function configure(): void
     {
+    }
+
+    /**
+     * Check whether this command is available to execute in the current system state
+     */
+    protected function isAvailable(): bool
+    {
+        return true;
     }
 
     /**

--- a/system/CLI/Exceptions/CommandNotAvailableException.php
+++ b/system/CLI/Exceptions/CommandNotAvailableException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\CLI\Exceptions;
+
+use CodeIgniter\Exceptions\RuntimeException;
+
+/**
+ * Exception thrown when a command is found but is not currently available for execution.
+ */
+final class CommandNotAvailableException extends RuntimeException
+{
+}

--- a/system/Language/en/Commands.php
+++ b/system/Language/en/Commands.php
@@ -59,4 +59,5 @@ return [
     'reservedOptionName'                    => 'Option name "--extra_options" is reserved and cannot be used.',
     'tooManyArguments'                      => '{1, plural, =1{One unexpected argument was} other{Multiple unexpected arguments were}} provided to "{0}" command: "{2}".',
     'unknownOptions'                        => 'The following {0, plural, =1{option} other{options}} {0, plural, =1{is} other{are}} unknown in the "{1}" command: {2}.',
+    'notAvailable'                          => 'Command "{0}" is not available in the current environment.',
 ];

--- a/system/Language/en/Commands.php
+++ b/system/Language/en/Commands.php
@@ -47,6 +47,7 @@ return [
     'noArgumentsExpected'                   => 'No arguments expected for "{0}" command. Received: "{1}".',
     'nonArrayArgumentWithArrayDefault'      => 'Argument "{0}" does not accept an array default value.',
     'nonArrayOptionWithArrayValue'          => 'Option "--{0}" does not accept an array value.',
+    'notAvailable'                          => 'Command "{0}" is not available in the current environment.',
     'optionClashesWithExistingNegation'     => 'Option "--{0}" clashes with the negation of negatable option "--{1}".',
     'optionNoValueAndNoDefault'             => 'Option "--{0}" does not accept a value and cannot have a default value.',
     'optionNotAcceptingValue'               => 'Option "--{0}" does not accept a value.',
@@ -59,5 +60,4 @@ return [
     'reservedOptionName'                    => 'Option name "--extra_options" is reserved and cannot be used.',
     'tooManyArguments'                      => '{1, plural, =1{One unexpected argument was} other{Multiple unexpected arguments were}} provided to "{0}" command: "{2}".',
     'unknownOptions'                        => 'The following {0, plural, =1{option} other{options}} {0, plural, =1{is} other{are}} unknown in the "{1}" command: {2}.',
-    'notAvailable'                          => 'Command "{0}" is not available in the current environment.',
 ];

--- a/tests/_support/Commands/Modern/UnavailableFixtureCommand.php
+++ b/tests/_support/Commands/Modern/UnavailableFixtureCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Commands\Modern;
+
+use CodeIgniter\CLI\AbstractCommand;
+use CodeIgniter\CLI\Attributes\Command;
+
+#[Command(name: 'test:unavailable', description: 'Fixture command to test runtime availability checks.', group: 'Tests')]
+final class UnavailableFixtureCommand extends AbstractCommand
+{
+    public static bool $initializeCalled = false;
+    public static bool $interactCalled   = false;
+    public static bool $executeCalled    = false;
+    public static bool $available        = true;
+
+    public static function reset(): void
+    {
+        self::$initializeCalled = false;
+        self::$interactCalled   = false;
+        self::$executeCalled    = false;
+        self::$available        = true;
+    }
+
+    protected function isAvailable(): bool
+    {
+        return self::$available;
+    }
+
+    protected function initialize(array &$arguments, array &$options): void
+    {
+        self::$initializeCalled = true;
+    }
+
+    protected function interact(array &$arguments, array &$options): void
+    {
+        self::$interactCalled = true;
+    }
+
+    protected function execute(array $arguments, array $options): int
+    {
+        self::$executeCalled = true;
+
+        return EXIT_SUCCESS;
+    }
+}

--- a/tests/system/CLI/AbstractCommandTest.php
+++ b/tests/system/CLI/AbstractCommandTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\CLI;
 
 use CodeIgniter\CLI\Attributes\Command;
 use CodeIgniter\CLI\Exceptions\ArgumentCountMismatchException;
+use CodeIgniter\CLI\Exceptions\CommandNotAvailableException;
 use CodeIgniter\CLI\Exceptions\InvalidArgumentDefinitionException;
 use CodeIgniter\CLI\Exceptions\InvalidOptionDefinitionException;
 use CodeIgniter\CLI\Exceptions\OptionValueMismatchException;
@@ -40,6 +41,7 @@ use Tests\Support\Commands\Modern\InteractFixtureCommand;
 use Tests\Support\Commands\Modern\InteractiveStateProbeCommand;
 use Tests\Support\Commands\Modern\ParentCallsInteractFixtureCommand;
 use Tests\Support\Commands\Modern\TestFixtureCommand;
+use Tests\Support\Commands\Modern\UnavailableFixtureCommand;
 use Throwable;
 
 /**
@@ -60,6 +62,7 @@ final class AbstractCommandTest extends CIUnitTestCase
         CLI::reset();
 
         InteractiveStateProbeCommand::reset();
+        UnavailableFixtureCommand::reset();
     }
 
     private function getUndecoratedBuffer(): string
@@ -928,6 +931,45 @@ final class AbstractCommandTest extends CIUnitTestCase
         $this->assertTrue($command->isInteractive());
         $this->assertFalse(InteractiveStateProbeCommand::$interactCalled);
         $this->assertFalse(InteractiveStateProbeCommand::$observedInteractive);
+    }
+
+    public function testRunThrowsWhenCommandIsUnavailable(): void
+    {
+        $command                              = new UnavailableFixtureCommand(new Commands());
+        UnavailableFixtureCommand::$available = false;
+
+        $this->expectException(CommandNotAvailableException::class);
+        $this->expectExceptionMessage('Command "test:unavailable" is not available in the current environment.');
+
+        $command->run([], []);
+    }
+
+    public function testRunExecutesWhenCommandIsAvailable(): void
+    {
+        $command                              = new UnavailableFixtureCommand(new Commands());
+        UnavailableFixtureCommand::$available = true;
+
+        $exitCode = $command->run([], []);
+
+        $this->assertSame(EXIT_SUCCESS, $exitCode);
+        $this->assertTrue(UnavailableFixtureCommand::$initializeCalled);
+        $this->assertTrue(UnavailableFixtureCommand::$interactCalled);
+        $this->assertTrue(UnavailableFixtureCommand::$executeCalled);
+    }
+
+    public function testRunChecksAvailabilityBeforeInitializeInteractAndExecute(): void
+    {
+        $command                              = new UnavailableFixtureCommand(new Commands());
+        UnavailableFixtureCommand::$available = false;
+
+        try {
+            $command->run([], []);
+            $this->fail('Expected CommandNotAvailableException was not thrown.');
+        } catch (CommandNotAvailableException) {
+            $this->assertFalse(UnavailableFixtureCommand::$initializeCalled);
+            $this->assertFalse(UnavailableFixtureCommand::$interactCalled);
+            $this->assertFalse(UnavailableFixtureCommand::$executeCalled);
+        }
     }
 
     /**

--- a/tests/system/CLI/AbstractCommandTest.php
+++ b/tests/system/CLI/AbstractCommandTest.php
@@ -935,7 +935,8 @@ final class AbstractCommandTest extends CIUnitTestCase
 
     public function testRunThrowsWhenCommandIsUnavailable(): void
     {
-        $command                              = new UnavailableFixtureCommand(new Commands());
+        $command = new UnavailableFixtureCommand(new Commands());
+
         UnavailableFixtureCommand::$available = false;
 
         $this->expectException(CommandNotAvailableException::class);
@@ -946,7 +947,8 @@ final class AbstractCommandTest extends CIUnitTestCase
 
     public function testRunExecutesWhenCommandIsAvailable(): void
     {
-        $command                              = new UnavailableFixtureCommand(new Commands());
+        $command = new UnavailableFixtureCommand(new Commands());
+
         UnavailableFixtureCommand::$available = true;
 
         $exitCode = $command->run([], []);
@@ -959,7 +961,8 @@ final class AbstractCommandTest extends CIUnitTestCase
 
     public function testRunChecksAvailabilityBeforeInitializeInteractAndExecute(): void
     {
-        $command                              = new UnavailableFixtureCommand(new Commands());
+        $command = new UnavailableFixtureCommand(new Commands());
+
         UnavailableFixtureCommand::$available = false;
 
         try {

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -29,18 +29,6 @@ final class HelpCommandTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    #[After]
-    #[Before]
-    protected function resetCli(): void
-    {
-        CLI::reset();
-    }
-
-    private function getUndecoratedBuffer(): string
-    {
-        return preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()) ?? '';
-    }
-
     public function testNoArgumentDescribesItself(): void
     {
         command('help');
@@ -65,6 +53,11 @@ final class HelpCommandTest extends CIUnitTestCase
                 EOT,
             $this->getUndecoratedBuffer(),
         );
+    }
+
+    private function getUndecoratedBuffer(): string
+    {
+        return preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()) ?? '';
     }
 
     public function testDescribeCommandNoArguments(): void
@@ -115,6 +108,29 @@ final class HelpCommandTest extends CIUnitTestCase
 
                 Arguments:
                   driver                The cache driver to use. [default: "file"]
+
+                Options:
+                  -h, --help            Display help for the given command.
+                      --no-header       Do not display the banner when running the command.
+                  -N, --no-interaction  Do not ask any interactive questions.
+
+                EOT,
+            $this->getUndecoratedBuffer(),
+        );
+    }
+
+    public function testDescribeUnavailableCommand(): void
+    {
+        command('help test:unavailable');
+
+        $this->assertSame(
+            <<<'EOT'
+
+                Usage:
+                  test:unavailable [options]
+
+                Description:
+                  Fixture command to test runtime availability checks.
 
                 Options:
                   -h, --help            Display help for the given command.
@@ -265,5 +281,12 @@ final class HelpCommandTest extends CIUnitTestCase
             $this->getStreamFilterBuffer(),
         );
         $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
+    }
+
+    #[After]
+    #[Before]
+    protected function resetCli(): void
+    {
+        CLI::reset();
     }
 }

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -29,6 +29,18 @@ final class HelpCommandTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
+    #[After]
+    #[Before]
+    protected function resetCli(): void
+    {
+        CLI::reset();
+    }
+
+    private function getUndecoratedBuffer(): string
+    {
+        return preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()) ?? '';
+    }
+
     public function testNoArgumentDescribesItself(): void
     {
         command('help');
@@ -53,11 +65,6 @@ final class HelpCommandTest extends CIUnitTestCase
                 EOT,
             $this->getUndecoratedBuffer(),
         );
-    }
-
-    private function getUndecoratedBuffer(): string
-    {
-        return preg_replace('/\e\[[^m]+m/', '', $this->getStreamFilterBuffer()) ?? '';
     }
 
     public function testDescribeCommandNoArguments(): void
@@ -281,12 +288,5 @@ final class HelpCommandTest extends CIUnitTestCase
             $this->getStreamFilterBuffer(),
         );
         $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
-    }
-
-    #[After]
-    #[Before]
-    protected function resetCli(): void
-    {
-        CLI::reset();
     }
 }

--- a/tests/system/Commands/ListCommandsTest.php
+++ b/tests/system/Commands/ListCommandsTest.php
@@ -58,6 +58,14 @@ final class ListCommandsTest extends CIUnitTestCase
         $this->assertStringNotContainsString('Clears the current system caches.', $this->getStreamFilterBuffer());
     }
 
+    public function testUnavailableCommandIsStillListed(): void
+    {
+        command('list');
+
+        $this->assertStringContainsString('test:unavailable', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('Fixture command to test runtime availability checks.', $this->getStreamFilterBuffer());
+    }
+
     public function testDuplicateCommandNameListedOnceInSimpleOutput(): void
     {
         $list = new ListCommands($this->mockRunnerWithDuplicate());

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -183,7 +183,7 @@ Commands
 ========
 
 - Added a new attribute-based command style built on :php:class:`AbstractCommand <CodeIgniter\\CLI\\AbstractCommand>` and the ``#[Command]`` attribute,
-  with ``configure()`` / ``initialize()`` / ``interact()`` / ``execute()`` hooks and typed ``Argument`` / ``Option`` definitions.
+  with ``configure()`` / ``isAvailable()`` / ``initialize()`` / ``interact()`` / ``execute()`` hooks and typed ``Argument`` / ``Option`` definitions.
   The legacy ``BaseCommand`` style continues to work. See :doc:`../cli/cli_modern_commands`.
 - Every modern command now ships with a ``--no-interaction`` / ``-N`` flag that skips the ``interact()`` hook, plus public
   ``isInteractive()`` / ``setInteractive()`` methods on ``AbstractCommand``. ``isInteractive()`` also auto-detects piped or

--- a/user_guide_src/source/cli/cli_modern_commands.rst
+++ b/user_guide_src/source/cli/cli_modern_commands.rst
@@ -68,10 +68,8 @@ this order:
    extra usage examples. A default ``--help``/ ``-h`` flag, ``--no-header``
    flag, and ``--no-interaction``/ ``-N`` flag are added automatically
    afterwards.
-2. ``isAvailable(): bool`` is called to check whether the command should run.
-   By default it returns ``true``, but you can override it to prevent command execution
-   based on environment, configuration, or any other condition. When it returns ``false``,
-   the command execution is skipped entirely and ``CommandNotAvailableException`` is thrown.
+2. ``isAvailable(): bool`` is called to check whether the command should execute
+   (see :ref:`restricting-execution`).
 3. ``initialize(array &$arguments, array &$options): void`` receives the raw
    arguments and options by reference. Useful when your command needs to
    massage input — for instance, to unfold an alias argument into the canonical
@@ -226,6 +224,8 @@ parameter of ``call()``:
 - ``false``: remove any forwarded ``--no-interaction`` / ``-N`` from the
   child ``$options`` so the sub-command resolves its own state. Note: TTY
   detection can still downgrade the sub-command if STDIN is not a TTY.
+
+.. _restricting-execution:
 
 *****************************
 Restricting Command Execution

--- a/user_guide_src/source/cli/cli_modern_commands.rst
+++ b/user_guide_src/source/cli/cli_modern_commands.rst
@@ -68,19 +68,23 @@ this order:
    extra usage examples. A default ``--help``/ ``-h`` flag, ``--no-header``
    flag, and ``--no-interaction``/ ``-N`` flag are added automatically
    afterwards.
-2. ``initialize(array &$arguments, array &$options): void`` receives the raw
+2. ``isAvailable(): bool`` is called to check whether the command should run.
+   By default it returns ``true``, but you can override it to prevent command execution
+   based on environment, configuration, or any other condition. When it returns ``false``,
+   the command execution is skipped entirely and ``CommandNotAvailableException`` is thrown.
+3. ``initialize(array &$arguments, array &$options): void`` receives the raw
    arguments and options by reference. Useful when your command needs to
    massage input — for instance, to unfold an alias argument into the canonical
    form before anything else runs.
-3. ``interact(array &$arguments, array &$options): void`` also receives the
+4. ``interact(array &$arguments, array &$options): void`` also receives the
    raw arguments and options by reference. This is where you prompt the user
    for missing input, set values conditionally, or abort early. This hook is
    skipped when the command is non-interactive (see :ref:`non-interactive-mode`).
-4. **Bind & validate.** The framework maps the raw input to the definitions
+5. **Bind & validate.** The framework maps the raw input to the definitions
    you declared in ``configure()``, applies defaults, and rejects input that
    violates the definitions (missing required argument, unknown option, array
    option passed without a value, and so on).
-5. ``execute(array $arguments, array $options): int`` receives the bound and
+6. ``execute(array $arguments, array $options): int`` receives the bound and
    validated arguments and options, and returns an exit code.
 
 You only have to implement ``execute()``; the other hooks are optional.
@@ -222,6 +226,24 @@ parameter of ``call()``:
 - ``false``: remove any forwarded ``--no-interaction`` / ``-N`` from the
   child ``$options`` so the sub-command resolves its own state. Note: TTY
   detection can still downgrade the sub-command if STDIN is not a TTY.
+
+*****************************
+Restricting Command Execution
+*****************************
+
+Sometimes a command should not run in a specific runtime context. For example,
+development-only commands may need to be blocked in the ``production`` environment.
+
+You can override ``isAvailable()`` to decide at runtime whether the command may execute.
+By default, this method returns ``true``.
+
+.. literalinclude:: cli_modern_commands/013.php
+
+The availability check runs before ``initialize()``, ``interact()``, argument and
+option binding, validation, and ``execute()``. If the command is not available,
+a ``CommandNotAvailableException`` is thrown immediately.
+
+.. note:: This method prevents execution of the command, but does not remove it from help output or command discovery.
 
 ******************
 Inside execute()

--- a/user_guide_src/source/cli/cli_modern_commands/013.php
+++ b/user_guide_src/source/cli/cli_modern_commands/013.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Commands;
+
+use CodeIgniter\CLI\AbstractCommand;
+use CodeIgniter\CLI\Attributes\Command;
+use CodeIgniter\CLI\CLI;
+
+#[Command(name: 'dev:only', description: 'A dev only command', group: 'Dev')]
+class DevOnly extends AbstractCommand
+{
+    public function isAvailable(): bool
+    {
+        // Only allow this command in the development environment
+        return ENVIRONMENT === 'development';
+    }
+
+    protected function execute(array $arguments, array $options): int
+    {
+        // ...
+
+        return EXIT_SUCCESS;
+    }
+}

--- a/user_guide_src/source/cli/cli_modern_commands/013.php
+++ b/user_guide_src/source/cli/cli_modern_commands/013.php
@@ -4,12 +4,11 @@ namespace App\Commands;
 
 use CodeIgniter\CLI\AbstractCommand;
 use CodeIgniter\CLI\Attributes\Command;
-use CodeIgniter\CLI\CLI;
 
 #[Command(name: 'dev:only', description: 'A dev only command', group: 'Dev')]
 class DevOnly extends AbstractCommand
 {
-    public function isAvailable(): bool
+    protected function isAvailable(): bool
     {
         // Only allow this command in the development environment
         return ENVIRONMENT === 'development';


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This PR adds a new method in `AbstractCommand.php`, `isAvailable()`. This method can be used to check in runtime if the command should be executed or not. Many times, we need to define environment specific commands, especially dev commands that shouldn't be callable in production or testing. In this case, one can use `isAvailable()` method to determine whether the command should execute or not.

The `run()` method will first call `isAvailable()` before any other lifecycle methods (like `initialize()`/`interact()`/`execute()`, etc.). The sole purpose of this method is to allow/restrict execution of commands based on runtime environment/config/state and NOT passed arguments or options, and that's why it doesn't accept any parameters.

If a caller calls a command that is not available for particular runtime, `CommandNotAvailableException` is thrown.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
