### PR TITLE
feat: resolve spark routes filters for custom placeholders

### DIFF
--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -146,4 +146,14 @@ class Routing extends BaseRouting
      * Default: false
      */
     public bool $translateUriToCamelCase = true;
+
+    /**
+     * Sample values for the ``spark routes`` command, keyed by placeholder
+     * name without the ``(:...)`` wrapper. Each value must match the
+     * placeholder's regular expression and overrides the built-in or
+     * auto-generated sample for that placeholder.
+     *
+     * @var array<string, string>
+     */
+    public array $placeholderSamples = [];
 }

--- a/system/Commands/Utilities/Routes/PlaceholderSampleGenerator.php
+++ b/system/Commands/Utilities/Routes/PlaceholderSampleGenerator.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+/**
+ * Generates a sample string that matches a simple regular expression pattern.
+ *
+ * Supports the common fragments seen in custom route placeholders: character
+ * classes (``[A-Z]``, ``[0-9a-f]``), shorthand escapes (``\d``, ``\w``),
+ * quantifiers (``{n}``, ``{n,m}``, ``+``, ``*``, ``?``), literals, and
+ * top-level alternation (``a|b``). Anchors (``^``, ``$``) are tolerated and
+ * ignored. Anything more exotic (lookarounds, backreferences, nested groups
+ * with quantifiers, POSIX classes) causes the generator to bail out by
+ * returning ``null``.
+ *
+ * The generated candidate is validated against the original pattern with
+ * ``preg_match`` before being returned, so callers never receive a non-matching
+ * sample even when the parser is too permissive for a given edge case.
+ *
+ * @see \CodeIgniter\Commands\Utilities\Routes\PlaceholderSampleGeneratorTest
+ */
+final class PlaceholderSampleGenerator
+{
+    private string $pattern;
+    private int $position = 0;
+    private int $length   = 0;
+
+    /**
+     * Returns a sample string matching the regular expression ``$pattern``, or
+     * ``null`` when the pattern uses features this generator cannot reverse.
+     */
+    public function generate(string $pattern): ?string
+    {
+        $this->pattern  = $pattern;
+        $this->position = 0;
+        $this->length   = strlen($pattern);
+
+        try {
+            $sample = $this->parseAlternation();
+        } catch (UnsupportedPatternException) {
+            return null;
+        }
+
+        if ($this->position !== $this->length) {
+            return null;
+        }
+
+        if (@preg_match('#^(?:' . $pattern . ')$#', $sample) !== 1) {
+            return null;
+        }
+
+        return $sample;
+    }
+
+    /**
+     * Parses a (possibly alternated) sequence and returns the first branch.
+     */
+    private function parseAlternation(): string
+    {
+        $branch = $this->parseSequence();
+
+        if ($this->position < $this->length && $this->pattern[$this->position] === '|') {
+            // Skip the remaining branches; the first one is enough.
+            while ($this->position < $this->length && $this->pattern[$this->position] === '|') {
+                $this->position++;
+                $this->parseSequence();
+            }
+        }
+
+        return $branch;
+    }
+
+    private function parseSequence(): string
+    {
+        $output = '';
+
+        while ($this->position < $this->length) {
+            $char = $this->pattern[$this->position];
+
+            if ($char === '|' || $char === ')') {
+                break;
+            }
+
+            $atom = $this->parseAtom();
+
+            [$minRepeat] = $this->parseQuantifier();
+
+            $output .= str_repeat($atom, $minRepeat);
+        }
+
+        return $output;
+    }
+
+    private function parseAtom(): string
+    {
+        $char = $this->pattern[$this->position];
+
+        if ($char === '^' || $char === '$') {
+            $this->position++;
+
+            return '';
+        }
+
+        if ($char === '.') {
+            $this->position++;
+
+            return 'a';
+        }
+
+        if ($char === '\\') {
+            return $this->parseEscape();
+        }
+
+        if ($char === '[') {
+            return $this->parseCharacterClass();
+        }
+
+        if ($char === '(') {
+            return $this->parseGroup();
+        }
+
+        // Unsupported metacharacters outside of the ones handled above.
+        if (in_array($char, ['+', '*', '?', '{', '}', ']'], true)) {
+            throw new UnsupportedPatternException();
+        }
+
+        $this->position++;
+
+        return $char;
+    }
+
+    private function parseEscape(): string
+    {
+        $this->position++;
+
+        if ($this->position >= $this->length) {
+            throw new UnsupportedPatternException();
+        }
+
+        $char = $this->pattern[$this->position];
+        $this->position++;
+
+        return match ($char) {
+            'd'     => '0',
+            'D'     => 'a',
+            'w'     => 'a',
+            'W'     => '-',
+            's'     => ' ',
+            'S'     => 'a',
+            default => $char,
+        };
+    }
+
+    private function parseCharacterClass(): string
+    {
+        $this->position++;
+        $negated = false;
+
+        if ($this->position < $this->length && $this->pattern[$this->position] === '^') {
+            $negated = true;
+            $this->position++;
+        }
+
+        $allowed = [];
+        $first   = true;
+
+        while ($this->position < $this->length && ($this->pattern[$this->position] !== ']' || $first)) {
+            $first = false;
+            $char  = $this->pattern[$this->position];
+
+            if ($char === '\\') {
+                $this->position++;
+
+                if ($this->position >= $this->length) {
+                    throw new UnsupportedPatternException();
+                }
+
+                $escaped = $this->pattern[$this->position];
+                $this->position++;
+
+                $allowed = [...$allowed, ...$this->expandEscapedClassChar($escaped)];
+
+                continue;
+            }
+
+            // Range a-z
+            if (
+                $this->position < $this->length - 2
+                && $this->pattern[$this->position + 1] === '-'
+                && $this->pattern[$this->position + 2] !== ']'
+            ) {
+                $start = $char;
+
+                $end = $this->pattern[$this->position + 2];
+                $this->position += 3;
+
+                if (ord($start) > ord($end)) {
+                    throw new UnsupportedPatternException();
+                }
+
+                for ($code = ord($start); $code <= ord($end); $code++) {
+                    $allowed[] = chr($code);
+                }
+
+                continue;
+            }
+
+            $allowed[] = $char;
+            $this->position++;
+        }
+
+        if ($this->position >= $this->length || $this->pattern[$this->position] !== ']') {
+            throw new UnsupportedPatternException();
+        }
+
+        $this->position++;
+
+        return $negated ? $this->pickNegated($allowed) : $this->pickPreferred($allowed);
+    }
+
+    private function parseGroup(): string
+    {
+        $this->position++;
+
+        // Skip non-capturing / named group prefixes (?:..), (?P<name>..), (?<name>..).
+        if (
+            $this->position < $this->length - 1
+            && $this->pattern[$this->position] === '?'
+            && $this->pattern[$this->position + 1] === ':'
+        ) {
+            $this->position += 2;
+        } elseif (
+            $this->position < $this->length
+            && $this->pattern[$this->position] === '?'
+        ) {
+            // Lookarounds, named groups with special syntax, atomic groups, etc.
+            throw new UnsupportedPatternException();
+        }
+
+        $inner = $this->parseAlternation();
+
+        if ($this->position >= $this->length || $this->pattern[$this->position] !== ')') {
+            throw new UnsupportedPatternException();
+        }
+
+        $this->position++;
+
+        return $inner;
+    }
+
+    /**
+     * Reads the quantifier following the current atom and returns ``[min, max]``.
+     *
+     * ``max`` is informational only; the generator always emits the minimum
+     * number of repetitions (with ``*`` and ``?`` normalized to zero).
+     *
+     * @return array{0: int, 1: int|null}
+     */
+    private function parseQuantifier(): array
+    {
+        if ($this->position >= $this->length) {
+            return [1, 1];
+        }
+
+        $char = $this->pattern[$this->position];
+
+        $bounds = match ($char) {
+            '?'     => [0, 1],
+            '*'     => [0, null],
+            '+'     => [1, null],
+            default => null,
+        };
+
+        if ($bounds !== null) {
+            $this->position++;
+            $this->consumeGreedyModifier();
+
+            return $bounds;
+        }
+
+        if ($char === '{') {
+            return $this->parseBraceQuantifier();
+        }
+
+        return [1, 1];
+    }
+
+    /**
+     * @return array{0: int, 1: int|null}
+     */
+    private function parseBraceQuantifier(): array
+    {
+        $end = strpos($this->pattern, '}', $this->position);
+        if ($end === false) {
+            throw new UnsupportedPatternException();
+        }
+
+        $body = substr($this->pattern, $this->position + 1, $end - $this->position - 1);
+
+        $this->position = $end + 1;
+        $this->consumeGreedyModifier();
+
+        if (preg_match('/^(\d+)(?:,(\d*))?$/', $body, $matches) !== 1) {
+            throw new UnsupportedPatternException();
+        }
+
+        $min = (int) $matches[1];
+        $max = isset($matches[2]) && $matches[2] !== '' ? (int) $matches[2] : null;
+
+        return [$min, $max];
+    }
+
+    private function consumeGreedyModifier(): void
+    {
+        if (
+            $this->position < $this->length
+            && ($this->pattern[$this->position] === '?' || $this->pattern[$this->position] === '+')
+        ) {
+            $this->position++;
+        }
+    }
+
+    /**
+     * Prefer letters, then digits, then anything printable. Keeps samples
+     * readable (``[A-Z0-9]`` → ``A``, not ``0``).
+     *
+     * @param list<string> $chars
+     */
+    private function pickPreferred(array $chars): string
+    {
+        foreach (['/[A-Za-z]/', '/\d/', '/[^\s\/]/'] as $preference) {
+            foreach ($chars as $c) {
+                if (preg_match($preference, $c) === 1) {
+                    return $c;
+                }
+            }
+        }
+
+        return $chars[0];
+    }
+
+    /**
+     * @param list<string> $forbidden
+     */
+    private function pickNegated(array $forbidden): string
+    {
+        $lookup = array_flip($forbidden);
+
+        foreach (['a', 'A', '0', '_', '-'] as $candidate) {
+            if (! isset($lookup[$candidate])) {
+                return $candidate;
+            }
+        }
+
+        throw new UnsupportedPatternException();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expandEscapedClassChar(string $char): array
+    {
+        return match ($char) {
+            'd'           => ['0'],
+            'w'           => ['a'],
+            's'           => [' '],
+            'D', 'W', 'S' => throw new UnsupportedPatternException(),
+            default       => [$char],
+        };
+    }
+}

--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -97,8 +97,8 @@ final class SampleURIGenerator
             return $this->resolvedCache[$placeholder];
         }
 
-        $sample = $this->configuredSample($placeholder, $regex)
-            ?? $this->samples[$placeholder]
+        $sample = $this->matchingSample($this->config->placeholderSamples[$placeholder] ?? null, $regex)
+            ?? $this->matchingSample($this->samples[$placeholder] ?? null, $regex)
             ?? $this->sampleGenerator->generate($regex)
             ?? self::UNKNOWN_SAMPLE;
 
@@ -108,14 +108,14 @@ final class SampleURIGenerator
     }
 
     /**
-     * Returns the configured sample for the placeholder when one is set and it
-     * matches the placeholder regex, otherwise ``null`` so resolution falls
-     * through to the built-in, auto-generated, or unknown sample.
+     * Returns the given sample when it is set and matches the placeholder
+     * regex, otherwise ``null`` so resolution falls through to the next source.
+     * Guards both the configured and built-in samples, since a built-in
+     * placeholder name may be redefined with a different regex via
+     * ``RouteCollection::addPlaceholder()``.
      */
-    private function configuredSample(string $placeholder, string $regex): ?string
+    private function matchingSample(?string $sample, string $regex): ?string
     {
-        $sample = $this->config->placeholderSamples[$placeholder] ?? null;
-
         if ($sample === null) {
             return null;
         }

--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Router\RouteCollection;
 use Config\App;
+use Config\Routing;
 
 /**
  * Generate a sample URI path from route key regex.
@@ -23,10 +24,20 @@ use Config\App;
  */
 final class SampleURIGenerator
 {
+    /**
+     * Placeholder inserted into a sample URI segment when no sample can be
+     * resolved. The resulting URI matches no route, so the ``spark routes``
+     * command reports that route's filters as ``<unknown>``.
+     */
+    public const UNKNOWN_SAMPLE = '::unknown::';
+
     private readonly RouteCollection $routes;
+    private readonly Routing $config;
+    private readonly PlaceholderSampleGenerator $sampleGenerator;
 
     /**
-     * Sample URI path for placeholder.
+     * Built-in sample URI paths for the standard placeholders shipped with
+     * ``RouteCollection``.
      *
      * @var array<string, string>
      */
@@ -39,9 +50,18 @@ final class SampleURIGenerator
         'hash'     => 'abc_123',
     ];
 
-    public function __construct(?RouteCollection $routes = null)
+    /**
+     * Memoized resolved samples, keyed by placeholder name.
+     *
+     * @var array<string, string>
+     */
+    private array $resolvedCache = [];
+
+    public function __construct(?RouteCollection $routes = null, ?Routing $config = null)
     {
-        $this->routes = $routes ?? service('routes');
+        $this->routes          = $routes ?? service('routes');
+        $this->config          = $config ?? config(Routing::class);
+        $this->sampleGenerator = new PlaceholderSampleGenerator();
     }
 
     /**
@@ -62,12 +82,44 @@ final class SampleURIGenerator
         }
 
         foreach ($this->routes->getPlaceholders() as $placeholder => $regex) {
-            $sample = $this->samples[$placeholder] ?? '::unknown::';
+            $sample = $this->resolveSample($placeholder, $regex);
 
             $sampleUri = str_replace('(' . $regex . ')', $sample, $sampleUri);
         }
 
         // auto route
         return str_replace('[/...]', '/1/2/3/4/5', $sampleUri);
+    }
+
+    private function resolveSample(string $placeholder, string $regex): string
+    {
+        if (isset($this->resolvedCache[$placeholder])) {
+            return $this->resolvedCache[$placeholder];
+        }
+
+        $sample = $this->configuredSample($placeholder, $regex)
+            ?? $this->samples[$placeholder]
+            ?? $this->sampleGenerator->generate($regex)
+            ?? self::UNKNOWN_SAMPLE;
+
+        $this->resolvedCache[$placeholder] = $sample;
+
+        return $sample;
+    }
+
+    /**
+     * Returns the configured sample for the placeholder when one is set and it
+     * matches the placeholder regex, otherwise ``null`` so resolution falls
+     * through to the built-in, auto-generated, or unknown sample.
+     */
+    private function configuredSample(string $placeholder, string $regex): ?string
+    {
+        $sample = $this->config->placeholderSamples[$placeholder] ?? null;
+
+        if ($sample === null) {
+            return null;
+        }
+
+        return @preg_match('#^(?:' . $regex . ')$#', $sample) === 1 ? $sample : null;
     }
 }

--- a/system/Commands/Utilities/Routes/UnsupportedPatternException.php
+++ b/system/Commands/Utilities/Routes/UnsupportedPatternException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Exceptions\RuntimeException;
+
+/**
+ * Internal control-flow exception raised when `PlaceholderSampleGenerator`
+ * encounters a regex fragment it cannot reverse.
+ *
+ * The caller turns this into a ``null`` return.
+ *
+ * @internal
+ */
+final class UnsupportedPatternException extends RuntimeException
+{
+}

--- a/system/Config/Routing.php
+++ b/system/Config/Routing.php
@@ -146,4 +146,14 @@ class Routing extends BaseConfig
      * Default: false
      */
     public bool $translateUriToCamelCase = false;
+
+    /**
+     * Sample values for the ``spark routes`` command, keyed by placeholder
+     * name without the ``(:...)`` wrapper. Each value must match the
+     * placeholder's regular expression and overrides the built-in or
+     * auto-generated sample for that placeholder.
+     *
+     * @var array<string, string>
+     */
+    public array $placeholderSamples = [];
 }

--- a/tests/system/Commands/Utilities/Routes/PlaceholderSampleGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/PlaceholderSampleGeneratorTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class PlaceholderSampleGeneratorTest extends CIUnitTestCase
+{
+    #[DataProvider('provideGenerateProducesMatchingSample')]
+    public function testGenerateProducesMatchingSample(string $pattern, string $expected): void
+    {
+        $generator = new PlaceholderSampleGenerator();
+
+        $sample = $generator->generate($pattern);
+
+        $this->assertSame($expected, $sample);
+        $this->assertMatchesRegularExpression('#^(?:' . $pattern . ')$#', $sample);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function provideGenerateProducesMatchingSample(): iterable
+    {
+        yield 'digit class' => ['[0-9]+', '0'];
+
+        yield 'uppercase class' => ['[A-Z]+', 'A'];
+
+        yield 'mixed class prefers letter' => ['[A-Z0-9]+', 'A'];
+
+        yield 'code pattern from issue #9804' => ['[A-Z]{3}[0-9]+', 'AAA0'];
+
+        yield 'fixed quantifier' => ['[a-z]{5}', 'aaaaa'];
+
+        yield 'range quantifier uses min' => ['[a-z]{2,5}', 'aa'];
+
+        yield 'star quantifier collapses' => ['[a-z]*abc', 'abc'];
+
+        yield 'optional collapses' => ['a?bc', 'bc'];
+
+        yield 'literal passthrough' => ['login', 'login'];
+
+        yield 'escape backslash digit' => ['\\d{4}', '0000'];
+
+        yield 'escape backslash word' => ['\\w+', 'a'];
+
+        yield 'escape backslash non-digit' => ['\\D+', 'a'];
+
+        yield 'escape backslash non-word' => ['\\W+', '-'];
+
+        yield 'escape backslash whitespace' => ['\\s+', ' '];
+
+        yield 'escape backslash non-whitespace' => ['\\S+', 'a'];
+
+        yield 'uuid (letters preferred)' => [
+            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+            'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        ];
+
+        yield 'anchored pattern tolerated' => ['^abc$', 'abc'];
+
+        yield 'alternation picks first' => ['(?:foo|bar)', 'foo'];
+
+        yield 'non-capturing group' => ['(?:x)+', 'x'];
+
+        yield 'escape in class' => ['[A-Z\\-]+', 'A'];
+
+        yield 'hyphen at end of class' => ['[A-Z-]+', 'A'];
+
+        yield 'negated class avoids forbidden digits' => ['[^0-9]+', 'a'];
+
+        yield 'negated class avoids forbidden letter' => ['[^a]+', 'A'];
+
+        yield 'escaped digit in class' => ['[\\d]+', '0'];
+
+        yield 'escaped word in class' => ['[\\w]+', 'a'];
+
+        yield 'escaped whitespace in class' => ['[\\s]+', ' '];
+
+        yield 'punctuation-only class' => ['[._-]+', '.'];
+
+        yield 'non-greedy star' => ['a*?', ''];
+
+        yield 'non-greedy plus' => ['a+?', 'a'];
+
+        yield 'possessive plus' => ['a++', 'a'];
+
+        yield 'possessive star collapses' => ['a*+', ''];
+
+        yield 'top-level alternation' => ['a|b', 'a'];
+
+        yield 'top-level multi-branch alternation' => ['cat|dog|fish', 'cat'];
+
+        yield 'escaped literal outside class' => ['a\\.b', 'a.b'];
+
+        yield 'open-ended brace quantifier' => ['[a-z]{2,}', 'aa'];
+
+        yield 'literal bracket first in class' => ['[]]', ']'];
+
+        yield 'negated class with bracket first' => ['[^]]', 'a'];
+
+        yield 'negated class forces digit' => ['[^a-zA-Z]+', '0'];
+
+        yield 'empty pattern' => ['', ''];
+    }
+
+    #[DataProvider('provideGenerateReturnsNullForUnsupportedPatterns')]
+    public function testGenerateReturnsNullForUnsupportedPatterns(string $pattern): void
+    {
+        $generator = new PlaceholderSampleGenerator();
+
+        $this->assertNull($generator->generate($pattern));
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function provideGenerateReturnsNullForUnsupportedPatterns(): iterable
+    {
+        yield 'lookahead' => ['(?=abc)abc'];
+
+        yield 'lookbehind' => ['(?<=abc)def'];
+
+        yield 'backreference' => ['(foo)\\1'];
+
+        yield 'named group' => ['(?P<name>abc)'];
+
+        yield 'negated class in class' => ['[\\D]+'];
+
+        yield 'unclosed class' => ['[abc'];
+
+        yield 'reversed range' => ['[z-a]'];
+
+        yield 'dangling brace' => ['a{2'];
+
+        yield 'stray closing paren' => ['abc)def'];
+
+        yield 'metachar at atom position' => ['+abc'];
+
+        yield 'trailing backslash' => ['abc\\'];
+
+        yield 'unclosed escape in class' => ['[\\'];
+
+        yield 'unclosed group' => ['(abc'];
+
+        yield 'non-numeric brace body' => ['a{foo}'];
+
+        yield 'negated class exhausts candidates' => ['[^aA0_-]'];
+
+        yield 'hash breaks validation delimiter' => ['[A-Z]#[0-9]+'];
+    }
+
+    public function testGenerateValidatesAgainstOriginalPattern(): void
+    {
+        $generator = new PlaceholderSampleGenerator();
+
+        // The dot atom emits 'a', which matches '.'. This sanity-checks the guard.
+        $this->assertSame('a', $generator->generate('.'));
+    }
+
+    public function testGenerateReturnsEmptyStringForOptionalOnlyPattern(): void
+    {
+        $generator = new PlaceholderSampleGenerator();
+
+        $this->assertSame('', $generator->generate('[a-z]?'));
+    }
+}

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Routing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -23,6 +24,13 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class SampleURIGeneratorTest extends CIUnitTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetServices();
+    }
+
     #[DataProvider('provideGet')]
     public function testGet(string $routeKey, string $expected): void
     {
@@ -35,18 +43,34 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
 
     public static function provideGet(): iterable
     {
-        yield from [
-            'root'                => ['/', '/'],
-            'placeholder num'     => ['shop/product/([0-9]+)', 'shop/product/123'],
-            'placeholder segment' => ['shop/product/([^/]+)', 'shop/product/abc_123'],
-            'placeholder any'     => ['shop/product/(.*)', 'shop/product/123/abc'],
-            'locale'              => ['{locale}/home', 'en/home'],
-            'locale segment'      => ['{locale}/product/([^/]+)', 'en/product/abc_123'],
-            'auto route'          => ['home/index[/...]', 'home/index/1/2/3/4/5'],
-        ];
+        yield 'root' => ['/', '/'];
+
+        yield 'placeholder num' => ['shop/product/([0-9]+)', 'shop/product/123'];
+
+        yield 'placeholder segment' => ['shop/product/([^/]+)', 'shop/product/abc_123'];
+
+        yield 'placeholder any' => ['shop/product/(.*)', 'shop/product/123/abc'];
+
+        yield 'locale' => ['{locale}/home', 'en/home'];
+
+        yield 'locale segment' => ['{locale}/product/([^/]+)', 'en/product/abc_123'];
+
+        yield 'auto route' => ['home/index[/...]', 'home/index/1/2/3/4/5'];
     }
 
-    public function testGetFromPlaceholderCustomPlaceholder(): void
+    public function testGetAutoGeneratesSampleForCustomPlaceholder(): void
+    {
+        $routes = service('routes');
+        $routes->addPlaceholder('code', '[A-Z]{3}[0-9]+');
+
+        $generator = new SampleURIGenerator();
+
+        $uri = $generator->get('test/([A-Z]{3}[0-9]+)');
+
+        $this->assertSame('test/AAA0', $uri);
+    }
+
+    public function testGetAutoGeneratesSampleForUuidPlaceholder(): void
     {
         $routes = service('routes');
         $routes->addPlaceholder(
@@ -59,6 +83,111 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
         $routeKey = 'shop/product/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})';
         $uri      = $generator->get($routeKey);
 
-        $this->assertSame('shop/product/::unknown::', $uri);
+        $this->assertSame('shop/product/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', $uri);
+    }
+
+    public function testGetUsesConfiguredSampleForCustomPlaceholder(): void
+    {
+        $routes = service('routes');
+        $routes->addPlaceholder('code', '[A-Z]{3}[0-9]+');
+
+        $config                     = new Routing();
+        $config->placeholderSamples = ['code' => 'ABC123'];
+
+        $generator = new SampleURIGenerator(null, $config);
+
+        $uri = $generator->get('test/([A-Z]{3}[0-9]+)');
+
+        $this->assertSame('test/ABC123', $uri);
+    }
+
+    public function testConfiguredSampleWinsOverAutoGeneration(): void
+    {
+        $routes = service('routes');
+        $routes->addPlaceholder('code', '[A-Z]{3}[0-9]+');
+
+        $config                     = new Routing();
+        $config->placeholderSamples = ['code' => 'XYZ42'];
+
+        $generator = new SampleURIGenerator(null, $config);
+
+        $uri = $generator->get('test/([A-Z]{3}[0-9]+)');
+
+        $this->assertSame('test/XYZ42', $uri);
+    }
+
+    public function testGetMemoizesSamplesAcrossCalls(): void
+    {
+        $routes = service('routes');
+        $routes->addPlaceholder('code', '[A-Z]{3}[0-9]+');
+
+        $generator = new SampleURIGenerator();
+
+        $this->assertSame('test/AAA0', $generator->get('test/([A-Z]{3}[0-9]+)'));
+        $this->assertSame('other/AAA0', $generator->get('other/([A-Z]{3}[0-9]+)'));
+    }
+
+    public function testGetFallsBackToUnknownForUnresolvablePlaceholder(): void
+    {
+        $routes = service('routes');
+        // A lookahead is unsupported, so expect the fallback sentinel.
+        $routes->addPlaceholder('guarded', '(?=abc)abc');
+
+        $generator = new SampleURIGenerator();
+
+        $uri = $generator->get('x/((?=abc)abc)');
+
+        $this->assertSame('x/' . SampleURIGenerator::UNKNOWN_SAMPLE, $uri);
+    }
+
+    public function testConfiguredSampleWinsOverBuiltIn(): void
+    {
+        $config                     = new Routing();
+        $config->placeholderSamples = ['num' => '987'];
+
+        $generator = new SampleURIGenerator(null, $config);
+
+        $uri = $generator->get('shop/product/([0-9]+)');
+
+        $this->assertSame('shop/product/987', $uri);
+    }
+
+    public function testBuiltInSampleWinsOverAutoGeneration(): void
+    {
+        $generator = new SampleURIGenerator();
+
+        // The built-in sample (123) is preferred over the value the regex
+        // generator would produce for [0-9]+ (0).
+        $this->assertSame('shop/product/123', $generator->get('shop/product/([0-9]+)'));
+    }
+
+    public function testNonMatchingConfiguredSampleIsIgnored(): void
+    {
+        $routes = service('routes');
+        $routes->addPlaceholder('code', '[A-Z]{3}[0-9]+');
+
+        $config                     = new Routing();
+        $config->placeholderSamples = ['code' => 'does not match'];
+
+        $generator = new SampleURIGenerator(null, $config);
+
+        $uri = $generator->get('test/([A-Z]{3}[0-9]+)');
+
+        $this->assertSame('test/AAA0', $uri);
+    }
+
+    public function testEmptyConfiguredSampleIsIgnored(): void
+    {
+        $routes = service('routes');
+        $routes->addPlaceholder('code', '[A-Z]{3}[0-9]+');
+
+        $config                     = new Routing();
+        $config->placeholderSamples = ['code' => ''];
+
+        $generator = new SampleURIGenerator(null, $config);
+
+        $uri = $generator->get('test/([A-Z]{3}[0-9]+)');
+
+        $this->assertSame('test/AAA0', $uri);
     }
 }

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -190,4 +190,18 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
 
         $this->assertSame('test/AAA0', $uri);
     }
+
+    public function testOverriddenBuiltInPlaceholderIgnoresStaleSample(): void
+    {
+        $routes = service('routes');
+        // Redefining a built-in name with a new regex must not reuse the stale
+        // built-in sample (123), which no longer matches.
+        $routes->addPlaceholder('num', '[A-Z]+');
+
+        $generator = new SampleURIGenerator();
+
+        $uri = $generator->get('shop/product/([A-Z]+)');
+
+        $this->assertSame('shop/product/A', $uri);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -201,6 +201,8 @@ Commands
 - Added ``key:rotate`` command to demote the current ``encryption.key`` to ``encryption.previousKeys`` in **.env** and generate a new key. See :ref:`spark-key-rotate`.
 - Added ``AbstractCommand::callSilently()`` to invoke another command with its output discarded, restoring the prior IO afterwards. See :ref:`modern-commands-call-silently`.
 - Added :php:class:`NullInputOutput <CodeIgniter\\CLI\\NullInputOutput>`, an :php:class:`InputOutput <CodeIgniter\\CLI\\InputOutput>` sink that discards all writes and returns an empty string from ``input()``.
+- The ``spark routes`` command now resolves the Before/After Filters columns for routes that use custom placeholders registered via ``$routes->addPlaceholder()``.
+  Sample URIs for custom placeholders are derived from the placeholder regex when possible, and can be overridden through the new ``$placeholderSamples`` property in ``Config\Routing``. See :ref:`placeholder-samples-for-spark-routes`.
 
 Testing
 =======

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -237,6 +237,35 @@ This must be called before you add the route:
 
 .. literalinclude:: routing/017.php
 
+.. _placeholder-samples-for-spark-routes:
+
+Sample Values for ``spark routes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 4.8.0
+
+The :doc:`spark routes </cli/spark_commands>` command needs a concrete URI that matches each route in order
+to resolve the filters that would run for it. For the built-in placeholders (``num``, ``segment``,
+``alpha``, and so on) it uses a hardcoded sample value. For custom placeholders it now attempts to generate
+a value from the placeholder's regular expression, so common patterns like ``[A-Z]{3}[0-9]+`` or the UUID
+example above work without any extra configuration.
+
+If the regex uses features the generator cannot reverse (lookarounds, backreferences, complex alternations,
+etc.), the Before/After Filters columns fall back to showing ``<unknown>``. You can fix that by providing an
+explicit sample in ``app/Config/Routing.php``:
+
+.. literalinclude:: routing/075.php
+
+Each value must match its placeholder's regular expression. A value that does not match is ignored. Entries
+override the samples for the built-in placeholders too, not only custom ones.
+
+The resolution order is: a matching value declared in ``$placeholderSamples``, then the built-in sample for
+standard placeholders, then an auto-generated value, then ``<unknown>`` as a last resort.
+
+.. note:: This configuration only affects the ``spark routes`` display.
+    Filter execution at request time already honors custom placeholders
+    without any setup.
+
 Regular Expressions
 -------------------
 

--- a/user_guide_src/source/incoming/routing/075.php
+++ b/user_guide_src/source/incoming/routing/075.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\Routing as BaseRouting;
+
+class Routing extends BaseRouting
+{
+    public array $placeholderSamples = [
+        'code' => 'ABC123',
+        'uuid' => '550e8400-e29b-41d4-a716-446655440000',
+    ];
+}

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -75,6 +75,8 @@ Config
 
 - app/Config/Mimes.php
     - ``Config\Mimes::$mimes`` added a new key ``md`` for Markdown files.
+- app/Config/Routing.php
+    - ``Config\Routing::$placeholderSamples`` was added to provide sample values for custom route placeholders so the ``spark routes`` command can resolve their filters.
 - app/Config/Security.php
     - ``Config\Security::$csrfFetchMetadata`` and ``Config\Security::$csrfFetchMetadataRejectSameSite`` were added for Fetch Metadata based CSRF protection.
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
`php spark routes` printed `<unknown>` in the Before/After Filters columns for any route using a custom placeholder registered with `$routes->addPlaceholder()`. `SampleURIGenerator` had no sample for such placeholders and substituted
`::unknown::`, producing a URI that matched no route, so `FilterCollector` could not resolve its filters. Filter execution at request time was unaffected. This was only the command's display, as confirmed in the issue.

This adds two ways to obtain a sample URI for a custom placeholder:

- `PlaceholderSampleGenerator` derives a value from the placeholder's regular  expression, covering the fragments common in route patterns (character classes,  shorthand escapes, quantifiers, literals, top-level alternation, anchors). Patterns it cannot reverse (lookarounds, backreferences, named groups, etc.) return `null`, and every candidate is validated with `preg_match` before use.
- `Config\Routing::$placeholderSamples` lets you set or override the sample per placeholder. A value that does not match the placeholder regex is ignored.

`SampleURIGenerator` resolves each placeholder in this order: a matching`$placeholderSamples` value, the built-in sample, an auto-generated value, then `::unknown::`. Results are memoized per placeholder.

Common patterns such as `[A-Z]{3}[0-9]+` and UUIDs now resolve without any configuration. The user guide, changelog, and upgrade notes are updated.

Fixes #9804 
Supersedes and closes #10206 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
