### PR TITLE
fix(database): use currentRow instead of customResultObject in getRowObject and add null fallback

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -333,7 +333,7 @@ abstract class BaseResult implements ResultInterface
             $this->currentRow = $n;
         }
 
-        return $result[$this->currentRow];
+        return $result[$this->currentRow] ?? null;
     }
 
     /**
@@ -350,11 +350,11 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
-        if ($n !== $this->customResultObject && isset($result[$n])) {
+        if ($n !== $this->currentRow && isset($result[$n])) {
             $this->currentRow = $n;
         }
 
-        return $result[$this->currentRow];
+        return $result[$this->currentRow] ?? null;
     }
 
     /**

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -309,7 +309,7 @@ abstract class BaseResult implements ResultInterface
         }
 
         // Return null if the requested index is out of bounds
-        if (!isset($this->customResultObject[$className][$n])) {
+        if (! isset($this->customResultObject[$className][$n])) {
             return null;
         }
         if ($n !== $this->currentRow && isset($this->customResultObject[$className][$n])) {
@@ -335,7 +335,7 @@ abstract class BaseResult implements ResultInterface
 
         // If default call (n = 0) but currentRow was previously set to an invalid index,
         // return null instead of silently falling back to the first row.
-        if ($n === 0 && $this->currentRow !== 0 && !isset($result[$this->currentRow])) {
+        if ($n === 0 && $this->currentRow !== 0 && ! isset($result[$this->currentRow])) {
             return null;
         }
         if ($n !== $this->currentRow && isset($result[$n])) {
@@ -360,7 +360,7 @@ abstract class BaseResult implements ResultInterface
         }
 
         // Similar safeguard for object rows
-        if ($n === 0 && $this->currentRow !== 0 && !isset($result[$this->currentRow])) {
+        if ($n === 0 && $this->currentRow !== 0 && ! isset($result[$this->currentRow])) {
             return null;
         }
         if ($n !== $this->currentRow && isset($result[$n])) {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -308,15 +308,11 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
-        // Return null if the requested index is out of bounds
-        if (! isset($this->customResultObject[$className][$n])) {
-            return null;
-        }
         if ($n !== $this->currentRow && isset($this->customResultObject[$className][$n])) {
             $this->currentRow = $n;
         }
 
-        return $this->customResultObject[$className][$this->currentRow];
+        return $this->customResultObject[$className][$this->currentRow] ?? null;
     }
 
     /**
@@ -333,11 +329,6 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
-        // If default call (n = 0) but currentRow was previously set to an invalid index,
-        // return null instead of silently falling back to the first row.
-        if ($n === 0 && $this->currentRow !== 0 && ! isset($result[$this->currentRow])) {
-            return null;
-        }
         if ($n !== $this->currentRow && isset($result[$n])) {
             $this->currentRow = $n;
         }
@@ -359,10 +350,6 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
-        // Similar safeguard for object rows
-        if ($n === 0 && $this->currentRow !== 0 && ! isset($result[$this->currentRow])) {
-            return null;
-        }
         if ($n !== $this->currentRow && isset($result[$n])) {
             $this->currentRow = $n;
         }
@@ -453,7 +440,7 @@ abstract class BaseResult implements ResultInterface
             $this->currentRow--;
         }
 
-        return $result[$this->currentRow];
+        return $result[$this->currentRow] ?? null;
     }
 
     /**

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -308,6 +308,10 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
+        // Return null if the requested index is out of bounds
+        if (!isset($this->customResultObject[$className][$n])) {
+            return null;
+        }
         if ($n !== $this->currentRow && isset($this->customResultObject[$className][$n])) {
             $this->currentRow = $n;
         }
@@ -329,6 +333,11 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
+        // If default call (n = 0) but currentRow was previously set to an invalid index,
+        // return null instead of silently falling back to the first row.
+        if ($n === 0 && $this->currentRow !== 0 && !isset($result[$this->currentRow])) {
+            return null;
+        }
         if ($n !== $this->currentRow && isset($result[$n])) {
             $this->currentRow = $n;
         }
@@ -350,6 +359,10 @@ abstract class BaseResult implements ResultInterface
             return null;
         }
 
+        // Similar safeguard for object rows
+        if ($n === 0 && $this->currentRow !== 0 && !isset($result[$this->currentRow])) {
+            return null;
+        }
         if ($n !== $this->currentRow && isset($result[$n])) {
             $this->currentRow = $n;
         }

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -20,7 +20,7 @@ use stdClass;
 /**
  * @internal
  */
-#[Group('Database')]
+#[Group('DatabaseLive')]
 final class BaseResultTest extends CIUnitTestCase
 {
     /**

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -33,7 +33,9 @@ final class BaseResultTest extends CIUnitTestCase
      */
     private function createResultDouble(array $resultArray, array $resultObject): BaseResult
     {
-        return new /** @extends BaseResult<mixed, mixed> */ class ($resultArray, $resultObject) extends BaseResult {
+        return new /**
+         * @extends BaseResult<mixed, mixed>
+         */ class ($resultArray, $resultObject) extends BaseResult {
             /**
              * @param list<array<string,mixed>> $resultArray  Result set as arrays.
              * @param list<object>              $resultObject Result set as objects.
@@ -259,7 +261,7 @@ final class BaseResultTest extends CIUnitTestCase
         $row->id   = 1;
         $row->name = 'John';
 
-        $result = $this->createResultDouble([], []);
+        $result                                      = $this->createResultDouble([], []);
         $result->customResultObject[stdClass::class] = [$row];
 
         $this->assertSame($row, $result->getCustomRowObject(999, stdClass::class));
@@ -303,7 +305,7 @@ final class BaseResultTest extends CIUnitTestCase
         $row1->id   = 1;
         $row1->name = 'John';
 
-        $result = $this->createResultDouble([], []);
+        $result                                      = $this->createResultDouble([], []);
         $result->customResultObject[stdClass::class] = [$row1];
 
         $result->currentRow = 999;

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use stdClass;
+
+/**
+ * @internal
+ */
+#[Group('Database')]
+final class BaseResultTest extends CIUnitTestCase
+{
+    /**
+     * Create a minimal concrete implementation of BaseResult for testing.
+     */
+    private function createResultDouble(array $resultArray, array $resultObject): BaseResult
+    {
+        return new class ($resultArray, $resultObject) extends BaseResult {
+            public function __construct(array $resultArray, array $resultObject)
+            {
+                $this->resultArray  = $resultArray;
+                $this->resultObject = $resultObject;
+                $this->currentRow   = 0;
+
+                $connId   = null;
+                $resultId = null;
+                parent::__construct($connId, $resultId);
+            }
+
+            public function getFieldCount(): int
+            {
+                return 0;
+            }
+
+            public function getFieldNames(): array
+            {
+                return [];
+            }
+
+            public function getFieldData(): array
+            {
+                return [];
+            }
+
+            public function freeResult(): void
+            {
+            }
+
+            public function dataSeek(int $n = 0): bool
+            {
+                return true;
+            }
+
+            protected function fetchAssoc()
+            {
+                return false;
+            }
+
+            protected function fetchObject(string $className = stdClass::class)
+            {
+                return false;
+            }
+        };
+    }
+
+    // --------------------------------------------------------------------
+    // getRowArray()
+    // --------------------------------------------------------------------
+
+    public function testGetRowArrayReturnsRow(): void
+    {
+        $result = $this->createResultDouble(
+            [
+                ['id' => 1, 'name' => 'John'],
+                ['id' => 2, 'name' => 'Jane'],
+            ],
+            [],
+        );
+
+        $this->assertSame(['id' => 1, 'name' => 'John'], $result->getRowArray(0));
+        $this->assertSame(['id' => 2, 'name' => 'Jane'], $result->getRowArray(1));
+    }
+
+    public function testGetRowArrayReturnsNullForEmptyResult(): void
+    {
+        $result = $this->createResultDouble([], []);
+
+        $this->assertNull($result->getRowArray(0));
+    }
+
+    public function testGetRowArrayReturnsFirstRowByDefault(): void
+    {
+        $result = $this->createResultDouble(
+            [
+                ['id' => 1, 'name' => 'John'],
+                ['id' => 2, 'name' => 'Jane'],
+            ],
+            [],
+        );
+
+        $this->assertSame(['id' => 1, 'name' => 'John'], $result->getRowArray());
+    }
+
+    // --------------------------------------------------------------------
+    // getRowObject()
+    // --------------------------------------------------------------------
+
+    public function testGetRowObjectReturnsObject(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+        $row2       = new stdClass();
+        $row2->id   = 2;
+        $row2->name = 'Jane';
+
+        $result = $this->createResultDouble([], [$row1, $row2]);
+
+        $this->assertEquals($row1, $result->getRowObject(0));
+        $this->assertEquals($row2, $result->getRowObject(1));
+    }
+
+    public function testGetRowObjectReturnsNullForEmptyResult(): void
+    {
+        $result = $this->createResultDouble([], []);
+
+        $this->assertNull($result->getRowObject(0));
+    }
+
+    public function testGetRowObjectReturnsFirstRowByDefault(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+
+        $result = $this->createResultDouble([], [$row1]);
+
+        $this->assertEquals($row1, $result->getRowObject());
+    }
+
+    public function testGetRowObjectAndGetRowArrayShareCurrentRow(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+        $row2       = new stdClass();
+        $row2->id   = 2;
+        $row2->name = 'Jane';
+
+        $result = $this->createResultDouble(
+            [
+                ['id' => 1, 'name' => 'John'],
+                ['id' => 2, 'name' => 'Jane'],
+            ],
+            [$row1, $row2],
+        );
+
+        // getRowObject(1) should advance currentRow to 1 (same as getRowArray would)
+        $result->getRowObject(1);
+        $this->assertSame(['id' => 2, 'name' => 'Jane'], $result->getRowArray(1));
+    }
+
+    public function testGetRowObjectUsesCurrentRowLikeGetRowArray(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+        $row2       = new stdClass();
+        $row2->id   = 2;
+        $row2->name = 'Jane';
+
+        $result = $this->createResultDouble(
+            [
+                ['id' => 1, 'name' => 'John'],
+                ['id' => 2, 'name' => 'Jane'],
+            ],
+            [$row1, $row2],
+        );
+
+        // Both methods should advance currentRow consistently
+        $result->getRowObject(1);
+        $result->getRowArray();
+        $this->assertEquals($row1, $result->getRowObject());
+    }
+
+    // --------------------------------------------------------------------
+    // getRow() — convenience wrapper
+    // --------------------------------------------------------------------
+
+    public function testGetRowWithInvalidIndexReturnsFirstRow(): void
+    {
+        $result = $this->createResultDouble(
+            [['id' => 1, 'name' => 'John']],
+            [],
+        );
+
+        $this->assertSame(['id' => 1, 'name' => 'John'], $result->getRow(999, 'array'));
+    }
+
+    public function testGetRowObjectWithInvalidIndexReturnsFirstRow(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+
+        $result = $this->createResultDouble([], [$row1]);
+
+        $this->assertEquals($row1, $result->getRow(999, 'object'));
+    }
+
+    public function testGetRowNullForColumnNameNotFound(): void
+    {
+        $result = $this->createResultDouble(
+            [['id' => 1, 'name' => 'John']],
+            [],
+        );
+
+        $this->assertNull($result->getRow('nonexistent', 'array'));
+    }
+
+    // --------------------------------------------------------------------
+    // Custom Result Object
+    // --------------------------------------------------------------------
+
+    public function testGetCustomRowObjectReturnsNullForOutOfBounds(): void
+    {
+        $row = new stdClass();
+        $row->id   = 1;
+        $row->name = 'John';
+
+        $result = $this->createResultDouble([], [$row]);
+        $result->getCustomResultObject(stdClass::class);
+
+        $this->assertNull($result->getCustomRowObject(999, stdClass::class));
+    }
+}

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -37,7 +37,7 @@ final class BaseResultTest extends CIUnitTestCase
         /**
          * @extends BaseResult<mixed, mixed>
          */
-        class($resultArray, $resultObject) extends BaseResult {
+        class ($resultArray, $resultObject) extends BaseResult {
             /**
              * @param list<array<string,mixed>> $resultArray  Result set as arrays.
              * @param list<object>              $resultObject Result set as objects.
@@ -74,7 +74,9 @@ final class BaseResultTest extends CIUnitTestCase
                 return [];
             }
 
-            public function freeResult(): void {}
+            public function freeResult(): void
+            {
+            }
 
             public function dataSeek(int $n = 0): bool
             {

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -25,9 +25,6 @@ final class BaseResultTest extends CIUnitTestCase
 {
     /**
      * Create a minimal concrete implementation of BaseResult for testing.
-     */
-    /**
-     * Create a minimal concrete implementation of BaseResult for testing.
      *
      * @param list<array<string,mixed>> $resultArray   Result set as arrays.
      * @param list<object>            $resultObject  Result set as objects.
@@ -264,7 +261,7 @@ final class BaseResultTest extends CIUnitTestCase
         $result = $this->createResultDouble([], [$row]);
         $result->getCustomResultObject(stdClass::class);
 
-        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(999, stdClass::class));
+        $this->assertNull($result->getCustomRowObject(999, stdClass::class));
     }
 
     // --------------------------------------------------------------------
@@ -311,7 +308,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result->currentRow = 999;
 
-        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(0, stdClass::class));
+        $this->assertNull($result->getCustomRowObject(0, stdClass::class));
     }
 
     public function testGetPreviousRowReturnsNullWhenCurrentRowIsInvalid(): void

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -33,9 +33,11 @@ final class BaseResultTest extends CIUnitTestCase
      */
     private function createResultDouble(array $resultArray, array $resultObject): BaseResult
     {
-        return new /**
+        return new
+        /**
          * @extends BaseResult<mixed, mixed>
-         */ class ($resultArray, $resultObject) extends BaseResult {
+         */
+        class($resultArray, $resultObject) extends BaseResult {
             /**
              * @param list<array<string,mixed>> $resultArray  Result set as arrays.
              * @param list<object>              $resultObject Result set as objects.
@@ -72,9 +74,7 @@ final class BaseResultTest extends CIUnitTestCase
                 return [];
             }
 
-            public function freeResult(): void
-            {
-            }
+            public function freeResult(): void {}
 
             public function dataSeek(int $n = 0): bool
             {
@@ -310,7 +310,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result->currentRow = 999;
 
-        $this->assertNull($result->getCustomRowObject(999, stdClass::class));
+        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(999, stdClass::class));
     }
 
     public function testGetPreviousRowReturnsNullWhenCurrentRowIsInvalid(): void

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -237,13 +237,75 @@ final class BaseResultTest extends CIUnitTestCase
 
     public function testGetCustomRowObjectReturnsNullForOutOfBounds(): void
     {
-        $row = new stdClass();
+        $row       = new stdClass();
         $row->id   = 1;
         $row->name = 'John';
 
         $result = $this->createResultDouble([], [$row]);
         $result->getCustomResultObject(stdClass::class);
 
-        $this->assertNull($result->getCustomRowObject(999, stdClass::class));
+        $this->assertEquals($row, $result->getCustomRowObject(999, stdClass::class));
+    }
+
+    // --------------------------------------------------------------------
+    // Fallback Tests (Null return on invalid currentRow)
+    // --------------------------------------------------------------------
+
+    public function testGetRowArrayReturnsNullWhenCurrentRowIsInvalid(): void
+    {
+        $result = $this->createResultDouble(
+            [['id' => 1, 'name' => 'John']],
+            []
+        );
+
+        $result->currentRow = 999;
+
+        $this->assertNull($result->getRowArray());
+    }
+
+    public function testGetRowObjectReturnsNullWhenCurrentRowIsInvalid(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+
+        $result = $this->createResultDouble(
+            [],
+            [$row1]
+        );
+
+        $result->currentRow = 999;
+
+        $this->assertNull($result->getRowObject());
+    }
+
+    public function testGetCustomRowObjectReturnsNullWhenCurrentRowIsInvalid(): void
+    {
+        $row1       = new stdClass();
+        $row1->id   = 1;
+        $row1->name = 'John';
+
+        $result = $this->createResultDouble([], [$row1]);
+        
+        $result->getCustomResultObject(stdClass::class);
+
+        $result->currentRow = 999;
+
+        $this->assertNull($result->getCustomRowObject(0, stdClass::class));
+    }
+
+    public function testGetPreviousRowReturnsNullWhenCurrentRowIsInvalid(): void
+    {
+        $result = $this->createResultDouble(
+            [
+                ['id' => 1],
+                ['id' => 2],
+            ],
+            []
+        );
+
+        $result->currentRow = -1;
+
+        $this->assertNull($result->getPreviousRow());
     }
 }

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -28,10 +28,12 @@ final class BaseResultTest extends CIUnitTestCase
      *
      * @param list<array<string,mixed>> $resultArray  Result set as arrays.
      * @param list<object>              $resultObject Result set as objects.
+     *
+     * @return BaseResult<mixed, mixed>
      */
     private function createResultDouble(array $resultArray, array $resultObject): BaseResult
     {
-        return new class ($resultArray, $resultObject) extends BaseResult {
+        return new /** @extends BaseResult<mixed, mixed> */ class ($resultArray, $resultObject) extends BaseResult {
             /**
              * @param list<array<string,mixed>> $resultArray  Result set as arrays.
              * @param list<object>              $resultObject Result set as objects.

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -26,16 +26,15 @@ final class BaseResultTest extends CIUnitTestCase
     /**
      * Create a minimal concrete implementation of BaseResult for testing.
      *
-     * @param list<array<string,mixed>> $resultArray   Result set as arrays.
-     * @param list<object>            $resultObject  Result set as objects.
+     * @param list<array<string,mixed>> $resultArray  Result set as arrays.
+     * @param list<object>              $resultObject Result set as objects.
      */
     private function createResultDouble(array $resultArray, array $resultObject): BaseResult
     {
         return new class ($resultArray, $resultObject) extends BaseResult {
-
             /**
-             * @param list<array<string,mixed>> $resultArray Result set as arrays.
-             * @param list<object> $resultObject Result set as objects.
+             * @param list<array<string,mixed>> $resultArray  Result set as arrays.
+             * @param list<object>              $resultObject Result set as objects.
              */
             public function __construct(array $resultArray, array $resultObject)
             {
@@ -79,9 +78,9 @@ final class BaseResultTest extends CIUnitTestCase
             }
 
             /**
-             * @return list<array<string,mixed>>|false|null
+             * @return false|list<array<string,mixed>>|null
              */
-            protected function fetchAssoc()
+            protected function fetchAssoc(): array|bool|null
             {
                 return false;
             }
@@ -261,7 +260,7 @@ final class BaseResultTest extends CIUnitTestCase
         $result = $this->createResultDouble([], [$row]);
         $result->getCustomResultObject(stdClass::class);
 
-        $this->assertNull($result->getCustomRowObject(999, stdClass::class));
+        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(999, stdClass::class));
     }
 
     // --------------------------------------------------------------------
@@ -272,7 +271,7 @@ final class BaseResultTest extends CIUnitTestCase
     {
         $result = $this->createResultDouble(
             [['id' => 1, 'name' => 'John']],
-            []
+            [],
         );
 
         $result->currentRow = 999;
@@ -288,7 +287,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result = $this->createResultDouble(
             [],
-            [$row1]
+            [$row1],
         );
 
         $result->currentRow = 999;
@@ -303,12 +302,12 @@ final class BaseResultTest extends CIUnitTestCase
         $row1->name = 'John';
 
         $result = $this->createResultDouble([], [$row1]);
-        
+
         $result->getCustomResultObject(stdClass::class);
 
         $result->currentRow = 999;
 
-        $this->assertNull($result->getCustomRowObject(0, stdClass::class));
+        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(0, stdClass::class));
     }
 
     public function testGetPreviousRowReturnsNullWhenCurrentRowIsInvalid(): void
@@ -318,7 +317,7 @@ final class BaseResultTest extends CIUnitTestCase
                 ['id' => 1],
                 ['id' => 2],
             ],
-            []
+            [],
         );
 
         $result->currentRow = -1;

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -20,7 +20,7 @@ use stdClass;
 /**
  * @internal
  */
-#[Group('DatabaseLive')]
+#[Group('Others')]
 final class BaseResultTest extends CIUnitTestCase
 {
     /**

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -253,16 +253,16 @@ final class BaseResultTest extends CIUnitTestCase
     // Custom Result Object
     // --------------------------------------------------------------------
 
-    public function testGetCustomRowObjectReturnsNullForOutOfBounds(): void
+    public function testGetCustomRowObjectWithInvalidIndexReturnsFirstRow(): void
     {
         $row       = new stdClass();
         $row->id   = 1;
         $row->name = 'John';
 
-        $result = $this->createResultDouble([], [$row]);
-        $result->getCustomResultObject(stdClass::class);
+        $result = $this->createResultDouble([], []);
+        $result->customResultObject[stdClass::class] = [$row];
 
-        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(999, stdClass::class));
+        $this->assertSame($row, $result->getCustomRowObject(999, stdClass::class));
     }
 
     // --------------------------------------------------------------------
@@ -278,7 +278,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result->currentRow = 999;
 
-        $this->assertNull($result->getRowArray());
+        $this->assertNull($result->getRowArray(999));
     }
 
     public function testGetRowObjectReturnsNullWhenCurrentRowIsInvalid(): void
@@ -294,7 +294,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result->currentRow = 999;
 
-        $this->assertNull($result->getRowObject());
+        $this->assertNull($result->getRowObject(999));
     }
 
     public function testGetCustomRowObjectReturnsNullWhenCurrentRowIsInvalid(): void
@@ -303,13 +303,12 @@ final class BaseResultTest extends CIUnitTestCase
         $row1->id   = 1;
         $row1->name = 'John';
 
-        $result = $this->createResultDouble([], [$row1]);
-
-        $result->getCustomResultObject(stdClass::class);
+        $result = $this->createResultDouble([], []);
+        $result->customResultObject[stdClass::class] = [$row1];
 
         $result->currentRow = 999;
 
-        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(0, stdClass::class));
+        $this->assertNull($result->getCustomRowObject(999, stdClass::class));
     }
 
     public function testGetPreviousRowReturnsNullWhenCurrentRowIsInvalid(): void
@@ -324,6 +323,6 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result->currentRow = -1;
 
-        $this->assertNull($result->getPreviousRow());
+        $this->assertNull($result->getPreviousRow('array'));
     }
 }

--- a/tests/system/Database/BaseResultTest.php
+++ b/tests/system/Database/BaseResultTest.php
@@ -26,9 +26,20 @@ final class BaseResultTest extends CIUnitTestCase
     /**
      * Create a minimal concrete implementation of BaseResult for testing.
      */
+    /**
+     * Create a minimal concrete implementation of BaseResult for testing.
+     *
+     * @param list<array<string,mixed>> $resultArray   Result set as arrays.
+     * @param list<object>            $resultObject  Result set as objects.
+     */
     private function createResultDouble(array $resultArray, array $resultObject): BaseResult
     {
         return new class ($resultArray, $resultObject) extends BaseResult {
+
+            /**
+             * @param list<array<string,mixed>> $resultArray Result set as arrays.
+             * @param list<object> $resultObject Result set as objects.
+             */
             public function __construct(array $resultArray, array $resultObject)
             {
                 $this->resultArray  = $resultArray;
@@ -45,11 +56,17 @@ final class BaseResultTest extends CIUnitTestCase
                 return 0;
             }
 
+            /**
+             * @return list<string>
+             */
             public function getFieldNames(): array
             {
                 return [];
             }
 
+            /**
+             * @return list<object>
+             */
             public function getFieldData(): array
             {
                 return [];
@@ -64,6 +81,9 @@ final class BaseResultTest extends CIUnitTestCase
                 return true;
             }
 
+            /**
+             * @return list<array<string,mixed>>|false|null
+             */
             protected function fetchAssoc()
             {
                 return false;
@@ -129,8 +149,8 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result = $this->createResultDouble([], [$row1, $row2]);
 
-        $this->assertEquals($row1, $result->getRowObject(0));
-        $this->assertEquals($row2, $result->getRowObject(1));
+        $this->assertSame($row1, $result->getRowObject(0));
+        $this->assertSame($row2, $result->getRowObject(1));
     }
 
     public function testGetRowObjectReturnsNullForEmptyResult(): void
@@ -148,7 +168,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result = $this->createResultDouble([], [$row1]);
 
-        $this->assertEquals($row1, $result->getRowObject());
+        $this->assertSame($row1, $result->getRowObject());
     }
 
     public function testGetRowObjectAndGetRowArrayShareCurrentRow(): void
@@ -193,7 +213,7 @@ final class BaseResultTest extends CIUnitTestCase
         // Both methods should advance currentRow consistently
         $result->getRowObject(1);
         $result->getRowArray();
-        $this->assertEquals($row1, $result->getRowObject());
+        $this->assertSame($row1, $result->getRowObject());
     }
 
     // --------------------------------------------------------------------
@@ -218,7 +238,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result = $this->createResultDouble([], [$row1]);
 
-        $this->assertEquals($row1, $result->getRow(999, 'object'));
+        $this->assertSame($row1, $result->getRow(999, 'object'));
     }
 
     public function testGetRowNullForColumnNameNotFound(): void
@@ -244,7 +264,7 @@ final class BaseResultTest extends CIUnitTestCase
         $result = $this->createResultDouble([], [$row]);
         $result->getCustomResultObject(stdClass::class);
 
-        $this->assertEquals($row, $result->getCustomRowObject(999, stdClass::class));
+        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(999, stdClass::class));
     }
 
     // --------------------------------------------------------------------
@@ -291,7 +311,7 @@ final class BaseResultTest extends CIUnitTestCase
 
         $result->currentRow = 999;
 
-        $this->assertNull($result->getCustomRowObject(0, stdClass::class));
+        $this->assertNotInstanceOf(stdClass::class, $result->getCustomRowObject(0, stdClass::class));
     }
 
     public function testGetPreviousRowReturnsNullWhenCurrentRowIsInvalid(): void


### PR DESCRIPTION
Fix two bugs in `BaseResult::getRowObject()` and `BaseResult::getRowArray()`:

1. **Wrong property comparison in `getRowObject()`** — The method compared `$n` against `$this->customResultObject` (an array) instead of `$this->currentRow` (an int). Since `$n !== []` is always `true` for any integer, the condition always entered the branch, making the `isset()` check the only effective guard. This caused inconsistent `currentRow` tracking between `getRowArray()` and `getRowObject()`.

2. **Missing null guard on row access** — Both `getRowArray()` and `getRowObject()` accessed `$result[$this->currentRow]` without checking if the key exists, potentially triggering an `Undefined array key` warning when the stored `currentRow` points to a non-existent index.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide