### PR TITLE
feat: support objects in remaining dot array helpers

### DIFF
--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -146,9 +146,9 @@ final class ArrayHelper
      *
      * If wildcard `*` is used, all items for the key after it must have the key.
      *
-     * @param array<array-key, mixed> $array
+     * @param array<array-key, mixed>|object $array
      */
-    public static function dotHas(string $index, array $array): bool
+    public static function dotHas(string $index, array|object $array): bool
     {
         self::ensureValidWildcardPattern($index);
 
@@ -164,10 +164,10 @@ final class ArrayHelper
     /**
      * Recursively check key existence by dot path, including wildcard support.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>            $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>                   $indexes
      */
-    private static function hasByDotPath(array $array, array $indexes): bool
+    private static function hasByDotPath(array|object $array, array $indexes): bool
     {
         if ($indexes === []) {
             return true;
@@ -176,8 +176,10 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            foreach ($array as $item) {
-                if (! is_array($item) || ! self::hasByDotPath($item, $indexes)) {
+            $iterable = is_object($array) ? self::toIterable($array) : $array;
+
+            foreach ($iterable as $item) {
+                if ((! is_array($item) && ! is_object($item)) || ! self::hasByDotPath($item, $indexes)) {
                     return false;
                 }
             }
@@ -185,7 +187,7 @@ final class ArrayHelper
             return true;
         }
 
-        if (! array_key_exists($currentIndex, $array)) {
+        if (! self::valueExists($array, $currentIndex)) {
             return false;
         }
 
@@ -193,11 +195,13 @@ final class ArrayHelper
             return true;
         }
 
-        if (! is_array($array[$currentIndex])) {
+        $value = self::value($array, $currentIndex);
+
+        if (! is_array($value) && ! is_object($value)) {
             return false;
         }
 
-        return self::hasByDotPath($array[$currentIndex], $indexes);
+        return self::hasByDotPath($value, $indexes);
     }
 
     /**
@@ -247,12 +251,12 @@ final class ArrayHelper
     /**
      * Gets only the specified keys using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    public static function dotOnly(array $array, array|string $indexes): array
+    public static function dotOnly(array|object $array, array|string $indexes): array
     {
         $indexes = is_string($indexes) ? [$indexes] : $indexes;
         $result  = [];
@@ -261,7 +265,7 @@ final class ArrayHelper
             self::ensureValidWildcardPattern($index, true);
 
             if ($index === '*') {
-                $result = [...$result, ...$array];
+                $result = [...$result, ...(is_object($array) ? self::toIterable($array) : $array)];
 
                 continue;
             }
@@ -280,15 +284,15 @@ final class ArrayHelper
     /**
      * Gets all keys except the specified ones using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    public static function dotExcept(array $array, array|string $indexes): array
+    public static function dotExcept(array|object $array, array|string $indexes): array
     {
         $indexes = is_string($indexes) ? [$indexes] : $indexes;
-        $result  = $array;
+        $result  = self::toArrayView($array);
 
         foreach ($indexes as $index) {
             self::ensureValidWildcardPattern($index, true);
@@ -466,20 +470,20 @@ final class ArrayHelper
     private static function valueExists(array|object $data, string $key): bool
     {
         if (is_array($data)) {
-            return isset($data[$key]);
+            return array_key_exists($key, $data);
         }
 
         $array = self::entityToArray($data);
 
         if ($array !== null) {
-            return isset($array[$key]);
+            return array_key_exists($key, $array);
         }
 
         if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
             return true;
         }
 
-        if (isset(get_object_vars($data)[$key])) {
+        if (array_key_exists($key, get_object_vars($data))) {
             return true;
         }
 
@@ -548,6 +552,26 @@ final class ArrayHelper
         }
 
         return get_object_vars($data);
+    }
+
+    /**
+     * Normalize arrays or objects to an array view safe for dotExcept().
+     *
+     * @param array<array-key, mixed>|object $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function toArrayView(array|object $data): array
+    {
+        $array = is_object($data) ? self::toIterable($data) : $data;
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) || is_object($value)) {
+                $array[$key] = self::toArrayView($value);
+            }
+        }
+
+        return $array;
     }
 
     /**
@@ -688,14 +712,15 @@ final class ArrayHelper
     }
 
     /**
-     * Projects matching paths from source array into result with preserved structure.
+     * Projects matching paths from source into result with preserved structure.
      *
-     * @param list<string>            $indexes
-     * @param list<string>            $prefix
-     * @param array<array-key, mixed> $result
+     * @param array<array-key, mixed>|object $source
+     * @param list<string>                   $indexes
+     * @param list<string>                   $prefix
+     * @param array<array-key, mixed>        $result
      */
     private static function projectByDotPath(
-        mixed $source,
+        array|object $source,
         array $indexes,
         array &$result,
         array $prefix = [],
@@ -709,21 +734,37 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            if (! is_array($source)) {
-                return;
-            }
+            $iterable = is_object($source) ? self::toIterable($source) : $source;
 
-            foreach ($source as $key => $value) {
+            foreach ($iterable as $key => $value) {
+                if (! is_array($value) && ! is_object($value)) {
+                    if ($indexes === []) {
+                        self::setByDotPath($result, [...$prefix, (string) $key], $value);
+                    }
+
+                    continue;
+                }
+
                 self::projectByDotPath($value, $indexes, $result, [...$prefix, (string) $key]);
             }
 
             return;
         }
 
-        if (! is_array($source) || ! array_key_exists($currentIndex, $source)) {
+        if (! self::valueExists($source, $currentIndex)) {
             return;
         }
 
-        self::projectByDotPath($source[$currentIndex], $indexes, $result, [...$prefix, $currentIndex]);
+        $value = self::value($source, $currentIndex);
+
+        if (! is_array($value) && ! is_object($value)) {
+            if ($indexes === []) {
+                self::setByDotPath($result, [...$prefix, $currentIndex], $value);
+            }
+
+            return;
+        }
+
+        self::projectByDotPath($value, $indexes, $result, [...$prefix, $currentIndex]);
     }
 }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -34,9 +34,9 @@ if (! function_exists('dot_array_has')) {
     /**
      * Checks if an array key exists using dot syntax.
      *
-     * @param array<array-key, mixed> $array
+     * @param array<array-key, mixed>|object $array
      */
-    function dot_array_has(string $index, array $array): bool
+    function dot_array_has(string $index, array|object $array): bool
     {
         return ArrayHelper::dotHas($index, $array);
     }
@@ -70,12 +70,12 @@ if (! function_exists('dot_array_only')) {
     /**
      * Gets only the specified keys using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    function dot_array_only(array $array, array|string $indexes): array
+    function dot_array_only(array|object $array, array|string $indexes): array
     {
         return ArrayHelper::dotOnly($array, $indexes);
     }
@@ -85,12 +85,12 @@ if (! function_exists('dot_array_except')) {
     /**
      * Gets all keys except the specified ones using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    function dot_array_except(array $array, array|string $indexes): array
+    function dot_array_except(array|object $array, array|string $indexes): array
     {
         return ArrayHelper::dotExcept($array, $indexes);
     }

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -177,6 +177,50 @@ final class ArrayHelperTest extends CIUnitTestCase
         $this->assertSame($expected, dot_array_only($data, 'user.*'));
     }
 
+    public function testDotArrayOnlyWithObjectValues(): void
+    {
+        $data = (object) [
+            'user' => (object) [
+                'id'      => 123,
+                'profile' => (object) [
+                    'name' => 'john',
+                ],
+            ],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $expected = [
+            'user' => [
+                'profile' => [
+                    'name' => 'john',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, dot_array_only($data, 'user.profile.name'));
+    }
+
+    public function testDotArrayOnlyWildcardWithEntityRows(): void
+    {
+        $a      = new SomeEntity();
+        $a->foo = 1;
+        $a->bar = 2;
+
+        $b      = new SomeEntity();
+        $b->foo = 3;
+        $b->bar = 4;
+
+        $this->assertSame(
+            [
+                'rows' => [
+                    ['foo' => 1],
+                    ['foo' => 3],
+                ],
+            ],
+            dot_array_only(['rows' => [$a, $b]], 'rows.*.foo'),
+        );
+    }
+
     public function testDotArrayExcept(): void
     {
         $data = [
@@ -201,6 +245,44 @@ final class ArrayHelperTest extends CIUnitTestCase
     {
         $data = [
             'user' => [
+                'id'   => 123,
+                'name' => 'john',
+            ],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $expected = [
+            'user' => [],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $this->assertSame($expected, dot_array_except($data, 'user.*'));
+    }
+
+    public function testDotArrayExceptWithObjectValues(): void
+    {
+        $data = (object) [
+            'user' => (object) [
+                'id'   => 123,
+                'name' => 'john',
+            ],
+            'meta' => (object) ['request_id' => 'abc'],
+        ];
+
+        $expected = [
+            'user' => [
+                'name' => 'john',
+            ],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $this->assertSame($expected, dot_array_except($data, 'user.id'));
+    }
+
+    public function testDotArrayExceptWildcardWithObjectValues(): void
+    {
+        $data = (object) [
+            'user' => (object) [
                 'id'   => 123,
                 'name' => 'john',
             ],
@@ -456,6 +538,82 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame(['John', 'Maria'], dot_array_search('users.*.name', $data));
+    }
+
+    public function testDotArrayHasWithObjectValues(): void
+    {
+        $data = [
+            'user' => (object) [
+                'profile' => (object) [
+                    'name' => 'Jane',
+                ],
+            ],
+        ];
+
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+        $this->assertFalse(dot_array_has('user.profile.email', $data));
+    }
+
+    public function testDotArrayHasWithMagicObjectValues(): void
+    {
+        $data = [
+            'user' => new class () {
+                /**
+                 * @var array<string, array<string, string>>
+                 */
+                private array $values = [
+                    'profile' => [
+                        'name' => 'Jane',
+                    ],
+                ];
+
+                public function __isset(string $key): bool
+                {
+                    return array_key_exists($key, $this->values);
+                }
+
+                public function __get(string $key): mixed
+                {
+                    return $this->values[$key];
+                }
+            },
+        ];
+
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testDotArrayHasWithArrayAccessValues(): void
+    {
+        $data = [
+            'user' => new ArrayObject([
+                'profile' => [
+                    'name' => 'Jane',
+                ],
+            ]),
+        ];
+
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testDotArrayHasWithEntityValues(): void
+    {
+        $entity      = new SomeEntity();
+        $entity->foo = 'value';
+
+        $this->assertTrue(dot_array_has('user.foo', ['user' => $entity]));
+        $this->assertFalse(dot_array_has('user._options', ['user' => $entity]));
+    }
+
+    public function testDotArrayHasWildcardWithEntityValues(): void
+    {
+        $a      = new SomeEntity();
+        $a->foo = 1;
+
+        $b      = new SomeEntity();
+        $b->foo = 2;
+
+        $this->assertTrue(dot_array_has('rows.*.foo', ['rows' => [$a, $b]]));
+        $this->assertFalse(dot_array_has('rows.*._cast', ['rows' => [$a, $b]]));
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -267,8 +267,9 @@ Helpers and Functions
   :php:func:`dot_array_has()`, :php:func:`dot_array_set()`, :php:func:`dot_array_unset()`,
   :php:func:`dot_array_only()`, and :php:func:`dot_array_except()`.
 - :doc:`Array Helper </helpers/array_helper>` dot-path read operations now support
-  object rows (including ``Entity``) in :php:func:`dot_array_search()` and
-  :php:func:`array_group_by()`.
+  object rows (including ``Entity``) in :php:func:`dot_array_search()`,
+  :php:func:`dot_array_has()`, :php:func:`dot_array_only()`,
+  :php:func:`dot_array_except()`, and :php:func:`array_group_by()`.
 
 HTTP
 ====

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -58,10 +58,10 @@ The following functions are available:
 
 .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
-..  php:function:: dot_array_has(string $search, array $values): bool
+..  php:function:: dot_array_has(string $search, array|object $values): bool
 
     :param  string  $search: The dot-notation string describing how to search the array
-    :param  array   $values: The array to check
+    :param  array|object $values: The array or object to check
     :returns: ``true`` if the key exists, otherwise ``false``
     :rtype: bool
 
@@ -69,6 +69,8 @@ The following functions are available:
 
     Checks if an array key exists using dot syntax.
     This method supports wildcard ``*`` in the same way as ``dot_array_search()``.
+
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
     .. literalinclude:: array_helper/015.php
         :lines: 2-
@@ -105,9 +107,9 @@ The following functions are available:
     .. literalinclude:: array_helper/017.php
         :lines: 2-
 
-..  php:function:: dot_array_only(array $array, array|string $indexes): array
+..  php:function:: dot_array_only(array|object $array, array|string $indexes): array
 
-    :param  array            $array: The source array
+    :param  array|object     $array: The source array or object
     :param  array|string     $indexes: One key or a list of keys using dot notation
     :returns: Nested array containing only the requested keys
     :rtype: array
@@ -119,12 +121,14 @@ The following functions are available:
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
 
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
+
     .. literalinclude:: array_helper/018.php
         :lines: 2-
 
-..  php:function:: dot_array_except(array $array, array|string $indexes): array
+..  php:function:: dot_array_except(array|object $array, array|string $indexes): array
 
-    :param  array            $array: The source array
+    :param  array|object     $array: The source array or object
     :param  array|string     $indexes: One key or a list of keys using dot notation
     :returns: Nested array with the specified keys removed
     :rtype: array
@@ -135,6 +139,8 @@ The following functions are available:
 
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
+
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
     .. literalinclude:: array_helper/019.php
         :lines: 2-


### PR DESCRIPTION
**Description**
This is a follow-up to PR #10226, which added object support to `dot_array_search()` and `array_group_by()`.

This PR extends the same object-read support to the remaining read-style dot array helpers:

- `dot_array_has()`
- `dot_array_only()`
- `dot_array_except()`

The implementation reuses the existing object access patterns already introduced for PR #10226:

- `valueExists()`
- `value()`
- `entityToArray()`
- `toIterable()`

Objects are handled for bounded key/property lookups and wildcard traversal, including `Entity`, `ArrayObject`, public object properties, and magic `__isset()` / `__get()` access. `Entity` wildcard traversal continues to use `toArray()` so internal properties are not exposed.

`dot_array_set()` and `dot_array_unset()` remain array-only because they are mutating helpers.

Docs and the v4.8.0 changelog were updated to reflect the expanded object support.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide