### PR TITLE
docs: update official package status

### DIFF
--- a/user_guide_src/source/libraries/official_packages.rst
+++ b/user_guide_src/source/libraries/official_packages.rst
@@ -41,18 +41,18 @@ while defaulting to the config files when not custom value has been stored. This
 an application to ship with the default config values, but adapt as the project grows
 or moves servers, without having to touch the code.
 
-************
-Tasks (BETA)
-************
+*****
+Tasks
+*****
 
 `CodeIgniter Tasks <https://tasks.codeigniter.com>`_ is a simple task scheduler
 for CodeIgniter 4. It allows you to schedule tasks to run at specific times, or
 on a recurring basis. It is designed to be simple to use, but flexible enough to
 handle most use cases.
 
-************
-Queue (BETA)
-************
+*****
+Queue
+*****
 
 `CodeIgniter Queue <https://queue.codeigniter.com>`_ is a simple queue system
 for CodeIgniter 4. It allows you to queue up tasks to be run later.


### PR DESCRIPTION
**Description**

This PR removes the stale `(BETA)` labels from the Tasks and Queue entries on the [Official Packages](https://codeigniter.com/user_guide/libraries/official_packages.html#tasks-beta) page. Both packages now have stable `v1.0+` releases, so the current labels are outdated.

**Checklist:**

- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide