### PR TITLE
feat: expose prepared `FormRequest` data during validation failure

### DIFF
--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -167,11 +167,13 @@ abstract class FormRequest
             ? 'get'
             : 'post';
 
-        service('session')->setFlashdata('_ci_old_input', [
+        $oldInput = [
             'get'  => [],
             'post' => [],
-            $key   => $preparedData,
-        ]);
+        ];
+        $oldInput[$key] = $preparedData;
+
+        service('session')->setFlashdata('_ci_old_input', $oldInput);
 
         return $redirect;
     }

--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -36,6 +36,13 @@ abstract class FormRequest
     private array $validatedData = [];
 
     /**
+     * Data after prepareForValidation() and before validation rules run.
+     *
+     * @var array<string, mixed>
+     */
+    private array $preparedValidationData = [];
+
+    /**
      * When called by the framework, the current IncomingRequest is injected
      * explicitly. When instantiated manually (e.g. in tests), the constructor
      * falls back to service('request').
@@ -144,6 +151,21 @@ abstract class FormRequest
     }
 
     /**
+     * Returns the data after prepareForValidation() has run.
+     *
+     * This is useful in failedValidation() when a custom failure response needs
+     * the same prepared data that was passed to validation. This data has not
+     * passed validation; use getValidated() or getValidatedInput() after
+     * successful validation for trusted values.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getPreparedValidationData(): array
+    {
+        return $this->preparedValidationData;
+    }
+
+    /**
      * Called when validation fails. Override to customize the failure response.
      *
      * The default implementation redirects back with input and flashes validation
@@ -249,16 +271,19 @@ abstract class FormRequest
      */
     final public function resolveRequest(): ?ResponseInterface
     {
+        $this->validatedData          = [];
+        $this->preparedValidationData = [];
+
         if (! $this->isAuthorized()) {
             return $this->failedAuthorization();
         }
 
-        $data = $this->prepareForValidation($this->validationData());
+        $this->preparedValidationData = $this->prepareForValidation($this->validationData());
 
         $validation = service('validation')
             ->setRules($this->rules(), $this->messages());
 
-        if (! $validation->run($data)) {
+        if (! $validation->run($this->preparedValidationData)) {
             return $this->failedValidation($validation->getErrors());
         }
 

--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -36,13 +36,6 @@ abstract class FormRequest
     private array $validatedData = [];
 
     /**
-     * Data after prepareForValidation() and before validation rules run.
-     *
-     * @var array<string, mixed>
-     */
-    private array $preparedValidationData = [];
-
-    /**
      * When called by the framework, the current IncomingRequest is injected
      * explicitly. When instantiated manually (e.g. in tests), the constructor
      * falls back to service('request').
@@ -151,21 +144,6 @@ abstract class FormRequest
     }
 
     /**
-     * Returns the data after prepareForValidation() has run.
-     *
-     * This is useful in failedValidation() when a custom failure response needs
-     * the same prepared data that was passed to validation. This data has not
-     * passed validation; use getValidated() or getValidatedInput() after
-     * successful validation for trusted values.
-     *
-     * @return array<string, mixed>
-     */
-    protected function getPreparedValidationData(): array
-    {
-        return $this->preparedValidationData;
-    }
-
-    /**
      * Called when validation fails. Override to customize the failure response.
      *
      * The default implementation redirects back with input and flashes validation
@@ -175,14 +153,27 @@ abstract class FormRequest
      * returns a 422 JSON response instead.
      *
      * @param array<string, string> $errors
+     * @param array<string, mixed>  $preparedData
      */
-    protected function failedValidation(array $errors): ResponseInterface
+    protected function failedValidation(array $errors, array $preparedData): ResponseInterface
     {
         if ($this->shouldReturnJsonResponse()) {
             return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
         }
 
-        return redirect()->back()->withInput();
+        $redirect = redirect()->back()->withInput();
+
+        $key = in_array($this->request->getMethod(), [Method::GET, Method::HEAD], true)
+            ? 'get'
+            : 'post';
+
+        service('session')->setFlashdata('_ci_old_input', [
+            'get'  => [],
+            'post' => [],
+            $key   => $preparedData,
+        ]);
+
+        return $redirect;
     }
 
     /**
@@ -271,20 +262,19 @@ abstract class FormRequest
      */
     final public function resolveRequest(): ?ResponseInterface
     {
-        $this->validatedData          = [];
-        $this->preparedValidationData = [];
+        $this->validatedData = [];
 
         if (! $this->isAuthorized()) {
             return $this->failedAuthorization();
         }
 
-        $this->preparedValidationData = $this->prepareForValidation($this->validationData());
+        $data = $this->prepareForValidation($this->validationData());
 
         $validation = service('validation')
             ->setRules($this->rules(), $this->messages());
 
-        if (! $validation->run($this->preparedValidationData)) {
-            return $this->failedValidation($validation->getErrors());
+        if (! $validation->run($data)) {
+            return $this->failedValidation($validation->getErrors(), $data);
         }
 
         $this->validatedData = $validation->getValidated();

--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -168,8 +168,8 @@ abstract class FormRequest
             : 'post';
 
         $oldInput = [
-            'get'  => [],
-            'post' => [],
+            'get'  => service('superglobals')->getGetArray(),
+            'post' => service('superglobals')->getPostArray(),
         ];
         $oldInput[$key] = $preparedData;
 

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -499,6 +499,38 @@ final class FormRequestTest extends CIUnitTestCase
         $this->assertSame([], $_SESSION['_ci_old_input']['post']);
     }
 
+    #[RunInSeparateProcess]
+    public function testDefaultFailedValidationPreservesGetDataWhenPostDataIsPrepared(): void
+    {
+        /** @var array<string, mixed> $_SESSION */
+        $_SESSION = [];
+
+        service('superglobals')->setGet('category', '2');
+        service('superglobals')->setPost('title', ' Hello World ');
+
+        $formRequest = new class ($this->makeRequest()) extends FormRequest {
+            public function rules(): array
+            {
+                return [
+                    'title' => 'required',
+                    'body'  => 'required',
+                ];
+            }
+
+            protected function prepareForValidation(array $data): array
+            {
+                $data['title'] = trim($data['title'] ?? '');
+
+                return $data;
+            }
+        };
+
+        $formRequest->resolveRequest();
+
+        $this->assertSame(['category' => '2'], $_SESSION['_ci_old_input']['get']);
+        $this->assertSame(['title' => 'Hello World'], $_SESSION['_ci_old_input']['post']);
+    }
+
     // -------------------------------------------------------------------------
     // Authorization failure
     // -------------------------------------------------------------------------

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -395,7 +395,7 @@ final class FormRequestTest extends CIUnitTestCase
         $this->assertSame(303, $response->getStatusCode());
     }
 
-    public function testPreparedValidationDataIsAvailableDuringFailedValidationWithoutPreparingAgain(): void
+    public function testPreparedValidationDataIsPassedToFailedValidationWithoutPreparingAgain(): void
     {
         service('superglobals')->setPost('title', ' Hello World ');
 
@@ -423,9 +423,9 @@ final class FormRequestTest extends CIUnitTestCase
                 return $data;
             }
 
-            protected function failedValidation(array $errors): ResponseInterface
+            protected function failedValidation(array $errors, array $preparedData): ResponseInterface
             {
-                $this->preparedData = $this->getPreparedValidationData();
+                $this->preparedData = $preparedData;
 
                 return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
             }
@@ -435,6 +435,68 @@ final class FormRequestTest extends CIUnitTestCase
 
         $this->assertSame(1, $formRequest->prepareCount);
         $this->assertSame(['title' => 'Hello World'], $formRequest->preparedData);
+    }
+
+    #[RunInSeparateProcess]
+    public function testDefaultFailedValidationFlashesPreparedValidationDataAsOldInput(): void
+    {
+        /** @var array<string, mixed> $_SESSION */
+        $_SESSION = [];
+
+        service('superglobals')->setPost('title', ' Hello World ');
+
+        $formRequest = new class ($this->makeRequest()) extends FormRequest {
+            public function rules(): array
+            {
+                return [
+                    'title' => 'required',
+                    'body'  => 'required',
+                ];
+            }
+
+            protected function prepareForValidation(array $data): array
+            {
+                $data['title'] = trim($data['title'] ?? '');
+
+                return $data;
+            }
+        };
+
+        $formRequest->resolveRequest();
+
+        $this->assertSame(['title' => 'Hello World'], $_SESSION['_ci_old_input']['post']);
+    }
+
+    #[RunInSeparateProcess]
+    public function testDefaultFailedValidationFlashesPreparedGetDataAsOldInput(): void
+    {
+        /** @var array<string, mixed> $_SESSION */
+        $_SESSION = [];
+
+        service('superglobals')->setServer('REQUEST_METHOD', 'GET');
+        service('superglobals')->setGet('title', ' Hello World ');
+
+        $formRequest = new class ($this->makeRequest()) extends FormRequest {
+            public function rules(): array
+            {
+                return [
+                    'title' => 'required',
+                    'body'  => 'required',
+                ];
+            }
+
+            protected function prepareForValidation(array $data): array
+            {
+                $data['title'] = trim($data['title'] ?? '');
+
+                return $data;
+            }
+        };
+
+        $formRequest->resolveRequest();
+
+        $this->assertSame(['title' => 'Hello World'], $_SESSION['_ci_old_input']['get']);
+        $this->assertSame([], $_SESSION['_ci_old_input']['post']);
     }
 
     // -------------------------------------------------------------------------
@@ -530,7 +592,7 @@ final class FormRequestTest extends CIUnitTestCase
                 return ['title' => 'required'];
             }
 
-            protected function failedValidation(array $errors): ResponseInterface
+            protected function failedValidation(array $errors, array $preparedData): ResponseInterface
             {
                 self::$called = true;
 

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -395,6 +395,48 @@ final class FormRequestTest extends CIUnitTestCase
         $this->assertSame(303, $response->getStatusCode());
     }
 
+    public function testPreparedValidationDataIsAvailableDuringFailedValidationWithoutPreparingAgain(): void
+    {
+        service('superglobals')->setPost('title', ' Hello World ');
+
+        $formRequest = new class ($this->makeRequest()) extends FormRequest {
+            public int $prepareCount = 0;
+
+            /**
+             * @var array<string, mixed>
+             */
+            public array $preparedData = [];
+
+            public function rules(): array
+            {
+                return [
+                    'title' => 'required',
+                    'body'  => 'required',
+                ];
+            }
+
+            protected function prepareForValidation(array $data): array
+            {
+                $this->prepareCount++;
+                $data['title'] = trim($data['title'] ?? '');
+
+                return $data;
+            }
+
+            protected function failedValidation(array $errors): ResponseInterface
+            {
+                $this->preparedData = $this->getPreparedValidationData();
+
+                return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
+            }
+        };
+
+        $formRequest->resolveRequest();
+
+        $this->assertSame(1, $formRequest->prepareCount);
+        $this->assertSame(['title' => 'Hello World'], $formRequest->preparedData);
+    }
+
     // -------------------------------------------------------------------------
     // Authorization failure
     // -------------------------------------------------------------------------

--- a/user_guide_src/source/incoming/form_requests.rst
+++ b/user_guide_src/source/incoming/form_requests.rst
@@ -171,10 +171,9 @@ normalized phone numbers, or trimmed strings.
 .. literalinclude:: form_requests/006.php
    :lines: 2-
 
-.. note:: ``old()`` returns the original submitted input, not the normalized
-    values. Use ``getValidated()`` to access the processed data after a successful
-    request. If you need ``old()`` to reflect normalized values, see
-    :ref:`form-request-flash-normalized`.
+.. note:: When validation fails and the default redirect response is used,
+    ``old()`` returns the prepared validation data. Use ``getValidated()`` to
+    access the processed data after a successful request.
 
 .. _form-request-validation-data:
 
@@ -225,19 +224,17 @@ Flashing Normalized Input
 =========================
 
 If your ``prepareForValidation()`` transforms visible form fields (for example,
-trimming strings or canonicalizing values), ``old()`` will return the original
-submitted input because the redirect flashes the raw superglobals.
+trimming strings or canonicalizing values), the default redirect response flashes
+the prepared validation data as old input.
 
-To make ``old()`` reflect the normalized values instead, override
-``failedValidation()`` and flash the data returned from
-``prepareForValidation()``:
+If you override ``failedValidation()`` and still need to flash normalized input,
+use the second ``$preparedData`` argument. It contains the same data that was
+passed to validation:
 
 .. literalinclude:: form_requests/013.php
    :lines: 2-
 
-Use ``getPreparedValidationData()`` inside ``failedValidation()`` to read that
-prepared data without running ``prepareForValidation()`` again. The prepared
-data has not passed validation. After successful validation, use
+The prepared data has not passed validation. After successful validation, use
 ``getValidated()`` or ``getValidatedInput()`` for trusted values.
 
 *****************************************

--- a/user_guide_src/source/incoming/form_requests.rst
+++ b/user_guide_src/source/incoming/form_requests.rst
@@ -226,12 +226,19 @@ Flashing Normalized Input
 
 If your ``prepareForValidation()`` transforms visible form fields (for example,
 trimming strings or canonicalizing values), ``old()`` will return the original
-submitted input because the redirect flashes the raw superglobals. To make
-``old()`` reflect the normalized values instead, override ``failedValidation()``
-and flash the normalized payload manually:
+submitted input because the redirect flashes the raw superglobals.
+
+To make ``old()`` reflect the normalized values instead, override
+``failedValidation()`` and flash the data returned from
+``prepareForValidation()``:
 
 .. literalinclude:: form_requests/013.php
    :lines: 2-
+
+Use ``getPreparedValidationData()`` inside ``failedValidation()`` to read that
+prepared data without running ``prepareForValidation()`` again. The prepared
+data has not passed validation. After successful validation, use
+``getValidated()`` or ``getValidatedInput()`` for trusted values.
 
 *****************************************
 How the Framework Resolves Form Requests

--- a/user_guide_src/source/incoming/form_requests/008.php
+++ b/user_guide_src/source/incoming/form_requests/008.php
@@ -16,7 +16,7 @@ class StorePostRequest extends FormRequest
     }
 
     // Always respond with JSON, regardless of the request type.
-    protected function failedValidation(array $errors): ResponseInterface
+    protected function failedValidation(array $errors, array $preparedData): ResponseInterface
     {
         return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
     }

--- a/user_guide_src/source/incoming/form_requests/013.php
+++ b/user_guide_src/source/incoming/form_requests/013.php
@@ -32,14 +32,14 @@ class StorePostRequest extends FormRequest
             return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
         }
 
-        // withInput() flashes the original superglobals and the validation
-        // errors. We then overwrite old input with the normalized payload so
-        // that old() returns the same values that were validated.
+        // withInput() flashes the original superglobals and validation errors.
+        // Then we overwrite old input with the prepared data so old() returns
+        // the same values that were passed to validation.
         $redirect = redirect()->back()->withInput();
 
         service('session')->setFlashdata('_ci_old_input', [
             'get'  => [],
-            'post' => $this->prepareForValidation($this->validationData()),
+            'post' => $this->getPreparedValidationData(),
         ]);
 
         return $redirect;

--- a/user_guide_src/source/incoming/form_requests/013.php
+++ b/user_guide_src/source/incoming/form_requests/013.php
@@ -22,8 +22,8 @@ class StorePostRequest extends FormRequest
         return $data;
     }
 
-    // Override so that old() reflects the normalized values on redirect.
-    protected function failedValidation(array $errors): ResponseInterface
+    // Override while still flashing the prepared values on redirect.
+    protected function failedValidation(array $errors, array $preparedData): ResponseInterface
     {
         if (
             $this->request->is('json')
@@ -32,14 +32,13 @@ class StorePostRequest extends FormRequest
             return service('response')->setStatusCode(422)->setJSON(['errors' => $errors]);
         }
 
-        // withInput() flashes the original superglobals and validation errors.
-        // Then we overwrite old input with the prepared data so old() returns
-        // the same values that were passed to validation.
+        // withInput() flashes validation errors. Then we replace old input with
+        // the same prepared values that were passed to validation.
         $redirect = redirect()->back()->withInput();
 
         service('session')->setFlashdata('_ci_old_input', [
             'get'  => [],
-            'post' => $this->getPreparedValidationData(),
+            'post' => $preparedData,
         ]);
 
         return $redirect;


### PR DESCRIPTION
**Description**

This PR proposes making the prepared FormRequest payload available while handling validation failure.

When a FormRequest normalizes input in `prepareForValidation()`, that prepared data is what the validator actually checks. But if validation fails, `failedValidation()` did not have a clean way to access that same payload. The user guide example for flashing normalized old input had to call `prepareForValidation($this->validationData())` a second time just to rebuild it, which felt a bit off.

This PR stores the prepared validation data when the FormRequest is resolved, and exposes it to subclasses with `getPreparedValidationData()`. That gives custom `failedValidation()` implementations access to the exact payload that was passed to validation, without running preparation twice.

The main use case is small and practical: if a request trims or canonicalizes visible form fields, a custom failure response can flash those prepared values back to the form instead of flashing raw submitted input.

This does not change the default validation failure response. Also, the prepared payload is still not trusted data; successful requests should continue using `getValidated()` or `getValidatedInput()`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide