### PR TITLE
fix: detect Safari version from Version token

### DIFF
--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -317,8 +317,15 @@ class UserAgent implements Stringable
         if (is_array($this->config->browsers) && $this->config->browsers !== []) {
             foreach ($this->config->browsers as $key => $val) {
                 if (preg_match('|' . $key . '.*?([0-9\.]+)|i', $this->agent, $match)) {
+                    $version = $match[1];
+
+                    // Safari's browser version is reported in the Version token.
+                    if ($val === 'Safari' && preg_match('|Version/([0-9\.]+).*?Safari|i', $this->agent, $safariMatch)) {
+                        $version = $safariMatch[1];
+                    }
+
                     $this->isBrowser = true;
-                    $this->version   = $match[1];
+                    $this->version   = $version;
                     $this->browser   = $val;
                     $this->setMobile();
 

--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -74,8 +74,36 @@ final class UserAgentTest extends CIUnitTestCase
     {
         $this->assertSame('Mac OS X', $this->agent->getPlatform());
         $this->assertSame('Safari', $this->agent->getBrowser());
-        $this->assertSame('533.20.27', $this->agent->getVersion());
+        $this->assertSame('5.0.4', $this->agent->getVersion());
         $this->assertSame('', $this->agent->getRobot());
+    }
+
+    public function testParseModernSafariUsesVersionToken(): void
+    {
+        $this->agent->parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15');
+
+        $this->assertSame('Mac OS X', $this->agent->getPlatform());
+        $this->assertSame('Safari', $this->agent->getBrowser());
+        $this->assertSame('16.3', $this->agent->getVersion());
+    }
+
+    public function testParseMobileSafariUsesVersionToken(): void
+    {
+        $this->agent->parse($this->_mobile_ua);
+
+        $this->assertSame('iOS', $this->agent->getPlatform());
+        $this->assertSame('Safari', $this->agent->getBrowser());
+        $this->assertSame('4.0.5', $this->agent->getVersion());
+        $this->assertSame('Apple iPhone', $this->agent->getMobile());
+    }
+
+    public function testParseChromeWithSafariTokenUsesChromeVersion(): void
+    {
+        $this->agent->parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36');
+
+        $this->assertSame('Mac OS X', $this->agent->getPlatform());
+        $this->assertSame('Chrome', $this->agent->getBrowser());
+        $this->assertSame('110.0.0.0', $this->agent->getVersion());
     }
 
     public function testParse(): void

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -31,6 +31,7 @@ Bugs Fixed
 **********
 
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
+- **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**

This PR fixes Safari version detection in the `UserAgent` parser. Safari user agents commonly include both a `Version/...` token and a `Safari/...` token:

```text
Version/16.3 Safari/605.1.15
```

The `Safari/...` token is not the user-facing Safari browser version. The actual browser version is reported by `Version/...`.

Previously, CodeIgniter identified the browser as Safari but returned the `Safari/...` value as the version. That could make browser-version checks behave incorrectly, e.g. treating Safari `16.3` as newer than `16.4` because it was reported as `605.1.15`.

This keeps Safari detection unchanged, but when Safari is matched it uses the `Version/...` token for `getVersion()` if present.

Tests cover desktop Safari, mobile Safari, and Chrome user agents that also contain a `Safari/...` token.

Fixes #10250

**Checklist:**

- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide