### PR TITLE
fix: prevent updateBatch with existing where conditions

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2589,6 +2589,13 @@ class BaseBuilder
      */
     public function updateBatch($set = null, $constraints = null, int $batchSize = 100)
     {
+        if ($this->QBWhere !== []) {
+            throw new DatabaseException(
+                'updateBatch() cannot be safely combined with existing Query Builder WHERE conditions. '
+                . 'Use updateBatch($data, $constraints), onConstraint(), or include all required constraint fields in the batch data.',
+            );
+        }
+
         $this->onConstraint($constraints);
 
         if (isset($this->QBOptions['setQueryAsData'])) {

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -299,6 +299,24 @@ final class UpdateTest extends CIUnitTestCase
         $builder->updateBatch(null, 'id');
     }
 
+    public function testUpdateBatchThrowsExceptionWithWhere(): void
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage(
+            'updateBatch() cannot be safely combined with existing Query Builder WHERE conditions. '
+            . 'Use updateBatch($data, $constraints), onConstraint(), or include all required constraint fields in the batch data.',
+        );
+
+        $builder->where('description', 'old')->updateBatch([
+            [
+                'id'   => 2,
+                'name' => 'Comedian',
+            ],
+        ], 'id');
+    }
+
     public function testUpdateBatchThrowsExceptionWithNoID(): void
     {
         $builder = new BaseBuilder('jobs', $this->db);

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
This PR fixes a bug where `updateBatch()` could be called after Query Builder `where()` conditions, even though that chaining is not supported.

Fixes #10234

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
