### PR TITLE
feat: add scoped transaction options

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1089,66 +1089,91 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @param callable(self): TReturn $callback
      * @param positive-int            $attempts
+     * @param bool|null               $transException   Temporarily override transaction exception mode.
+     * @param bool                    $resetTransStatus Reset transaction status before an outermost transaction starts.
      *
      * @return false|TReturn
      */
-    public function transaction(callable $callback, int $attempts = 1): mixed
-    {
+    public function transaction(
+        callable $callback,
+        int $attempts = 1,
+        ?bool $transException = null,
+        bool $resetTransStatus = false,
+    ): mixed {
         if ($attempts < 1) {
             throw new InvalidArgumentException('Transaction attempts must be a positive integer.');
         }
 
-        if (! $this->transEnabled) {
-            return $callback($this);
+        $restoreTransException  = $transException !== null;
+        $previousTransException = $this->transException;
+
+        if ($restoreTransException) {
+            $this->transException = $transException;
         }
 
-        $attempts = $this->transDepth === 0 ? $attempts : 1;
-
-        for ($attempt = 1; $attempt <= $attempts; $attempt++) {
-            if (! $this->transBegin()) {
-                return false;
+        try {
+            if (! $this->transEnabled) {
+                return $callback($this);
             }
 
-            try {
-                $result = $callback($this);
-            } catch (Throwable $e) {
+            $outermostTransaction = $this->transDepth === 0;
+
+            if ($resetTransStatus && $outermostTransaction) {
+                $this->resetTransStatus();
+            }
+
+            $attempts = $outermostTransaction ? $attempts : 1;
+
+            for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+                if (! $this->transBegin()) {
+                    return false;
+                }
+
                 try {
-                    $this->transRollback();
-                } catch (Throwable $rollbackException) {
-                    log_message('error', 'Database: Transaction callback threw an exception before rollback failed: ' . $e);
+                    $result = $callback($this);
+                } catch (Throwable $e) {
+                    try {
+                        $this->transRollback();
+                    } catch (Throwable $rollbackException) {
+                        log_message('error', 'Database: Transaction callback threw an exception before rollback failed: ' . $e);
 
-                    throw $rollbackException;
-                } finally {
-                    if ($this->transDepth > 0) {
-                        $this->transStatus = false;
-                    } elseif ($this->transStrict === false) {
-                        $this->transStatus = true;
+                        throw $rollbackException;
+                    } finally {
+                        if ($this->transDepth > 0) {
+                            $this->transStatus = false;
+                        } elseif ($this->transStrict === false) {
+                            $this->transStatus = true;
+                        }
                     }
+
+                    if ($this->transDepth === 0 && $e instanceof RetryableTransactionException && $attempt < $attempts) {
+                        $this->prepareTransactionRetry();
+
+                        continue;
+                    }
+
+                    throw $e;
                 }
 
-                if ($this->transDepth === 0 && $e instanceof RetryableTransactionException && $attempt < $attempts) {
-                    $this->prepareTransactionRetry();
+                if (! $this->transComplete()) {
+                    if ($this->transDepth === 0 && $this->transFailureException instanceof RetryableTransactionException && $attempt < $attempts) {
+                        $this->prepareTransactionRetry();
 
-                    continue;
+                        continue;
+                    }
+
+                    return false;
                 }
 
-                throw $e;
+                return $result;
             }
 
-            if (! $this->transComplete()) {
-                if ($this->transDepth === 0 && $this->transFailureException instanceof RetryableTransactionException && $attempt < $attempts) {
-                    $this->prepareTransactionRetry();
-
-                    continue;
-                }
-
-                return false;
+            return false;
+        } finally {
+            if ($restoreTransException) {
+                $this->transException = $previousTransException;
             }
-
-            return $result;
         }
-
-        return false;
     }
 
     /**

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -145,10 +145,17 @@ interface ConnectionInterface
      *
      * @param callable(self): TReturn $callback
      * @param positive-int            $attempts
+     * @param bool|null               $transException   Temporarily override transaction exception mode.
+     * @param bool                    $resetTransStatus Reset transaction status before an outermost transaction starts.
      *
      * @return false|TReturn
      */
-    public function transaction(callable $callback, int $attempts = 1): mixed;
+    public function transaction(
+        callable $callback,
+        int $attempts = 1,
+        ?bool $transException = null,
+        bool $resetTransStatus = false,
+    ): mixed;
 
     /**
      * Returns an instance of the query builder for this connection.

--- a/tests/system/Database/Live/TransactionClosureTest.php
+++ b/tests/system/Database/Live/TransactionClosureTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\RetryableTransactionException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
@@ -100,6 +101,25 @@ final class TransactionClosureTest extends CIUnitTestCase
         $this->assertSame([2], $callbacks);
         $this->dontSeeInDatabase('job', ['name' => 'Retried Job 1']);
         $this->seeInDatabase('job', ['name' => 'Retried Job 2']);
+    }
+
+    public function testTransactionScopedTransExceptionRestoresAfterRetryAttempts(): void
+    {
+        $attempts = 0;
+
+        $result = $this->db->transaction(static function () use (&$attempts): string {
+            $attempts++;
+
+            if ($attempts === 1) {
+                throw new RetryableTransactionException('Deadlock found when trying to get lock.', 1213);
+            }
+
+            return 'committed';
+        }, attempts: 2, transException: true);
+
+        $this->assertSame('committed', $result);
+        $this->assertSame(2, $attempts);
+        $this->assertFalse($this->getPrivateProperty($this->db, 'transException'));
     }
 
     public function testRollbackCallbacksRunForFailedRetryAttempts(): void
@@ -239,6 +259,121 @@ final class TransactionClosureTest extends CIUnitTestCase
 
         $this->assertFalse($result);
         $this->dontSeeInDatabase('job', ['name' => 'Rolled Back Job']);
+
+        $this->enableDBDebug();
+    }
+
+    public function testTransactionScopedTransExceptionRestoresAfterSuccess(): void
+    {
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'name'        => 'Scoped Exception Mode Job',
+                'description' => 'The transaction should commit.',
+            ]);
+
+            return 'committed';
+        }, transException: true);
+
+        $this->assertSame('committed', $result);
+        $this->assertFalse($this->getPrivateProperty($this->db, 'transException'));
+    }
+
+    public function testTransactionScopedTransExceptionRestoresAfterQueryFailure(): void
+    {
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->table('job')->insert([
+                    'id'          => 1,
+                    'name'        => 'Duplicate Job',
+                    'description' => 'This should fail.',
+                ]);
+            }, transException: true);
+            $this->fail('Expected database exception.');
+        } catch (DatabaseException) {
+            // The scoped transaction exception mode should be restored after failure.
+        }
+
+        $this->assertFalse($this->getPrivateProperty($this->db, 'transException'));
+    }
+
+    public function testTransactionScopedTransExceptionCanTemporarilyDisableExistingMode(): void
+    {
+        $this->db->transException(true);
+
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'id'          => 1,
+                'name'        => 'Duplicate Job',
+                'description' => 'This should fail.',
+            ]);
+
+            return 'not returned';
+        }, transException: false);
+
+        $this->assertFalse($result);
+        $this->assertTrue($this->getPrivateProperty($this->db, 'transException'));
+    }
+
+    public function testTransactionResetTransStatusRestartsAfterStrictModeFailure(): void
+    {
+        $this->disableDBDebug();
+
+        $failed = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'id'          => 1,
+                'name'        => 'Duplicate Job',
+                'description' => 'This should fail.',
+            ]);
+
+            return 'not returned';
+        });
+
+        $this->assertFalse($failed);
+        $this->assertFalse($this->db->transStatus());
+
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'name'        => 'Restarted Job',
+                'description' => 'The transaction should commit.',
+            ]);
+
+            return 'committed';
+        }, resetTransStatus: true);
+
+        $this->assertSame('committed', $result);
+        $this->assertTrue($this->db->transStatus());
+        $this->seeInDatabase('job', ['name' => 'Restarted Job']);
+
+        $this->enableDBDebug();
+    }
+
+    public function testTransactionWithoutResetTransStatusPreservesStrictModeFailure(): void
+    {
+        $this->disableDBDebug();
+
+        $failed = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'id'          => 1,
+                'name'        => 'Duplicate Job',
+                'description' => 'This should fail.',
+            ]);
+
+            return 'not returned';
+        });
+
+        $this->assertFalse($failed);
+
+        $result = $this->db->transaction(static function (BaseConnection $db): string {
+            $db->table('job')->insert([
+                'name'        => 'Still Rolled Back Job',
+                'description' => 'The strict-mode failure should still apply.',
+            ]);
+
+            return 'not returned';
+        });
+
+        $this->assertFalse($result);
+        $this->dontSeeInDatabase('job', ['name' => 'Still Rolled Back Job']);
 
         $this->enableDBDebug();
     }
@@ -410,6 +545,27 @@ final class TransactionClosureTest extends CIUnitTestCase
 
         $this->dontSeeInDatabase('job', ['name' => 'Outer Job']);
         $this->dontSeeInDatabase('job', ['name' => 'Inner Job']);
+    }
+
+    public function testNestedTransactionResetTransStatusDoesNotClearOuterFailure(): void
+    {
+        $this->disableDBDebug();
+
+        $this->db->transStart();
+        $this->db->table('job')->insert([
+            'id'          => 1,
+            'name'        => 'Duplicate Job',
+            'description' => 'This should fail.',
+        ]);
+
+        $result = $this->db->transaction(static fn (): string => 'not returned', resetTransStatus: true);
+
+        $this->assertFalse($result);
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->enableDBDebug();
     }
 
     public function testNestedTransactionRetryAttemptsRunOnce(): void

--- a/tests/system/Database/Live/TransactionClosureTest.php
+++ b/tests/system/Database/Live/TransactionClosureTest.php
@@ -568,6 +568,31 @@ final class TransactionClosureTest extends CIUnitTestCase
         $this->enableDBDebug();
     }
 
+    public function testNestedTransactionScopedTransExceptionQueryFailureRollsBackOuterTransaction(): void
+    {
+        $this->db->transStart();
+        $this->db->table('job')->insert([
+            'name'        => 'Outer Job',
+            'description' => 'The outer transaction should roll back.',
+        ]);
+
+        try {
+            $this->db->transaction(static function (BaseConnection $db): void {
+                $db->table('job')->insert([
+                    'id'          => 1,
+                    'name'        => 'Duplicate Job',
+                    'description' => 'This should fail.',
+                ]);
+            }, transException: true);
+            $this->fail('Expected database exception.');
+        } catch (DatabaseException) {
+            // Existing transaction exception handling rolls back the full stack.
+        }
+
+        $this->assertSame(0, $this->db->transDepth);
+        $this->dontSeeInDatabase('job', ['name' => 'Outer Job']);
+    }
+
     public function testNestedTransactionRetryAttemptsRunOnce(): void
     {
         $attempts = 0;

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -212,7 +212,7 @@ Database
 - Added ``inTransaction()`` to database connections to check whether the connection is inside an active CodeIgniter-managed transaction. See :ref:`transactions-checking-transaction-state`.
 - Prepared query execution failures now throw or store typed database exceptions such as ``UniqueConstraintViolationException`` and ``RetryableTransactionException`` when applicable, matching normal query failures.
 - Added ``RetryableTransactionException`` for driver-specific retryable transaction failures such as deadlocks and serialization failures. See :ref:`transactions-retryable-exceptions`.
-- Added the ``transaction()`` method to database connections to run a callback inside a transaction, with optional retry attempts for retryable transaction failures. See :ref:`transactions-closure`.
+- Added the ``transaction()`` method to database connections to run a callback inside a transaction, with optional retry attempts for retryable transaction failures and scoped ``transException`` and ``resetTransStatus`` options. See :ref:`transactions-closure`.
 - Added ``trustServerCertificate`` option to ``SQLSRV`` database connections in ``Config\Database``. Set it to ``true`` to trust the server certificate without CA validation when using encrypted connections.
 
 Query Builder

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -95,7 +95,9 @@ exception mode configured by ``transException()``. The previous mode is restored
 after ``transaction()`` finishes, even if the callback throws an exception.
 If ``transaction()`` is called inside an active transaction, the temporary mode
 applies while the nested callback runs, then the previous mode is restored for
-the outer transaction.
+the outer transaction. When ``transException`` is set to ``true`` in a nested
+transaction and a query fails, CodeIgniter's existing transaction exception
+handling rolls back the outer transaction as well.
 
 Set ``resetTransStatus`` to reset the transaction status before the helper starts
 an outermost transaction. This is equivalent to calling ``resetTransStatus()``

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -82,6 +82,33 @@ Callbacks registered with ``afterCommit()`` or ``afterRollback()`` inside the
 transaction callback follow the same rules as other transaction callbacks: they
 run only after the outermost transaction commits or rolls back.
 
+Scoped Transaction Options
+--------------------------
+
+The ``transaction()`` method can temporarily override existing transaction
+options for the duration of the helper call:
+
+.. literalinclude:: transactions/017.php
+
+Set ``transException`` to temporarily enable or disable the same transaction
+exception mode configured by ``transException()``. The previous mode is restored
+after ``transaction()`` finishes, even if the callback throws an exception.
+If ``transaction()`` is called inside an active transaction, the temporary mode
+applies while the nested callback runs, then the previous mode is restored for
+the outer transaction.
+
+Set ``resetTransStatus`` to reset the transaction status before the helper starts
+an outermost transaction. This is equivalent to calling ``resetTransStatus()``
+before the transaction, and is useful when strict mode has marked the connection
+as failed from an earlier transaction.
+
+``resetTransStatus`` only applies when ``transaction()`` starts the outermost
+transaction. If ``transaction()`` is called inside an active transaction, it does
+not reset the outer transaction status.
+
+The ``transException`` option follows CodeIgniter's existing transaction
+exception behavior, including the current ``DBDebug`` setting.
+
 Retrying Transactions
 ---------------------
 

--- a/user_guide_src/source/database/transactions/017.php
+++ b/user_guide_src/source/database/transactions/017.php
@@ -1,0 +1,11 @@
+<?php
+
+$result = $this->db->transaction(
+    static function ($db) use ($order) {
+        $db->table('orders')->insert($order);
+
+        return $db->insertID();
+    },
+    transException: true,
+    resetTransStatus: true,
+);


### PR DESCRIPTION
**Description**

This PR proposes adding scoped transaction options to the closure-based `transaction()` helper. The goal is narrow: make two existing transaction controls local to a single `transaction()` call, without changing CodeIgniter’s transaction model.

Today, the closure helper lets users keep transactional work in one focused block:

```php
$result = $db->transaction(static function ($db) {
    // transactional work
});
```

But some behavior that directly affects that transaction still has to be configured outside the call, through mutable connection state:

```php
$db->resetTransStatus();
$db->transException(true);

$result = $db->transaction(static function ($db) {
    // transactional work
});
```

That means the transaction body is local, but the transaction policy is not. A reader has to look before the helper call to understand how query failures will behave, whether a previous strict-mode failure has been cleared, and whether temporary connection state might affect later code.

For simple write transactions this is mostly ceremony. In larger applications, it is also an easy place for accidental state leakage or local wrapper APIs to appear.

This PR keeps the existing behavior and names, but allows those controls to be scoped to one helper call:

```php
$result = $db->transaction(
    static function ($db) use ($order) {
        $db->table('orders')->insert($order);

        return $db->insertID();
    },
    transException: true,
    resetTransStatus: true,
);
```

`transException` temporarily applies the same transaction exception mode configured by `transException()`. The previous mode is restored after the helper finishes, including when the callback throws.

`resetTransStatus` resets transaction status before the helper starts an outermost transaction. This is equivalent to calling `resetTransStatus()` before the transaction, but keeps that intent attached to the transaction call itself.

This does not add a new "strict transaction" mode. It does not change retry behavior, transaction strict mode, callback behavior, or the `false|TReturn` return contract. The defaults preserve current behavior.

The boundaries are intentional:

- `transException` follows existing CodeIgniter transaction exception behavior, including `DBDebug`.
- `transException` is restored after the helper finishes.
- `resetTransStatus` only applies when `transaction()` starts the outermost transaction.
- Nested calls cannot clear an outer transaction failure.
- Retry attempts still behave as they do today.

Tests cover scoped exception-mode restoration, temporary disabling of an existing exception mode, strict-mode status reset behavior, nested transaction safety, and retry attempts.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide