### PR TITLE
refactor: restrict object deserialization in selected unserialize() calls

### DIFF
--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -92,7 +92,8 @@ class PredisHandler extends BaseHandler
         }
 
         return match ($data['__ci_type']) {
-            'array', 'object'                                => unserialize($data['__ci_value']),
+            'array'                                          => unserialize($data['__ci_value'], ['allowed_classes' => false]),
+            'object'                                         => unserialize($data['__ci_value']),
             'boolean', 'integer', 'double', 'string', 'NULL' => settype($data['__ci_value'], $data['__ci_type']) ? $data['__ci_value'] : null,
             default                                          => null,
         };

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -108,7 +108,8 @@ class RedisHandler extends BaseHandler
         }
 
         return match ($data['__ci_type']) {
-            'array', 'object'                                => unserialize($data['__ci_value']),
+            'array'                                          => unserialize($data['__ci_value'], ['allowed_classes' => false]),
+            'object'                                         => unserialize($data['__ci_value']),
             'boolean', 'integer', 'double', 'string', 'NULL' => settype($data['__ci_value'], $data['__ci_type']) ? $data['__ci_value'] : null,
             default                                          => null,
         };

--- a/system/Cache/ResponseCache.php
+++ b/system/Cache/ResponseCache.php
@@ -120,7 +120,7 @@ final class ResponseCache
         $cachedResponse = $this->cache->get($this->generateCacheKey($request));
 
         if (is_string($cachedResponse) && $cachedResponse !== '') {
-            $cachedResponse = unserialize($cachedResponse);
+            $cachedResponse = unserialize($cachedResponse, ['allowed_classes' => false]);
 
             if (
                 ! is_array($cachedResponse)

--- a/system/Entity/Cast/ArrayCast.php
+++ b/system/Entity/Cast/ArrayCast.php
@@ -18,7 +18,7 @@ class ArrayCast extends BaseCast
     public static function get($value, array $params = []): array
     {
         if (is_string($value) && (str_starts_with($value, 'a:') || str_starts_with($value, 's:'))) {
-            $value = unserialize($value);
+            $value = unserialize($value, ['allowed_classes' => false]);
         }
 
         return (array) $value;

--- a/tests/system/Cache/ResponseCacheTest.php
+++ b/tests/system/Cache/ResponseCacheTest.php
@@ -257,4 +257,37 @@ final class ResponseCacheTest extends CIUnitTestCase
         // Check cache with a request with the same URI path.
         $pageCache->get($request, new Response(new App()));
     }
+
+    public function testGetResponseCacheRejectsObjectsInSerializedData(): void
+    {
+        /** @var MockCache $mockCache */
+        $mockCache = mock(CacheFactory::class);
+        $pageCache = new ResponseCache(new Cache(), $mockCache);
+
+        $request = $this->createIncomingRequest('foo/bar');
+
+        $response = new Response(new App());
+        $response->setHeader('ETag', 'abcd1234');
+        $response->setBody('The response body.');
+
+        $pageCache->make($request, $response);
+
+        $cacheKey = $pageCache->generateCacheKey($request);
+
+        // Inject a serialized object (PHP Object Injection simulation).
+        // With allowed_classes => false, unserialize() returns an
+        // __PHP_Incomplete_Class and the subsequent is_array() check rejects it.
+        $malicious = serialize([
+            'output'  => serialize(new \stdClass()),
+            'headers' => [],
+            'status'  => 200,
+            'reason'  => 'OK',
+        ]);
+        $mockCache->save($cacheKey, $malicious);
+
+        // The cache entry contains a nested serialized object; get() should
+        // return false (cache miss) rather than instantiating the object.
+        $result = $pageCache->get($request, new Response(new App()));
+        $this->assertFalse($result);
+    }
 }

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -606,6 +606,26 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame([1, 2, 3], $entity->seventh);
     }
 
+    public function testCastArrayRejectsSerializedObjects(): void
+    {
+        // A serialized object injected as a database column value should not
+        // be instantiated. With allowed_classes => false the object becomes
+        // a __PHP_Incomplete_Class, which is then cast to an array — the
+        // important thing is no real class is instantiated.
+        $entity = $this->getCastEntity();
+
+        // Store a serialized stdClass directly into the raw attribute
+        // (simulating a poisoned DB column value).
+        $this->setPrivateProperty($entity, 'attributes', array_merge(
+            $this->getPrivateProperty($entity, 'attributes'),
+            ['seventh' => serialize(new \stdClass())]
+        ));
+
+        // Accessing the cast attribute must NOT instantiate stdClass.
+        $result = $entity->seventh;
+        $this->assertNotInstanceOf(\stdClass::class, $result);
+    }
+
     public function testCastNullable(): void
     {
         $entity = $this->getCastNullableEntity();

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -30,6 +30,9 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Security:** ``RedisHandler::get()`` and ``PredisHandler::get()`` now pass ``['allowed_classes' => false]`` to ``unserialize()`` when restoring cached arrays, preventing PHP Object Injection via a poisoned cache backend. See `Security Advisory <https://github.com/codeigniter4/CodeIgniter4/security>`_.
+- **Security:** ``ResponseCache::get()`` now passes ``['allowed_classes' => false]`` to ``unserialize()``, preventing PHP Object Injection via the page cache.
+- **Security:** ``Entity/Cast/ArrayCast::get()`` now passes ``['allowed_classes' => false]`` to ``unserialize()``, preventing PHP Object Injection via a poisoned database column value.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 
 See the repo's


### PR DESCRIPTION
**Description**

PHP's `unserialize()` without `allowed_classes` will instantiate any class in the autoloader that's in the payload. A few places in CI4 call it on data that's expected to be plain arrays, not objects — so they're unnecessarily exposed to PHP Object Injection if an attacker can influence what gets stored (cache poisoning, SQL injection, etc).

Three spots I found:

1. `ResponseCache::get()` — the cached page data is always a plain array of `[output, headers, status, reason]`. Passing `allowed_classes => false` is safe here.
2. `RedisHandler` and `PredisHandler` — the `array` branch of the `match` doesn't need to instantiate objects. I split it out so arrays get `allowed_classes => false` while the object branch stays unrestricted.
3. `ArrayCast::get()` in the legacy Entity cast — the newer `DataCaster/Cast/ArrayCast` already has this fix. This patch applies the same thing to the legacy one.

Tests cover: ResponseCache rejecting a poisoned cache entry that contains a serialised object, and ArrayCast not instantiating a class from a poisoned DB column value.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide