### PR TITLE
fix: refine FormRequest JSON failure detection

### DIFF
--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -149,17 +149,27 @@ abstract class FormRequest
      * The default implementation redirects back with input and flashes validation
      * errors via the standard ``_ci_validation_errors`` channel (the same channel
      * used by controller-level validation and readable by ``validation_errors()``
-     * helpers). For JSON/AJAX requests it returns a 422 JSON response instead.
+     * helpers). For JSON requests or requests that prefer JSON responses, it
+     * returns a 422 JSON response instead.
      *
      * @param array<string, string> $errors
      */
     protected function failedValidation(array $errors): ResponseInterface
     {
-        if ($this->request->is('json') || $this->request->isAJAX()) {
+        if ($this->shouldReturnJsonResponse()) {
             return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
         }
 
         return redirect()->back()->withInput();
+    }
+
+    /**
+     * Determine whether the default validation failure response should be JSON.
+     */
+    private function shouldReturnJsonResponse(): bool
+    {
+        return $this->request->is('json')
+            || $this->request->negotiate('media', ['text/html', 'application/json'], true) === 'application/json';
     }
 
     /**

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -346,7 +346,22 @@ final class FormRequestTest extends CIUnitTestCase
         $this->assertSame(422, $response->getStatusCode());
     }
 
-    public function testResolveRequestReturns422ForAjaxRequest(): void
+    public function testResolveRequestReturns422WhenJsonIsPreferred(): void
+    {
+        service('superglobals')->setServer('HTTP_ACCEPT', 'application/json');
+        $formRequest = $this->makeFormRequest($this->makeRequest());
+
+        $response = $formRequest->resolveRequest();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame(422, $response->getStatusCode());
+
+        $body = json_decode($response->getBody(), true);
+        $this->assertArrayHasKey('errors', $body);
+        $this->assertArrayHasKey('title', $body['errors']);
+    }
+
+    public function testResolveRequestRedirectsForAjaxRequest(): void
     {
         service('superglobals')->setServer('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
         $formRequest = $this->makeFormRequest($this->makeRequest());
@@ -354,7 +369,30 @@ final class FormRequestTest extends CIUnitTestCase
         $response = $formRequest->resolveRequest();
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame(303, $response->getStatusCode());
+    }
+
+    public function testResolveRequestReturns422ForAjaxRequestThatPrefersJson(): void
+    {
+        service('superglobals')->setServer('HTTP_ACCEPT', 'application/json');
+        service('superglobals')->setServer('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
+        $formRequest = $this->makeFormRequest($this->makeRequest());
+
+        $response = $formRequest->resolveRequest();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testResolveRequestRedirectsForWildcardAcceptHeader(): void
+    {
+        service('superglobals')->setServer('HTTP_ACCEPT', '*/*');
+        $formRequest = $this->makeFormRequest($this->makeRequest());
+
+        $response = $formRequest->resolveRequest();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     // -------------------------------------------------------------------------
@@ -678,7 +716,7 @@ final class FormRequestTest extends CIUnitTestCase
     }
 
     // -------------------------------------------------------------------------
-    // Integration: validation failure - JSON / AJAX
+    // Integration: validation failure - JSON
     // -------------------------------------------------------------------------
 
     #[RunInSeparateProcess]
@@ -697,13 +735,28 @@ final class FormRequestTest extends CIUnitTestCase
     }
 
     #[RunInSeparateProcess]
-    public function testInvalidFormRequestReturns422ForAjaxRequest(): void
+    public function testInvalidFormRequestReturns422WhenJsonIsPreferred(): void
     {
-        service('superglobals')->setServer('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
+        service('superglobals')->setServer('HTTP_ACCEPT', 'application/json');
 
         $response = $this->runRequest('/posts', 'store', 'POST');
 
         $this->assertSame(422, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('errors', $body);
+        $this->assertArrayHasKey('title', $body['errors']);
+    }
+
+    #[RunInSeparateProcess]
+    public function testInvalidFormRequestRedirectsForAjaxRequest(): void
+    {
+        service('superglobals')->setServer('HTTP_REFERER', 'http://example.com/posts/create');
+        service('superglobals')->setServer('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
+
+        $response = $this->runRequest('/posts', 'store', 'POST');
+
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     // -------------------------------------------------------------------------

--- a/user_guide_src/source/incoming/form_requests.rst
+++ b/user_guide_src/source/incoming/form_requests.rst
@@ -40,7 +40,8 @@ Type-hint the FormRequest class as a parameter of your controller method. The
 framework instantiates it, runs authorization and validation, and passes the
 resolved object to your method. If validation fails, the default behavior
 redirects back with errors for web requests or returns a 422 JSON response for
-JSON/AJAX requests - the method body is never reached.
+JSON request bodies or requests that prefer ``application/json`` - the method
+body is never reached.
 
 .. literalinclude:: form_requests/002.php
    :lines: 2-
@@ -209,10 +210,14 @@ control of what happens when a request is rejected. Both methods return a
 .. literalinclude:: form_requests/008.php
    :lines: 2-
 
-The default ``failedValidation()`` already detects JSON and AJAX requests and
-returns the appropriate 422 response automatically. Override it only when you
-need a different behavior, such as always responding with JSON even for ordinary
-browser requests.
+The default ``failedValidation()`` returns a 422 JSON response for JSON request
+bodies or requests that prefer ``application/json`` through the ``Accept``
+header. Otherwise, it redirects back with input and validation errors.
+
+.. note:: The ``X-Requested-With: XMLHttpRequest`` header alone does not select
+    a JSON response. If an AJAX client expects JSON validation errors, send an
+    ``Accept: application/json`` header. If your application needs HTML
+    fragments for AJAX form failures, override ``failedValidation()``.
 
 .. _form-request-flash-normalized:
 

--- a/user_guide_src/source/incoming/form_requests/013.php
+++ b/user_guide_src/source/incoming/form_requests/013.php
@@ -25,7 +25,10 @@ class StorePostRequest extends FormRequest
     // Override so that old() reflects the normalized values on redirect.
     protected function failedValidation(array $errors): ResponseInterface
     {
-        if ($this->request->is('json') || $this->request->isAJAX()) {
+        if (
+            $this->request->is('json')
+            || $this->request->negotiate('media', ['text/html', 'application/json'], true) === 'application/json'
+        ) {
             return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
         }
 


### PR DESCRIPTION
**Description**

This PR adjusts the default `FormRequest` validation failure response so AJAX/XHR requests are not treated as JSON requests automatically.

Currently, the default `failedValidation()` returns a `422` JSON response when either:

- the request body is JSON, or
- the request has `X-Requested-With: XMLHttpRequest`

The JSON body case makes sense, but the XHR case feels too broad. A lot of modern apps use AJAX-like requests while still expecting HTML in response. HTMX, Turbo, Unpoly, and similar HTML-over-the-wire approaches can submit forms asynchronously, but the response may still be an HTML form, modal, sheet, or page fragment with validation errors. In those cases, receiving JSON validation errors by default is surprising and makes `FormRequest` harder to use for HTML-first applications.

With this change, the default JSON response is selected only when the client is explicit about JSON:

- `Content-Type: application/json`
- `Accept: application/json`

Plain AJAX/XHR requests now follow the normal web behavior and redirect back with input and validation errors. If an AJAX client expects JSON, it can send `Accept: application/json`, while HTML-first apps are not pushed into JSON accidentally.

This keeps the default behavior predictable. Apps that need custom failure responses can still override `failedValidation()`, just like they can today.

The docs were updated to make this explicit, and the tests cover JSON body, JSON `Accept`, AJAX-only, AJAX plus JSON `Accept`, wildcard `Accept`, and the controller integration path.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide