### PR TITLE
chore: Bump structarmed to 0.11.0 and use new expanded +LayerName in the config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "boundwize/structarmed": "0.9.1",
+        "boundwize/structarmed": "0.11.0",
         "codeigniter/phpstan-codeigniter": "^1.5",
         "fakerphp/faker": "^1.24",
         "kint-php/kint": "^6.1",

--- a/structarmed.php
+++ b/structarmed.php
@@ -101,7 +101,7 @@ return Architecture::define()
         'Pager'         => ['URI', 'View'],
         'Publisher'     => ['Files', 'URI'],
         // +API = API + its allowed layers; +Controller = Controller + its allowed layers
-        'RESTful'       => ['API', 'Controller', 'Database', 'Format', 'HTTP', 'Model', 'Pager', 'URI', 'Validation'],
+        'RESTful'       => ['+API', '+Controller'],
         'Router'        => ['HTTP', 'I18n'],
         'Security'      => ['Cookie', 'HTTP', 'I18n', 'Session'],
         'Session'       => ['Cookie', 'Database', 'HTTP', 'I18n'],


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

Per discussion on https://github.com/codeigniter4/CodeIgniter4/pull/10198#discussion_r3243910103, StructArmed 0.11.0 brings support for the +LayerName shorthand in ruleset definition.

implemented on:

- https://github.com/boundwize/structarmed/pull/124

/cc @paulbalandan @michalsn

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
