### PR TITLE
feat: add Query Builder `explain()`

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2030,6 +2030,47 @@ class BaseBuilder
     }
 
     /**
+     * Explains the select statement based on the other functions called
+     * and runs the query.
+     *
+     * @return BaseResult|false|Query|string SQL string when test mode is enabled.
+     */
+    public function explain(bool $reset = true)
+    {
+        $this->assertExplainSupported();
+
+        $sql = $this->compileExplain($this->compileSelect());
+
+        $result = $this->testMode
+            ? $this->compileFinalQuery($sql)
+            : $this->db->query($sql, $this->binds, false);
+
+        if ($reset) {
+            $this->resetSelect();
+
+            // Clear our binds so we don't eat up memory
+            $this->binds = [];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Ensures the current driver supports explaining Query Builder selects.
+     */
+    protected function assertExplainSupported(): void
+    {
+    }
+
+    /**
+     * Compiles an execution-plan query for the current SELECT query.
+     */
+    protected function compileExplain(string $sql): string
+    {
+        return 'EXPLAIN ' . $sql;
+    }
+
+    /**
      * Generates a platform-specific query string that counts all records in
      * the particular table
      *

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -236,7 +236,7 @@ class Builder extends BaseBuilder
     /**
      * Ensures the current driver supports explaining Query Builder selects.
      */
-    protected function assertExplainSupported(): void
+    protected function assertExplainSupported(): never
     {
         throw new DatabaseException('OCI8 does not support explain().');
     }

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -234,6 +234,14 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Ensures the current driver supports explaining Query Builder selects.
+     */
+    protected function assertExplainSupported(): void
+    {
+        throw new DatabaseException('OCI8 does not support explain().');
+    }
+
+    /**
      * Generates a platform-specific batch update string from the supplied data
      */
     protected function _updateBatch(string $table, array $keys, array $values): string

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -719,7 +719,7 @@ class Builder extends BaseBuilder
     /**
      * Ensures the current driver supports explaining Query Builder selects.
      */
-    protected function assertExplainSupported(): void
+    protected function assertExplainSupported(): never
     {
         throw new DatabaseException('SQLSRV does not support explain().');
     }

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -717,6 +717,14 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Ensures the current driver supports explaining Query Builder selects.
+     */
+    protected function assertExplainSupported(): void
+    {
+        throw new DatabaseException('SQLSRV does not support explain().');
+    }
+
+    /**
      * Compiles the select statement based on the other functions called
      * and runs the query
      *

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -68,6 +68,14 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Compiles an execution-plan query for the current SELECT query.
+     */
+    protected function compileExplain(string $sql): string
+    {
+        return 'EXPLAIN QUERY PLAN ' . $sql;
+    }
+
+    /**
      * Replace statement
      *
      * Generates a platform-specific replace string from the supplied data

--- a/system/Model.php
+++ b/system/Model.php
@@ -16,10 +16,12 @@ namespace CodeIgniter;
 use Closure;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\Exceptions\UniqueConstraintViolationException;
+use CodeIgniter\Database\Query;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\BadMethodCallException;
 use CodeIgniter\Exceptions\InvalidArgumentException;
@@ -530,6 +532,18 @@ class Model extends BaseModel
         $this->prepareSoftDeleteQuery($reset);
 
         return $this->builder()->testMode($test)->countAllResults($reset);
+    }
+
+    /**
+     * Explains the current Model query.
+     *
+     * @return BaseResult|false|Query|string Returns a SQL string if in test mode.
+     */
+    public function explain(bool $reset = true, bool $test = false)
+    {
+        $this->prepareSoftDeleteQuery($reset);
+
+        return $this->builder()->testMode($test)->explain($reset);
     }
 
     /**

--- a/tests/system/Database/Builder/ExplainTest.php
+++ b/tests/system/Database/Builder/ExplainTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Builder;
+
+use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\OCI8\Builder as OCI8Builder;
+use CodeIgniter\Database\SQLite3\Builder as SQLite3Builder;
+use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class ExplainTest extends CIUnitTestCase
+{
+    protected $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = new MockConnection([]);
+    }
+
+    public function testExplainReturnsSqlInTestMode(): void
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+        $builder->testMode();
+
+        $answer = $builder->where('id >', 3)->explain(false);
+
+        $expectedSQL = 'EXPLAIN SELECT * FROM "jobs" WHERE "id" > 3';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+    }
+
+    public function testSQLiteExplainUsesQueryPlanInTestMode(): void
+    {
+        $builder = new SQLite3Builder('jobs', $this->db);
+        $builder->testMode();
+
+        $answer = $builder->where('id >', 3)->explain(false);
+
+        $expectedSQL = 'EXPLAIN QUERY PLAN SELECT * FROM "jobs" WHERE "id" > 3';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+    }
+
+    public function testExplainResetsByDefault(): void
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+        $builder->testMode();
+
+        $builder->where('id >', 3)->explain();
+
+        $this->assertSame('SELECT * FROM "jobs"', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSame([], $builder->getBinds());
+    }
+
+    public function testExplainHonorsResetFalse(): void
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+        $builder->testMode();
+
+        $builder->where('id >', 3)->explain(false);
+
+        $this->assertSame('SELECT * FROM "jobs" WHERE "id" > 3', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSame([
+            'id' => [
+                3,
+                true,
+            ],
+        ], $builder->getBinds());
+    }
+
+    public function testExplainReturnsFalseWhenQueryFails(): void
+    {
+        $db = new MockConnection([]);
+        $db->shouldReturn('execute', false);
+
+        $builder = new BaseBuilder('jobs', $db);
+
+        $this->assertFalse($builder->where('id >', 3)->explain());
+        $this->assertSame('SELECT * FROM "jobs"', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSame([], $builder->getBinds());
+    }
+
+    public function testSQLSRVExplainIsNotSupported(): void
+    {
+        $builder = new SQLSRVBuilder('jobs', new MockConnection([
+            'DBDriver' => 'SQLSRV',
+            'database' => 'test',
+            'schema'   => 'dbo',
+        ]));
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('SQLSRV does not support explain().');
+
+        $builder->explain();
+    }
+
+    public function testSQLSRVExplainChecksSupportBeforeCompilingSelect(): void
+    {
+        $db = new MockConnection([
+            'DBDriver' => 'SQLSRV',
+            'database' => 'test',
+            'schema'   => 'dbo',
+        ]);
+
+        $builder = new SQLSRVBuilder('jobs', $db);
+        $builder->union(new SQLSRVBuilder('jobs', $db))->lockForUpdate();
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('SQLSRV does not support explain().');
+
+        $builder->explain();
+    }
+
+    public function testOCI8ExplainIsNotSupported(): void
+    {
+        $builder = new OCI8Builder('jobs', new MockConnection(['DBDriver' => 'OCI8']));
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('OCI8 does not support explain().');
+
+        $builder->explain();
+    }
+}

--- a/tests/system/Database/Live/ExplainTest.php
+++ b/tests/system/Database/Live/ExplainTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\ResultInterface;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class ExplainTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    public function testExplainReturnsResultForSupportedDrivers(): void
+    {
+        if (in_array($this->db->DBDriver, ['OCI8', 'SQLSRV'], true)) {
+            $this->markTestSkipped($this->db->DBDriver . ' does not support explain().');
+        }
+
+        $result = $this->db->table('job')
+            ->where('name', 'Developer')
+            ->explain();
+
+        $this->assertInstanceOf(ResultInterface::class, $result);
+
+        $expectedPrefix = $this->db->DBDriver === 'SQLite3'
+            ? 'EXPLAIN QUERY PLAN SELECT'
+            : 'EXPLAIN SELECT';
+
+        $this->assertStringStartsWith(
+            $expectedPrefix,
+            str_replace("\n", ' ', (string) $this->db->getLastQuery()),
+        );
+    }
+
+    public function testExplainThrowsForUnsupportedDrivers(): void
+    {
+        if (! in_array($this->db->DBDriver, ['OCI8', 'SQLSRV'], true)) {
+            $this->markTestSkipped($this->db->DBDriver . ' supports explain().');
+        }
+
+        $this->expectException(DatabaseException::class);
+
+        $this->db->table('job')->explain();
+    }
+}

--- a/tests/system/Models/ExplainModelTest.php
+++ b/tests/system/Models/ExplainModelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Models;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Models\UserModel;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class ExplainModelTest extends LiveModelTestCase
+{
+    public function testExplainRespectsSoftDeletesInTestMode(): void
+    {
+        if (in_array($this->db->DBDriver, ['OCI8', 'SQLSRV'], true)) {
+            $this->markTestSkipped($this->db->DBDriver . ' does not support explain().');
+        }
+
+        $this->createModel(UserModel::class);
+
+        $sql = $this->model->where('id', 1)->explain(test: true);
+
+        $expectedPrefix = $this->db->DBDriver === 'SQLite3'
+            ? 'EXPLAIN QUERY PLAN SELECT'
+            : 'EXPLAIN SELECT';
+
+        $this->assertStringStartsWith($expectedPrefix, str_replace("\n", ' ', (string) $sql));
+        $this->assertStringContainsString('deleted_at', (string) $sql);
+    }
+
+    public function testExplainWithDeletedOmitsSoftDeleteConstraintInTestMode(): void
+    {
+        if (in_array($this->db->DBDriver, ['OCI8', 'SQLSRV'], true)) {
+            $this->markTestSkipped($this->db->DBDriver . ' does not support explain().');
+        }
+
+        $this->createModel(UserModel::class);
+
+        $sql = $this->model->withDeleted()->where('id', 1)->explain(test: true);
+
+        $this->assertStringNotContainsString('deleted_at', (string) $sql);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -219,6 +219,7 @@ Query Builder
 -------------
 
 - Added ``exists()`` and ``doesntExist()`` to Query Builder to check whether the current Query Builder query would return at least one row. See :ref:`query-builder-exists`.
+- Added ``explain()`` to Query Builder to run execution-plan queries for the current ``SELECT`` query. See :ref:`query-builder-explain`.
 - Added ``havingBetween()``, ``orHavingBetween()``, ``havingNotBetween()``, and ``orHavingNotBetween()`` to Query Builder. See :ref:`query-builder-having-between`.
 - Added ``whereBetween()``, ``orWhereBetween()``, ``whereNotBetween()``, and ``orWhereNotBetween()`` to Query Builder. See :ref:`query-builder-where-between`.
 - Added ``whereColumn()`` and ``orWhereColumn()`` to compare one column to another column while protecting identifiers by default. See :ref:`query-builder-where-column`.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -123,6 +123,8 @@ Runs an execution-plan query for the current Query Builder ``SELECT`` query:
 
 This method returns a database result object. The result columns are driver-specific
 because each database reports execution plans in its own format.
+You can read the result with ``getResultArray()`` or ``getResultObject()``, the
+same as any other query result.
 If test mode is enabled, it returns the compiled execution-plan SQL string.
 If the query fails and ``DBDebug`` is ``false``, it returns ``false``.
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -129,8 +129,9 @@ If the query fails and ``DBDebug`` is ``false``, it returns ``false``.
 The method resets the current Query Builder state by default. If you need to keep
 the current Query Builder state, you can pass ``false`` as the first parameter.
 
-This method is currently supported by MySQLi, Postgre, and SQLite3. SQLite3 uses
-``EXPLAIN QUERY PLAN``. SQLSRV and OCI8 are not supported by this method.
+.. note:: This method is currently supported by MySQLi, Postgre, and SQLite3.
+    SQLite3 uses ``EXPLAIN QUERY PLAN``. SQLSRV and OCI8 are not supported by
+    this method.
 
 $builder->getWhere()
 --------------------

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -110,6 +110,28 @@ The key thing to notice in the above example is that the second query did not
 utilize ``limit(10, 20)`` but the generated SQL query has ``LIMIT 20, 10``.
 The reason for this outcome is because the parameter in the first query is set to ``false``, ``limit(10, 20)`` remained in the second query.
 
+.. _query-builder-explain:
+
+$builder->explain()
+-------------------
+
+.. versionadded:: 4.8.0
+
+Runs an execution-plan query for the current Query Builder ``SELECT`` query:
+
+.. literalinclude:: query_builder/129.php
+
+This method returns a database result object. The result columns are driver-specific
+because each database reports execution plans in its own format.
+If test mode is enabled, it returns the compiled execution-plan SQL string.
+If the query fails and ``DBDebug`` is ``false``, it returns ``false``.
+
+The method resets the current Query Builder state by default. If you need to keep
+the current Query Builder state, you can pass ``false`` as the first parameter.
+
+This method is currently supported by MySQLi, Postgre, and SQLite3. SQLite3 uses
+``EXPLAIN QUERY PLAN``. SQLSRV and OCI8 are not supported by this method.
+
 $builder->getWhere()
 --------------------
 
@@ -1598,6 +1620,14 @@ Class Reference
 
         Generates a platform-specific query string that counts
         all records in the particular table.
+
+    .. php:method:: explain([$reset = true])
+
+        :param bool $reset: Whether to reset values for SELECTs
+        :returns:   The execution-plan result, SQL string when test mode is enabled, or ``false`` on failure
+        :rtype:     ResultInterface|false|string
+
+        Runs an execution-plan query for the current Query Builder ``SELECT`` query.
 
     .. php:method:: exists([$reset = true])
 

--- a/user_guide_src/source/database/query_builder/129.php
+++ b/user_guide_src/source/database/query_builder/129.php
@@ -1,3 +1,4 @@
 <?php
 
-$query = $builder->where('status', 'pending')->explain();
+$result = $builder->where('status', 'pending')->explain();
+$plan   = $result->getResultArray();

--- a/user_guide_src/source/database/query_builder/129.php
+++ b/user_guide_src/source/database/query_builder/129.php
@@ -1,0 +1,3 @@
+<?php
+
+$query = $builder->where('status', 'pending')->explain();


### PR DESCRIPTION
**Description**

This PR adds `explain()` to Query Builder so applications can inspect the execution plan for the current `SELECT` query without manually compiling and prefixing SQL.

```php
$query = $builder->where('status', 'pending')->explain();
```

The helper intentionally keeps the first slice small:

- MySQLi and Postgre use `EXPLAIN`.
- SQLite3 uses `EXPLAIN QUERY PLAN`.
- SQLSRV and OCI8 throw a clear `DatabaseException` because their explain flows need different mechanics.
- Test mode returns the compiled execution-plan SQL string.
- `DBDebug=false` query failures return `false`, matching normal builder execution behavior.
- The builder state resets by default, with `explain(false)` preserving it.

This also adds `Model::explain()` so model queries keep the expected soft-delete behavior, similar to other terminal builder operations.

Tests cover compiled SQL, SQLite syntax, reset behavior, failure behavior, unsupported drivers, live execution, and Model soft deletes.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide