### PR TITLE
feat: add immutable URI query variable helpers

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -876,23 +876,17 @@ class URI implements Stringable
     }
 
     /**
-     * Return an instance with one query var added, replaced, or removed.
+     * Return an instance with one query var added or replaced.
      *
      * Note: Method not in PSR-7
      *
-     * @param int|string|null $value Null removes the query var.
+     * @param int|string|null $value
      *
      * @return static
      */
-    public function withQueryVar(string $key, $value)
+    public function withAddedQueryVar(string $key, $value)
     {
         $uri = clone $this;
-
-        if ($value === null) {
-            unset($uri->query[$key]);
-
-            return $uri;
-        }
 
         $uri->query[$key] = $value;
 
@@ -900,25 +894,19 @@ class URI implements Stringable
     }
 
     /**
-     * Return an instance with multiple query vars added, replaced, or removed.
+     * Return an instance with multiple query vars added or replaced.
      *
      * Note: Method not in PSR-7
      *
-     * @param array<string, int|string|null> $params Null values remove query vars.
+     * @param array<string, int|string|null> $params
      *
      * @return static
      */
-    public function withQueryVars(array $params)
+    public function withAddedQueryVars(array $params)
     {
         $uri = clone $this;
 
         foreach ($params as $key => $value) {
-            if ($value === null) {
-                unset($uri->query[$key]);
-
-                continue;
-            }
-
             $uri->query[$key] = $value;
         }
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -876,15 +876,11 @@ class URI implements Stringable
     }
 
     /**
-     * Return an instance with one query var added or replaced.
+     * Returns an instance with one query var added or replaced.
      *
      * Note: Method not in PSR-7
-     *
-     * @param int|string|null $value
-     *
-     * @return static
      */
-    public function withQueryVar(string $key, $value)
+    public function withQueryVar(string $key, int|string|null $value): static
     {
         $uri = clone $this;
 
@@ -894,15 +890,13 @@ class URI implements Stringable
     }
 
     /**
-     * Return an instance with multiple query vars added or replaced.
+     * Returns an instance with multiple query vars added or replaced.
      *
      * Note: Method not in PSR-7
      *
      * @param array<string, int|string|null> $params
-     *
-     * @return static
      */
-    public function withQueryVars(array $params)
+    public function withQueryVars(array $params): static
     {
         $uri = clone $this;
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -884,7 +884,7 @@ class URI implements Stringable
      *
      * @return static
      */
-    public function withAddedQueryVar(string $key, $value)
+    public function withQueryVar(string $key, $value)
     {
         $uri = clone $this;
 
@@ -902,7 +902,7 @@ class URI implements Stringable
      *
      * @return static
      */
-    public function withAddedQueryVars(array $params)
+    public function withQueryVars(array $params)
     {
         $uri = clone $this;
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -876,6 +876,56 @@ class URI implements Stringable
     }
 
     /**
+     * Return an instance with one query var added, replaced, or removed.
+     *
+     * Note: Method not in PSR-7
+     *
+     * @param int|string|null $value Null removes the query var.
+     *
+     * @return static
+     */
+    public function withQueryVar(string $key, $value)
+    {
+        $uri = clone $this;
+
+        if ($value === null) {
+            unset($uri->query[$key]);
+
+            return $uri;
+        }
+
+        $uri->query[$key] = $value;
+
+        return $uri;
+    }
+
+    /**
+     * Return an instance with multiple query vars added, replaced, or removed.
+     *
+     * Note: Method not in PSR-7
+     *
+     * @param array<string, int|string|null> $params Null values remove query vars.
+     *
+     * @return static
+     */
+    public function withQueryVars(array $params)
+    {
+        $uri = clone $this;
+
+        foreach ($params as $key => $value) {
+            if ($value === null) {
+                unset($uri->query[$key]);
+
+                continue;
+            }
+
+            $uri->query[$key] = $value;
+        }
+
+        return $uri;
+    }
+
+    /**
      * Removes one or more query vars from the URI.
      *
      * Note: Method not in PSR-7

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -835,45 +835,45 @@ final class URITest extends CIUnitTestCase
         $this->assertSame('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
     }
 
-    public function testWithAddedQueryVarAddsQueryVarWithoutMutatingOriginal(): void
+    public function testWithQueryVarAddsQueryVarWithoutMutatingOriginal(): void
     {
         $base = 'http://example.com/foo';
         $uri  = new URI($base);
 
-        $new = $uri->withAddedQueryVar('bar', 'baz');
+        $new = $uri->withQueryVar('bar', 'baz');
 
         $this->assertSame('http://example.com/foo?bar=baz', (string) $new);
         $this->assertSame('http://example.com/foo', (string) $uri);
     }
 
-    public function testWithAddedQueryVarReplacesQueryVarAndPreservesFragment(): void
+    public function testWithQueryVarReplacesQueryVarAndPreservesFragment(): void
     {
         $base = 'http://example.com/foo?bar=baz#section';
         $uri  = new URI($base);
 
-        $new = $uri->withAddedQueryVar('bar', 'foz');
+        $new = $uri->withQueryVar('bar', 'foz');
 
         $this->assertSame('http://example.com/foo?bar=foz#section', (string) $new);
         $this->assertSame('http://example.com/foo?bar=baz#section', (string) $uri);
     }
 
-    public function testWithAddedQueryVarKeepsEmptyStringQueryVar(): void
+    public function testWithQueryVarKeepsEmptyStringQueryVar(): void
     {
         $base = 'http://example.com/foo?bar=baz';
         $uri  = new URI($base);
 
-        $new = $uri->withAddedQueryVar('bar', '');
+        $new = $uri->withQueryVar('bar', '');
 
         $this->assertSame('http://example.com/foo?bar=', (string) $new);
         $this->assertSame('http://example.com/foo?bar=baz', (string) $uri);
     }
 
-    public function testWithAddedQueryVarsAddsAndReplacesWithoutMutatingOriginal(): void
+    public function testWithQueryVarsAddsAndReplacesWithoutMutatingOriginal(): void
     {
         $base = 'http://example.com/foo?foo=bar&bar=baz&baz=foz#section';
         $uri  = new URI($base);
 
-        $new = $uri->withAddedQueryVars([
+        $new = $uri->withQueryVars([
             'baz' => 'updated',
             'new' => 'value',
         ]);

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -842,6 +842,7 @@ final class URITest extends CIUnitTestCase
 
         $new = $uri->withQueryVar('bar', 'baz');
 
+        $this->assertNotSame($uri, $new);
         $this->assertSame('http://example.com/foo?bar=baz', (string) $new);
         $this->assertSame('http://example.com/foo', (string) $uri);
     }
@@ -853,6 +854,7 @@ final class URITest extends CIUnitTestCase
 
         $new = $uri->withQueryVar('bar', 'foz');
 
+        $this->assertNotSame($uri, $new);
         $this->assertSame('http://example.com/foo?bar=foz#section', (string) $new);
         $this->assertSame('http://example.com/foo?bar=baz#section', (string) $uri);
     }
@@ -864,6 +866,7 @@ final class URITest extends CIUnitTestCase
 
         $new = $uri->withQueryVar('bar', '');
 
+        $this->assertNotSame($uri, $new);
         $this->assertSame('http://example.com/foo?bar=', (string) $new);
         $this->assertSame('http://example.com/foo?bar=baz', (string) $uri);
     }
@@ -878,6 +881,7 @@ final class URITest extends CIUnitTestCase
             'new' => 'value',
         ]);
 
+        $this->assertNotSame($uri, $new);
         $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=updated&new=value#section', (string) $new);
         $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=foz#section', (string) $uri);
     }

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -835,6 +835,65 @@ final class URITest extends CIUnitTestCase
         $this->assertSame('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
     }
 
+    public function testWithQueryVarAddsQueryVarWithoutMutatingOriginal(): void
+    {
+        $base = 'http://example.com/foo';
+        $uri  = new URI($base);
+
+        $new = $uri->withQueryVar('bar', 'baz');
+
+        $this->assertSame('http://example.com/foo?bar=baz', (string) $new);
+        $this->assertSame('http://example.com/foo', (string) $uri);
+    }
+
+    public function testWithQueryVarReplacesQueryVarAndPreservesFragment(): void
+    {
+        $base = 'http://example.com/foo?bar=baz#section';
+        $uri  = new URI($base);
+
+        $new = $uri->withQueryVar('bar', 'foz');
+
+        $this->assertSame('http://example.com/foo?bar=foz#section', (string) $new);
+        $this->assertSame('http://example.com/foo?bar=baz#section', (string) $uri);
+    }
+
+    public function testWithQueryVarRemovesQueryVarWhenValueIsNull(): void
+    {
+        $base = 'http://example.com/foo?foo=bar&bar=baz&baz=foz';
+        $uri  = new URI($base);
+
+        $new = $uri->withQueryVar('bar', null);
+
+        $this->assertSame('http://example.com/foo?foo=bar&baz=foz', (string) $new);
+        $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=foz', (string) $uri);
+    }
+
+    public function testWithQueryVarKeepsEmptyStringQueryVar(): void
+    {
+        $base = 'http://example.com/foo?bar=baz';
+        $uri  = new URI($base);
+
+        $new = $uri->withQueryVar('bar', '');
+
+        $this->assertSame('http://example.com/foo?bar=', (string) $new);
+        $this->assertSame('http://example.com/foo?bar=baz', (string) $uri);
+    }
+
+    public function testWithQueryVarsAddsReplacesAndRemovesWithoutMutatingOriginal(): void
+    {
+        $base = 'http://example.com/foo?foo=bar&bar=baz&baz=foz#section';
+        $uri  = new URI($base);
+
+        $new = $uri->withQueryVars([
+            'bar' => null,
+            'baz' => 'updated',
+            'new' => 'value',
+        ]);
+
+        $this->assertSame('http://example.com/foo?foo=bar&baz=updated&new=value#section', (string) $new);
+        $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=foz#section', (string) $uri);
+    }
+
     public function testStripQueryVars(): void
     {
         $base = 'http://example.com/foo?foo=bar&bar=baz&baz=foz';

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -835,62 +835,50 @@ final class URITest extends CIUnitTestCase
         $this->assertSame('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
     }
 
-    public function testWithQueryVarAddsQueryVarWithoutMutatingOriginal(): void
+    public function testWithAddedQueryVarAddsQueryVarWithoutMutatingOriginal(): void
     {
         $base = 'http://example.com/foo';
         $uri  = new URI($base);
 
-        $new = $uri->withQueryVar('bar', 'baz');
+        $new = $uri->withAddedQueryVar('bar', 'baz');
 
         $this->assertSame('http://example.com/foo?bar=baz', (string) $new);
         $this->assertSame('http://example.com/foo', (string) $uri);
     }
 
-    public function testWithQueryVarReplacesQueryVarAndPreservesFragment(): void
+    public function testWithAddedQueryVarReplacesQueryVarAndPreservesFragment(): void
     {
         $base = 'http://example.com/foo?bar=baz#section';
         $uri  = new URI($base);
 
-        $new = $uri->withQueryVar('bar', 'foz');
+        $new = $uri->withAddedQueryVar('bar', 'foz');
 
         $this->assertSame('http://example.com/foo?bar=foz#section', (string) $new);
         $this->assertSame('http://example.com/foo?bar=baz#section', (string) $uri);
     }
 
-    public function testWithQueryVarRemovesQueryVarWhenValueIsNull(): void
-    {
-        $base = 'http://example.com/foo?foo=bar&bar=baz&baz=foz';
-        $uri  = new URI($base);
-
-        $new = $uri->withQueryVar('bar', null);
-
-        $this->assertSame('http://example.com/foo?foo=bar&baz=foz', (string) $new);
-        $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=foz', (string) $uri);
-    }
-
-    public function testWithQueryVarKeepsEmptyStringQueryVar(): void
+    public function testWithAddedQueryVarKeepsEmptyStringQueryVar(): void
     {
         $base = 'http://example.com/foo?bar=baz';
         $uri  = new URI($base);
 
-        $new = $uri->withQueryVar('bar', '');
+        $new = $uri->withAddedQueryVar('bar', '');
 
         $this->assertSame('http://example.com/foo?bar=', (string) $new);
         $this->assertSame('http://example.com/foo?bar=baz', (string) $uri);
     }
 
-    public function testWithQueryVarsAddsReplacesAndRemovesWithoutMutatingOriginal(): void
+    public function testWithAddedQueryVarsAddsAndReplacesWithoutMutatingOriginal(): void
     {
         $base = 'http://example.com/foo?foo=bar&bar=baz&baz=foz#section';
         $uri  = new URI($base);
 
-        $new = $uri->withQueryVars([
-            'bar' => null,
+        $new = $uri->withAddedQueryVars([
             'baz' => 'updated',
             'new' => 'value',
         ]);
 
-        $this->assertSame('http://example.com/foo?foo=bar&baz=updated&new=value#section', (string) $new);
+        $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=updated&new=value#section', (string) $new);
         $this->assertSame('http://example.com/foo?foo=bar&bar=baz&baz=foz#section', (string) $uri);
     }
 

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -276,6 +276,7 @@ HTTP
 - ``CLIRequest`` now supports options with values specified using an equals sign (e.g., ``--option=value``) in addition to the existing space-separated syntax (e.g., ``--option value``).
   This provides more flexibility in how you can pass options to CLI requests.
 - Added ``$enableStyleNonce`` and ``$enableScriptNonce`` options to ``Config\App`` to automatically add nonces to control whether to add nonces to style-* and script-* directives in the Content Security Policy (CSP) header when CSP is enabled. See :ref:`csp-control-nonce-generation` for details.
+- Added ``URI::withQueryVar()`` and ``URI::withQueryVars()`` to return a cloned URI with query variables added, replaced, or removed.
 - ``URI`` now accepts an optional boolean second parameter in the constructor, defaulting to ``false``, to control how the query string is parsed in instantiation.
   This is the behavior of ``->useRawQueryString()`` brought into the constructor for convenience. Previously, you need to call ``$uri->useRawQueryString(true)->setURI($uri)`` to get this behavior.
   Now you can simply do ``new URI($uri, true)``.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -276,7 +276,7 @@ HTTP
 - ``CLIRequest`` now supports options with values specified using an equals sign (e.g., ``--option=value``) in addition to the existing space-separated syntax (e.g., ``--option value``).
   This provides more flexibility in how you can pass options to CLI requests.
 - Added ``$enableStyleNonce`` and ``$enableScriptNonce`` options to ``Config\App`` to automatically add nonces to control whether to add nonces to style-* and script-* directives in the Content Security Policy (CSP) header when CSP is enabled. See :ref:`csp-control-nonce-generation` for details.
-- Added ``URI::withAddedQueryVar()`` and ``URI::withAddedQueryVars()`` to return a cloned URI with query variables added or replaced.
+- Added ``URI::withQueryVar()`` and ``URI::withQueryVars()`` to return a cloned URI with query variables added or replaced.
 - ``URI`` now accepts an optional boolean second parameter in the constructor, defaulting to ``false``, to control how the query string is parsed in instantiation.
   This is the behavior of ``->useRawQueryString()`` brought into the constructor for convenience. Previously, you need to call ``$uri->useRawQueryString(true)->setURI($uri)`` to get this behavior.
   Now you can simply do ``new URI($uri, true)``.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -276,7 +276,7 @@ HTTP
 - ``CLIRequest`` now supports options with values specified using an equals sign (e.g., ``--option=value``) in addition to the existing space-separated syntax (e.g., ``--option value``).
   This provides more flexibility in how you can pass options to CLI requests.
 - Added ``$enableStyleNonce`` and ``$enableScriptNonce`` options to ``Config\App`` to automatically add nonces to control whether to add nonces to style-* and script-* directives in the Content Security Policy (CSP) header when CSP is enabled. See :ref:`csp-control-nonce-generation` for details.
-- Added ``URI::withQueryVar()`` and ``URI::withQueryVars()`` to return a cloned URI with query variables added, replaced, or removed.
+- Added ``URI::withAddedQueryVar()`` and ``URI::withAddedQueryVars()`` to return a cloned URI with query variables added or replaced.
 - ``URI`` now accepts an optional boolean second parameter in the constructor, defaulting to ``false``, to control how the query string is parsed in instantiation.
   This is the behavior of ``->useRawQueryString()`` brought into the constructor for convenience. Previously, you need to call ``$uri->useRawQueryString(true)->setURI($uri)`` to get this behavior.
   Now you can simply do ``new URI($uri, true)``.

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -188,6 +188,19 @@ parameter is the name of the variable, and the second parameter is the value:
 
 .. literalinclude:: uri/019.php
 
+Changing Query Values Without Mutation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 4.8.0
+
+You can return a new URI instance with one or more query variables changed by using the ``withQueryVar()``
+and ``withQueryVars()`` methods. Existing query variables are preserved unless they are replaced or removed.
+Passing ``null`` removes a query variable:
+
+.. literalinclude:: uri/028.php
+
+The original URI instance is not modified.
+
 Filtering Query Values
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -193,9 +193,9 @@ Changing Query Values Without Mutation
 
 .. versionadded:: 4.8.0
 
-You can return a new URI instance with one or more query variables changed by using the ``withQueryVar()``
-and ``withQueryVars()`` methods. Existing query variables are preserved unless they are replaced or removed.
-Passing ``null`` removes a query variable:
+You can return a new URI instance with one or more query variables added or replaced by using the
+``withAddedQueryVar()`` and ``withAddedQueryVars()`` methods. Existing query variables are preserved unless they
+are replaced:
 
 .. literalinclude:: uri/028.php
 

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -194,7 +194,7 @@ Changing Query Values Without Mutation
 .. versionadded:: 4.8.0
 
 You can return a new URI instance with one or more query variables added or replaced by using the
-``withAddedQueryVar()`` and ``withAddedQueryVars()`` methods. Existing query variables are preserved unless they
+``withQueryVar()`` and ``withQueryVars()`` methods. Existing query variables are preserved unless they
 are replaced:
 
 .. literalinclude:: uri/028.php

--- a/user_guide_src/source/libraries/uri/028.php
+++ b/user_guide_src/source/libraries/uri/028.php
@@ -1,0 +1,16 @@
+<?php
+
+$uri = new \CodeIgniter\HTTP\URI('https://example.com/users?q=bob&page=1');
+
+$nextPage = $uri->withQueryVar('page', 2);
+// https://example.com/users?q=bob&page=2
+
+$withoutSearch = $uri->withQueryVar('q', null);
+// https://example.com/users?page=1
+
+$filtered = $uri->withQueryVars([
+    'q'    => null,
+    'page' => 1,
+    'role' => 'admin',
+]);
+// https://example.com/users?page=1&role=admin

--- a/user_guide_src/source/libraries/uri/028.php
+++ b/user_guide_src/source/libraries/uri/028.php
@@ -2,15 +2,12 @@
 
 $uri = new \CodeIgniter\HTTP\URI('https://example.com/users?q=bob&page=1');
 
-$nextPage = $uri->withQueryVar('page', 2);
+$nextPage = $uri->withAddedQueryVar('page', 2);
 // https://example.com/users?q=bob&page=2
 
-$withoutSearch = $uri->withQueryVar('q', null);
-// https://example.com/users?page=1
-
-$filtered = $uri->withQueryVars([
-    'q'    => null,
+$filtered = $uri->withAddedQueryVars([
+    'q'    => 'alice',
     'page' => 1,
     'role' => 'admin',
 ]);
-// https://example.com/users?page=1&role=admin
+// https://example.com/users?q=alice&page=1&role=admin

--- a/user_guide_src/source/libraries/uri/028.php
+++ b/user_guide_src/source/libraries/uri/028.php
@@ -2,10 +2,10 @@
 
 $uri = new \CodeIgniter\HTTP\URI('https://example.com/users?q=bob&page=1');
 
-$nextPage = $uri->withAddedQueryVar('page', 2);
+$nextPage = $uri->withQueryVar('page', 2);
 // https://example.com/users?q=bob&page=2
 
-$filtered = $uri->withAddedQueryVars([
+$filtered = $uri->withQueryVars([
     'q'    => 'alice',
     'page' => 1,
     'role' => 'admin',


### PR DESCRIPTION
**Description**

This PR proposes adding two small helpers to `URI` for changing query variables without mutating the current instance:

```php
$nextPage = $uri->withQueryVar('page', 2);

$filtered = $uri->withQueryVars([
    'q'    => 'alice',
    'page' => 1,
    'role' => 'admin',
]);
```

Both methods return a cloned URI. Existing query variables are preserved, matching keys are replaced, and new keys are added.

This is handy for everyday URL-building work: pagination links, filter links, canonical URLs, and other places where code needs to adjust a URI while preserving the original instance.

The naming follows the direction discussed in review: `withQueryVar()` / `withQueryVars()` are for merging into the current query, while future immutable full-query replacement can use names like `withQuery()` / `withQueryArray()`.

Tests cover single and bulk query updates, replacing existing values, preserving empty strings, preserving fragments, and keeping the original URI unchanged.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide