### PR TITLE
fix: handle null ini values in phpini check

### DIFF
--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -182,8 +182,8 @@ class CheckPhpIni
         foreach ($items as $key => $values) {
             $hasKeyInIni  = array_key_exists($key, $ini);
             $output[$key] = [
-                'global'      => $hasKeyInIni ? $ini[$key]['global_value'] : 'disabled',
-                'current'     => $hasKeyInIni ? $ini[$key]['local_value'] : 'disabled',
+                'global'      => $hasKeyInIni ? (string) ($ini[$key]['global_value'] ?? '') : 'disabled',
+                'current'     => $hasKeyInIni ? (string) ($ini[$key]['local_value'] ?? '') : 'disabled',
                 'recommended' => $values['recommended'] ?? '',
                 'remark'      => $values['remark'] ?? '',
             ];

--- a/tests/system/Security/CheckPhpIniTest.php
+++ b/tests/system/Security/CheckPhpIniTest.php
@@ -18,12 +18,32 @@ use CodeIgniter\Test\StreamFilterTrait;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
+ * @return array<string, array<string, mixed>>|false
+ */
+function ini_get_all(?string $extension = null, bool $details = true): array|false
+{
+    return CheckPhpIniTest::$iniGetAllReturn ?? \ini_get_all($extension, $details);
+}
+
+/**
  * @internal
  */
 #[Group('Others')]
 final class CheckPhpIniTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
+
+    /**
+     * @var array<string, array<string, mixed>>|null
+     */
+    public static ?array $iniGetAllReturn = null;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        self::$iniGetAllReturn = null;
+    }
 
     public function testCheckIni(): void
     {
@@ -49,6 +69,26 @@ final class CheckPhpIniTest extends CIUnitTestCase
             'remark'      => 'Enable when your code requires to read docblock annotations at runtime',
         ];
         $this->assertSame($expected, $output['opcache.save_comments']);
+    }
+
+    public function testCheckIniCastsNullIniValuesToString(): void
+    {
+        self::$iniGetAllReturn = [
+            'default_charset' => [
+                'global_value' => null,
+                'local_value'  => null,
+            ],
+        ];
+
+        $output = self::getPrivateMethodInvoker(CheckPhpIni::class, 'checkIni')();
+
+        $expected = [
+            'global'      => '',
+            'current'     => '',
+            'recommended' => 'UTF-8',
+            'remark'      => '',
+        ];
+        $this->assertSame($expected, $output['default_charset']);
     }
 
     public function testRunCli(): void

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -41,6 +41,7 @@ Bugs Fixed
 - **Filters:** Fixed a bug in ``InvalidChars`` filter where invalid UTF-8 or control characters in array keys were not checked.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
+- **Security:** Fixed a bug where ``CheckPhpIni`` could raise a type error when ``ini_get_all()`` returned ``null`` for a configured directive value.
 - **Session:** Fixed a bug in ``RedisHandler`` where the configured ``$lockMaxRetries`` and ``$lockRetryInterval`` values were not respected when acquiring session locks.
 - **Testing:** Fixed a bug where using ``MockInputOutput`` within a test that also uses ``StreamFilterTrait`` tore down the trait's stream filters, so CLI output produced after the ``MockInputOutput`` interaction (such as in ``tearDown()``) was no longer captured and leaked to the console.
 


### PR DESCRIPTION
Refs #9968.

## Summary
- Normalize null values returned by ini_get_all() before rendering phpini:check output.
- Prevent CLI color/table rendering from receiving null for directives such as request_order or error_reporting on newer PHP runtimes.

## Tests
- vendor/bin/phpunit --no-coverage tests/system/Commands/Utilities/PhpIniCheckTest.php
- vendor/bin/phpunit --no-coverage --order-by=random --random-order-seed=12345 tests/system/Commands
- utils/vendor/bin/php-cs-fixer check --ansi --verbose --diff system/Security/CheckPhpIni.php