### PR TITLE
fix(model): pass $recursive parameter to parent in objectToRawArray

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -711,11 +711,6 @@ class Model extends BaseModel
         return parent::update($id, $row);
     }
 
-    protected function objectToRawArray($object, bool $onlyChanged = true, bool $recursive = false): array
-    {
-        return parent::objectToRawArray($object, $onlyChanged, $recursive);
-    }
-
     /**
      * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
      *

--- a/system/Model.php
+++ b/system/Model.php
@@ -713,7 +713,7 @@ class Model extends BaseModel
 
     protected function objectToRawArray($object, bool $onlyChanged = true, bool $recursive = false): array
     {
-        return parent::objectToRawArray($object, $onlyChanged);
+        return parent::objectToRawArray($object, $onlyChanged, $recursive);
     }
 
     /**

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Models;
+
+use CodeIgniter\Entity\Entity;
+use CodeIgniter\Model;
+use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use ReflectionMethod;
+
+/**
+ * @internal
+ */
+#[Group('Models')]
+final class ObjectToRawArrayModelTest extends CIUnitTestCase
+{
+    private function createModel(): Model
+    {
+        return new class () extends Model {
+            public function __construct()
+            {
+                // Skip DB connection — we only test objectToRawArray
+            }
+
+            protected $table          = 'test';
+            protected $allowedFields  = ['name', 'nested', 'entity'];
+            protected $returnType     = 'array';
+            protected $useSoftDeletes = false;
+        };
+    }
+
+    /**
+     * Call protected objectToRawArray via reflection.
+     */
+    private function callObjectToRawArray(Model $model, object $object, bool $onlyChanged, bool $recursive): array
+    {
+        $method = new ReflectionMethod(Model::class, 'objectToRawArray');
+
+        return $method->invoke($model, $object, $onlyChanged, $recursive);
+    }
+
+    public function testObjectToRawArrayPassesRecursiveTrue(): void
+    {
+        $model = $this->createModel();
+
+        $inner       = new class () extends Entity {
+            protected $attributes = ['name' => 'inner'];
+            protected $original   = ['name' => 'inner'];
+        };
+
+        $outer            = new class () extends Entity {
+            protected $attributes = ['name' => 'outer', 'nested' => null];
+            protected $original   = ['name' => 'outer', 'nested' => null];
+        };
+        $outer->nested = $inner;
+
+        $result = $this->callObjectToRawArray($model, $outer, false, true);
+
+        $this->assertArrayHasKey('name', $result);
+        $this->assertSame('outer', $result['name']);
+        $this->assertArrayHasKey('nested', $result);
+        $this->assertIsArray($result['nested']);
+        $this->assertSame(['name' => 'inner'], $result['nested']);
+    }
+
+    public function testObjectToRawArrayPassesRecursiveFalse(): void
+    {
+        $model = $this->createModel();
+
+        $inner       = new class () extends Entity {
+            protected $attributes = ['name' => 'inner'];
+            protected $original   = ['name' => 'inner'];
+        };
+
+        $outer            = new class () extends Entity {
+            protected $attributes = ['name' => 'outer', 'nested' => null];
+            protected $original   = ['name' => 'outer', 'nested' => null];
+        };
+        $outer->nested = $inner;
+
+        $result = $this->callObjectToRawArray($model, $outer, false, false);
+
+        $this->assertArrayHasKey('name', $result);
+        $this->assertSame('outer', $result['name']);
+        $this->assertArrayHasKey('nested', $result);
+        // With recursive=false, nested Entity should remain as object
+        $this->assertInstanceOf(Entity::class, $result['nested']);
+    }
+
+    public function testObjectToRawArrayNonEntity(): void
+    {
+        $model = $this->createModel();
+
+        $obj = new class () {
+            public string $name  = 'test';
+            public string $value = '123';
+        };
+
+        $result = $this->callObjectToRawArray($model, $obj, false, false);
+
+        $this->assertSame(['name' => 'test', 'value' => '123'], $result);
+    }
+
+    public function testObjectToRawArrayOnlyChanged(): void
+    {
+        $model = $this->createModel();
+
+        $entity = new class () extends Entity {
+            protected $attributes = ['name' => 'original', 'value' => 'keep'];
+            protected $original   = ['name' => 'original', 'value' => 'keep'];
+        };
+        $entity->name = 'modified';
+
+        $result = $this->callObjectToRawArray($model, $entity, true, false);
+
+        $this->assertSame(['name' => 'modified'], $result);
+    }
+}

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\Group;
 /**
  * @internal
  */
-#[Group('Models')]
+#[Group('Others')]
 final class ObjectToRawArrayModelTest extends CIUnitTestCase
 {
     private function createModel(): Model

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Models;
+namespace CodeIgniter\Models; // Fixed model-recursive behavior
 
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Model;

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -45,9 +45,9 @@ final class ObjectToRawArrayModelTest extends CIUnitTestCase
      */
     private function callObjectToRawArray(Model $model, object $object, bool $onlyChanged, bool $recursive): array
     {
-        $method = new ReflectionMethod(Model::class, 'objectToRawArray');
+        $method = self::getPrivateMethodInvoker($model, 'objectToRawArray');
 
-        return $method->invoke($model, $object, $onlyChanged, $recursive);
+        return $method($object, $onlyChanged, $recursive);
     }
 
     public function testObjectToRawArrayPassesRecursiveTrue(): void

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Models; // Fixed model-recursive behavior
+namespace CodeIgniter\Models;
 
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Model;

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Entity\Entity;
 use CodeIgniter\Model;
 use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionMethod;
 
 /**
  * @internal

--- a/tests/system/Models/ObjectToRawArrayModelTest.php
+++ b/tests/system/Models/ObjectToRawArrayModelTest.php
@@ -41,6 +41,8 @@ final class ObjectToRawArrayModelTest extends CIUnitTestCase
 
     /**
      * Call protected objectToRawArray via reflection.
+     *
+     * @return array<string, mixed>
      */
     private function callObjectToRawArray(Model $model, object $object, bool $onlyChanged, bool $recursive): array
     {
@@ -53,12 +55,12 @@ final class ObjectToRawArrayModelTest extends CIUnitTestCase
     {
         $model = $this->createModel();
 
-        $inner       = new class () extends Entity {
+        $inner = new class () extends Entity {
             protected $attributes = ['name' => 'inner'];
             protected $original   = ['name' => 'inner'];
         };
 
-        $outer            = new class () extends Entity {
+        $outer = new class () extends Entity {
             protected $attributes = ['name' => 'outer', 'nested' => null];
             protected $original   = ['name' => 'outer', 'nested' => null];
         };
@@ -77,12 +79,12 @@ final class ObjectToRawArrayModelTest extends CIUnitTestCase
     {
         $model = $this->createModel();
 
-        $inner       = new class () extends Entity {
+        $inner = new class () extends Entity {
             protected $attributes = ['name' => 'inner'];
             protected $original   = ['name' => 'inner'];
         };
 
-        $outer            = new class () extends Entity {
+        $outer = new class () extends Entity {
             protected $attributes = ['name' => 'outer', 'nested' => null];
             protected $original   = ['name' => 'outer', 'nested' => null];
         };
@@ -113,8 +115,7 @@ final class ObjectToRawArrayModelTest extends CIUnitTestCase
 
     public function testObjectToRawArrayOnlyChanged(): void
     {
-        $model = $this->createModel();
-
+        $model  = $this->createModel();
         $entity = new class () extends Entity {
             protected $attributes = ['name' => 'original', 'value' => 'keep'];
             protected $original   = ['name' => 'original', 'value' => 'keep'];

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -32,6 +32,7 @@ Bugs Fixed
 
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
+- **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
Fix a bug in `Model::objectToRawArray()` where the `$recursive` parameter was accepted but never forwarded to `BaseModel::objectToRawArray()`. The method called `parent::objectToRawArray($object, $onlyChanged)` without the third argument, causing nested Entity objects to always be returned as objects instead of recursively converting them to arrays when `$recursive=true`.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide