### PR TITLE
feat: add Query Builder `insertGetID()`

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2879,6 +2879,26 @@ class BaseBuilder
     }
 
     /**
+     * Inserts a row and returns the insert ID.
+     *
+     * @param array<array-key, mixed>|object|null $set
+     *
+     * @return false|int|string
+     *
+     * @throws DatabaseException
+     */
+    public function insertGetID($set = null, ?bool $escape = null)
+    {
+        $result = $this->insert($set, $escape);
+
+        if ($result === false || $result instanceof Query || $this->db->affectedRows() < 1) {
+            return false;
+        }
+
+        return $this->db->insertID();
+    }
+
+    /**
      * @internal This is a temporary solution.
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/pull/5376

--- a/system/Model.php
+++ b/system/Model.php
@@ -162,6 +162,7 @@ class Model extends BaseModel
         'getCompiledInsert',
         'getCompiledSelect',
         'getCompiledUpdate',
+        'insertGetID',
     ];
 
     public function __construct(?ConnectionInterface $db = null, ?ValidationInterface $validation = null)

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
+use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Database\RawSql;
@@ -37,6 +38,51 @@ final class InsertTest extends CIUnitTestCase
         parent::setUp();
 
         $this->db = new MockConnection([]);
+    }
+
+    private function insertGetIDConnection(int $affectedRows = 1, int $insertID = 123): MockConnection
+    {
+        return new class ($affectedRows, $insertID) extends MockConnection {
+            public function __construct(
+                private readonly int $affectedRowCount,
+                private readonly int $lastInsertID,
+            ) {
+                parent::__construct([]);
+            }
+
+            /**
+             * @param mixed|null $binds
+             */
+            public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = ''): bool|Query
+            {
+                $query = new Query($this);
+                $query->setQuery($sql, $binds, $setEscapeFlags);
+
+                $this->lastQuery = $query;
+
+                if ($this->pretend) {
+                    return $query;
+                }
+
+                $this->resultID = $this->simpleQuery($query->getQuery());
+
+                if ($this->resultID === false) {
+                    return false;
+                }
+
+                return $query->isWriteType();
+            }
+
+            public function affectedRows(): int
+            {
+                return $this->affectedRowCount;
+            }
+
+            public function insertID(): int
+            {
+                return $this->lastInsertID;
+            }
+        };
     }
 
     public function testInsertArray(): void
@@ -143,6 +189,65 @@ final class InsertTest extends CIUnitTestCase
         $this->expectExceptionMessage('You must use the "set" method to insert an entry.');
 
         $builder->testMode()->insert(null, true);
+    }
+
+    public function testInsertGetIDReturnsInsertID(): void
+    {
+        $db = $this->insertGetIDConnection(insertID: 456);
+        $db->shouldReturn('execute', new class () {});
+
+        $insertID = (new BaseBuilder('jobs', $db))->insertGetID([
+            'name' => 'Grocery Sales',
+        ]);
+
+        $this->assertSame(456, $insertID);
+    }
+
+    public function testInsertGetIDReturnsFalseWhenInsertFails(): void
+    {
+        $db = $this->insertGetIDConnection();
+        $db->shouldReturn('execute', false);
+
+        $insertID = (new BaseBuilder('jobs', $db))->insertGetID([
+            'name' => 'Grocery Sales',
+        ]);
+
+        $this->assertFalse($insertID);
+    }
+
+    public function testInsertGetIDReturnsFalseWhenNoRowsAreInserted(): void
+    {
+        $db = $this->insertGetIDConnection(affectedRows: 0);
+        $db->shouldReturn('execute', new class () {});
+
+        $insertID = (new BaseBuilder('jobs', $db))->insertGetID([
+            'name' => 'Grocery Sales',
+        ]);
+
+        $this->assertFalse($insertID);
+    }
+
+    public function testInsertGetIDReturnsFalseInTestMode(): void
+    {
+        $db = $this->insertGetIDConnection();
+
+        $insertID = (new BaseBuilder('jobs', $db))->testMode()->insertGetID([
+            'name' => 'Grocery Sales',
+        ]);
+
+        $this->assertFalse($insertID);
+    }
+
+    public function testInsertGetIDReturnsFalseInPretendMode(): void
+    {
+        $db = $this->insertGetIDConnection();
+        $db->pretend();
+
+        $insertID = (new BaseBuilder('jobs', $db))->insertGetID([
+            'name' => 'Grocery Sales',
+        ]);
+
+        $this->assertFalse($insertID);
     }
 
     public function testInsertBatch(): void

--- a/tests/system/Models/GetCompiledModelTest.php
+++ b/tests/system/Models/GetCompiledModelTest.php
@@ -70,4 +70,17 @@ final class GetCompiledModelTest extends CIUnitTestCase
             ->set('email', 'mark@example.com')
             ->getCompiledUpdate();
     }
+
+    public function testInsertGetID(): void
+    {
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('You cannot use "insertGetID()" in "Tests\Support\Models\UserObjModel".');
+
+        $this->createModel(UserObjModel::class);
+
+        $this->model->insertGetID([
+            'name'  => 'Mark',
+            'email' => 'mark@example.com',
+        ]);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -221,6 +221,7 @@ Query Builder
 - Added ``exists()`` and ``doesntExist()`` to Query Builder to check whether the current Query Builder query would return at least one row. See :ref:`query-builder-exists`.
 - Added ``explain()`` to Query Builder to run execution-plan queries for the current ``SELECT`` query. See :ref:`query-builder-explain`.
 - Added ``havingBetween()``, ``orHavingBetween()``, ``havingNotBetween()``, and ``orHavingNotBetween()`` to Query Builder. See :ref:`query-builder-having-between`.
+- Added ``insertGetID()`` to Query Builder to insert a row and return the insert ID reported by the database driver. See :ref:`query-builder-insert-get-id`.
 - Added ``whereBetween()``, ``orWhereBetween()``, ``whereNotBetween()``, and ``orWhereNotBetween()`` to Query Builder. See :ref:`query-builder-where-between`.
 - Added ``whereColumn()`` and ``orWhereColumn()`` to compare one column to another column while protecting identifiers by default. See :ref:`query-builder-where-column`.
 - Added ``whereExists()``, ``orWhereExists()``, ``whereNotExists()``, and ``orWhereNotExists()`` to add ``EXISTS`` and ``NOT EXISTS`` subquery conditions. See :ref:`query-builder-where-exists`.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1099,6 +1099,20 @@ Here is an example using an object:
 
 The first parameter is an object.
 
+.. _query-builder-insert-get-id:
+
+$builder->insertGetID()
+-----------------------
+
+.. versionadded:: 4.8.0
+
+Inserts a row and returns the insert ID reported by the database driver:
+
+.. literalinclude:: query_builder/130.php
+
+This method returns ``false`` if the insert fails, no row is inserted, or the
+builder is in test mode. It uses the same insert ID behavior as ``$db->insertID()``.
+
 $builder->ignore()
 ------------------
 
@@ -2283,6 +2297,15 @@ Class Reference
         :rtype:     bool
 
         Compiles and executes an ``INSERT`` statement.
+
+    .. php:method:: insertGetID([$set = null[, $escape = null]])
+
+        :param array $set: An associative array of field/value pairs
+        :param bool $escape: Whether to escape values
+        :returns: The insert ID reported by the database driver, or ``false`` on failure
+        :rtype:    int|string|false
+
+        Compiles and executes an ``INSERT`` statement and returns the insert ID.
 
     .. php:method:: insertBatch([$set = null[, $escape = null[, $batch_size = 100]]])
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1113,6 +1113,9 @@ Inserts a row and returns the insert ID reported by the database driver:
 This method returns ``false`` if the insert fails, no row is inserted, or the
 builder is in test mode. It uses the same insert ID behavior as ``$db->insertID()``.
 
+.. note:: This method cannot be used when preparing queries with ``$db->prepare()``
+    because prepared queries require the builder method to return a query object.
+
 $builder->ignore()
 ------------------
 

--- a/user_guide_src/source/database/query_builder/130.php
+++ b/user_guide_src/source/database/query_builder/130.php
@@ -1,0 +1,9 @@
+<?php
+
+$data = [
+    'title' => 'My title',
+    'name'  => 'My Name',
+    'date'  => '2022-01-01',
+];
+
+$insertID = $builder->insertGetID($data);


### PR DESCRIPTION
**Description**

This PR proposes adding `insertGetID()` to Query Builder. This is a small API, but it removes a very common bit of friction: inserting a row and then immediately asking the connection for the generated ID.

Instead of writing:

```php
$builder->insert($data);
$insertID = $db->insertID();
```

users can write:

```php
$insertID = $builder->insertGetID($data);
```

That keeps the intent in one place: "insert this row and give me its ID". It is easier to read, harder to misuse, and avoids making users jump from the builder back to the connection for the second half of the same operation.

The method stays deliberately thin. It uses the existing `insert()` flow, then returns the database driver's existing `insertID()` value. It returns `false` when the insert fails, when no row is inserted, or when the builder is running in test/pretend mode.

I also blocked this from being proxied through `Model`, since Model already has its own insert flow with validation, events, timestamps, and return-ID behavior. This keeps the new method scoped to Query Builder, where it belongs.

Tests cover successful inserts, insert failures, no affected rows, test/pretend mode, and the Model guard.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide