### PR TITLE
feat: support `BackedEnum` values in database binds

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
+use BackedEnum;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
@@ -3939,7 +3940,7 @@ class BaseBuilder
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {
-            if ((! is_object($val) || $val instanceof RawSql) && ! is_array($val)) {
+            if (($val instanceof BackedEnum || ! is_object($val) || $val instanceof RawSql) && ! is_array($val)) {
                 $array[$key] = $val;
             }
         }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
+use BackedEnum;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\RetryableTransactionException;
@@ -1758,7 +1759,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Escapes data based on type.
      * Sets boolean and null types
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param array|BackedEnum|bool|float|int|object|string|null $str
      *
      * @return ($str is array ? array : float|int|string)
      */
@@ -1766,6 +1767,10 @@ abstract class BaseConnection implements ConnectionInterface
     {
         if (is_array($str)) {
             return array_map($this->escape(...), $str);
+        }
+
+        if ($str instanceof BackedEnum) {
+            $str = $str->value;
         }
 
         if ($str instanceof Stringable) {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1759,7 +1759,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Escapes data based on type.
      * Sets boolean and null types
      *
-     * @param array|BackedEnum|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return ($str is array ? array : float|int|string)
      */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database;
 
 use ArgumentCountError;
+use BackedEnum;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\BadMethodCallException;
@@ -122,6 +123,12 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      */
     public function execute(...$data)
     {
+        foreach ($data as $key => $value) {
+            if ($value instanceof BackedEnum) {
+                $data[$key] = $value->value;
+            }
+        }
+
         // Execute the Query.
         $startTime = microtime(true);
 

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
+use BackedEnum;
+
 /**
  * @template TConnection
  * @template TResult
@@ -179,7 +181,7 @@ interface ConnectionInterface
      * Escapes data based on type.
      * Sets boolean and null types.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param array|BackedEnum|bool|float|int|object|string|null $str
      *
      * @return ($str is array ? array : float|int|string)
      */

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use BackedEnum;
-
 /**
  * @template TConnection
  * @template TResult
@@ -181,7 +179,7 @@ interface ConnectionInterface
      * Escapes data based on type.
      * Sets boolean and null types.
      *
-     * @param array|BackedEnum|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return ($str is array ? array : float|int|string)
      */

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -355,7 +355,7 @@ class Connection extends BaseConnection
      *
      * Escapes data based on type
      *
-     * @param array|BackedEnum|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return ($str is array ? array : float|int|string)
      */

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Postgre;
 
+use BackedEnum;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\RawSql;
@@ -354,7 +355,7 @@ class Connection extends BaseConnection
      *
      * Escapes data based on type
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param array|BackedEnum|bool|float|int|object|string|null $str
      *
      * @return ($str is array ? array : float|int|string)
      */
@@ -362,6 +363,10 @@ class Connection extends BaseConnection
     {
         if (! $this->connID) {
             $this->initialize();
+        }
+
+        if ($str instanceof BackedEnum) {
+            $str = $str->value;
         }
 
         if ($str instanceof Stringable) {

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Enum\RoleEnum;
+use Tests\Support\Enum\StatusEnum;
 
 /**
  * @internal
@@ -238,6 +240,17 @@ final class BaseQueryTest extends CIUnitTestCase
         $query->setQuery('SELECT * FROM users WHERE name = ?', ["O'Reilly"]);
 
         $expected = "SELECT * FROM users WHERE name = 'O''Reilly'";
+
+        $this->assertSame($expected, $query->getQuery());
+    }
+
+    public function testBindingBackedEnum(): void
+    {
+        $query = new Query($this->db);
+
+        $query->setQuery('SELECT * FROM users WHERE status = ? AND role = ?', [StatusEnum::ACTIVE, RoleEnum::ADMIN]);
+
+        $expected = "SELECT * FROM users WHERE status = 'active' AND role = 2";
 
         $this->assertSame($expected, $query->getQuery());
     }

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -80,6 +80,20 @@ final class InsertTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
     }
 
+    public function testInsertObjectWithBackedEnum(): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder->testMode()->insert((object) [
+            'id'     => 1,
+            'status' => StatusEnum::ACTIVE,
+        ], true);
+
+        $expectedSQL = 'INSERT INTO "jobs" ("id", "status") VALUES (1, \'active\')';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+    }
+
     public function testInsertObject(): void
     {
         $builder = $this->db->table('jobs');

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -20,6 +20,7 @@ use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Enum\StatusEnum;
 
 /**
  * @internal
@@ -63,6 +64,20 @@ final class InsertTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
         $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testInsertWithBackedEnum(): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder->testMode()->insert([
+            'id'     => 1,
+            'status' => StatusEnum::ACTIVE,
+        ], true);
+
+        $expectedSQL = 'INSERT INTO "jobs" ("id", "status") VALUES (1, \'active\')';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
     }
 
     public function testInsertObject(): void

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -25,6 +25,8 @@ use ErrorException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
+use Tests\Support\Enum\RoleEnum;
+use Tests\Support\Enum\StatusEnum;
 
 /**
  * @internal
@@ -398,6 +400,28 @@ final class WhereTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereWithBackedEnum(): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder->where('status', StatusEnum::ACTIVE);
+
+        $expectedSQL = 'SELECT * FROM "jobs" WHERE "status" = \'active\'';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereBetweenWithBackedEnums(): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder->whereBetween('role', [RoleEnum::GUEST, RoleEnum::ADMIN]);
+
+        $expectedSQL = 'SELECT * FROM "jobs" WHERE "role" BETWEEN 0 AND 2';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     #[DataProvider('provideWhereColumnWithOperators')]
@@ -838,6 +862,17 @@ final class WhereTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereInWithBackedEnums(): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder->whereIn('status', [StatusEnum::ACTIVE, StatusEnum::INACTIVE]);
+
+        $expectedSQL = 'SELECT * FROM "jobs" WHERE "status" IN (\'active\',\'inactive\')';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     public function testWhereInSubQuery(): void

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Enum\RoleEnum;
+use Tests\Support\Enum\StatusEnum;
 
 /**
  * @internal
@@ -61,6 +63,16 @@ final class EscapeTest extends CIUnitTestCase
         $sql      = 'SELECT * FROM brands WHERE name = ' . $this->db->escape(new Time('2024-01-01 12:00:00'));
 
         $this->assertSame($expected, $sql);
+    }
+
+    public function testEscapeStringBackedEnum(): void
+    {
+        $this->assertSame("'active'", $this->db->escape(StatusEnum::ACTIVE));
+    }
+
+    public function testEscapeIntBackedEnum(): void
+    {
+        $this->assertSame(2, $this->db->escape(RoleEnum::ADMIN));
     }
 
     public function testEscapeString(): void
@@ -111,7 +123,7 @@ final class EscapeTest extends CIUnitTestCase
 
     public function testEscapeStringArray(): void
     {
-        $stringArray = [' A simple string ', new RawSql('CURRENT_TIMESTAMP()'), false, null];
+        $stringArray = [' A simple string ', new RawSql('CURRENT_TIMESTAMP()'), false, null, StatusEnum::ACTIVE, RoleEnum::ADMIN];
 
         $escapedString = $this->db->escape($stringArray);
 
@@ -125,5 +137,7 @@ final class EscapeTest extends CIUnitTestCase
         }
 
         $this->assertSame('NULL', $escapedString[3]);
+        $this->assertSame("'active'", $escapedString[4]);
+        $this->assertSame(2, $escapedString[5]);
     }
 }

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -23,6 +23,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
+use Tests\Support\Enum\StatusEnum;
 
 /**
  * @internal
@@ -284,6 +285,19 @@ final class PreparedQueryTest extends CIUnitTestCase
 
         $expectedRow = ['name' => 'Derek Jones', 'email' => 'derek@world.com', 'country' => 'US'];
         $this->assertSame($expectedRow, $result->getRowArray());
+    }
+
+    public function testExecuteWithBackedEnum(): void
+    {
+        $this->query = $this->db->prepare(static fn ($db) => $db->table('team_members')
+            ->select('person_id')
+            ->where('status', StatusEnum::PENDING)
+            ->get());
+
+        $result = $this->query->execute(StatusEnum::ACTIVE);
+
+        $this->assertInstanceOf(ResultInterface::class, $result);
+        $this->assertCount(2, $result->getResultArray());
     }
 
     public function testExecuteSelectQueryManualAndCheckTypeAndResult(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -210,6 +210,7 @@ Database
 
 - Added ``afterCommit()`` and ``afterRollback()`` transaction callbacks to database connections. These callbacks run after the outermost transaction commits or rolls back. See :ref:`transactions-transaction-callbacks`.
 - Added ``inTransaction()`` to database connections to check whether the connection is inside an active CodeIgniter-managed transaction. See :ref:`transactions-checking-transaction-state`.
+- Added support for PHP ``BackedEnum`` values in database escaping, query bindings, and Query Builder bound values.
 - Prepared query execution failures now throw or store typed database exceptions such as ``UniqueConstraintViolationException`` and ``RetryableTransactionException`` when applicable, matching normal query failures.
 - Added ``RetryableTransactionException`` for driver-specific retryable transaction failures such as deadlocks and serialization failures. See :ref:`transactions-retryable-exceptions`.
 - Added the ``transaction()`` method to database connections to run a callback inside a transaction, with optional retry attempts for retryable transaction failures and scoped ``transException`` and ``resetTransStatus`` options. See :ref:`transactions-closure`.

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -193,9 +193,9 @@ automatically escaped producing safer queries.
 You don't have to remember to manually escape data - the engine does it automatically for you.
 
 .. versionadded:: 4.8.0
-    Query bindings and Query Builder bound values accept PHP ``BackedEnum``
-    values. CodeIgniter uses the enum backing value when escaping the bound
-    value.
+    Query bindings, prepared query values, and Query Builder bound values accept
+    PHP ``BackedEnum`` values. CodeIgniter uses the enum backing value before
+    escaping or passing the value to the database driver.
 
 .. literalinclude:: queries/032.php
 
@@ -318,6 +318,10 @@ placeholders in the query. They must also be passed in the same order as the pla
 query:
 
 .. literalinclude:: queries/019.php
+
+.. versionadded:: 4.8.0
+    Prepared query values accept PHP ``BackedEnum`` values and pass their
+    backing values to the database driver.
 
 For queries of type "write" it returns true or false, indicating the success or failure of the query.
 For queries of type "read" it returns a standard :doc:`result set </database/results>`.

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -138,6 +138,10 @@ don't have to:
 
 .. literalinclude:: queries/009.php
 
+.. versionadded:: 4.8.0
+    ``$db->escape()`` accepts PHP ``BackedEnum`` values and escapes their backing
+    values.
+
 2. $db->escapeString()
 ======================
 
@@ -187,6 +191,13 @@ The resulting query will be::
 The secondary benefit of using binds is that the values are
 automatically escaped producing safer queries.
 You don't have to remember to manually escape data - the engine does it automatically for you.
+
+.. versionadded:: 4.8.0
+    Query bindings and Query Builder bound values accept PHP ``BackedEnum``
+    values. CodeIgniter uses the enum backing value when escaping the bound
+    value.
+
+.. literalinclude:: queries/032.php
 
 Named Bindings
 ==============

--- a/user_guide_src/source/database/queries/032.php
+++ b/user_guide_src/source/database/queries/032.php
@@ -1,0 +1,8 @@
+<?php
+
+$db->table('users')->where('status', \UserStatus::Active)->get();
+
+$db->query(
+    'SELECT * FROM users WHERE status = ?',
+    [\UserStatus::Active],
+);

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -322,6 +322,13 @@ methods:
 .. note:: ``$builder->where()`` accepts an optional third parameter. If you set it to
     ``false``, CodeIgniter will not try to protect your field or table names.
 
+.. versionadded:: 4.8.0
+    Query Builder methods that bind and escape field values or value lists,
+    such as ``where()``, ``whereIn()``, ``having()``, ``set()``, ``insert()``,
+    and ``update()``, accept PHP ``BackedEnum`` instances and use their backing
+    values. Raw SQL values, such as values passed with escaping disabled, are
+    not converted.
+
 1. Simple key/value method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -783,11 +783,6 @@ parameters:
             path: ../../system/Database/BaseConnection.php
 
         -
-            message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:escape\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/BaseConnection.php
-
-        -
             message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:escape\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/BaseConnection.php
@@ -1009,11 +1004,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:callFunction\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/ConnectionInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:escape\(\) has parameter \$str with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/ConnectionInterface.php
 
@@ -1386,11 +1376,6 @@ parameters:
             message: '#^Property CodeIgniter\\Database\\Postgre\\Builder\:\:\$randomKeyword type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/Postgre/Builder.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\Postgre\\Connection\:\:escape\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/Postgre/Connection.php
 
         -
             message: '#^Method CodeIgniter\\Database\\Postgre\\Connection\:\:escape\(\) return type has no value type specified in iterable type array\.$#'


### PR DESCRIPTION
**Description**

This PR adds support for PHP `BackedEnum` values in database escaping, query bindings, and escaped Query Builder values.

It was inspired by @maniaba's [forum post](https://forum.codeigniter.com/showthread.php?tid=94121) and #10223.

For apps that use native PHP enums for domain values, this makes database code a bit nicer to write:

```php
$db->table('users')
    ->where('status', UserStatus::Active)
    ->get();
```

CodeIgniter will use the enum's backing value when escaping it, so string-backed enums are treated like strings and int-backed enums are treated like integers.

This avoids repeating `->value` at every query call site, while keeping raw SQL and escape-disabled values in the caller's control.

The implementation is intentionally small: enum cases are unwrapped during database escaping, so regular query bindings and escaped Query Builder values use the same existing path.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide