### PR TITLE
feat: add per-type API transformer sparse fieldsets

### DIFF
--- a/system/API/BaseTransformer.php
+++ b/system/API/BaseTransformer.php
@@ -25,6 +25,11 @@ use InvalidArgumentException;
  * - fields: Comma-separated list of fields to include in the response
  *      (e.g., ?fields=id,name,email)
  *      If not provided, all fields from toArray() are included.
+ *      Since v4.8.0, per-type sparse fieldsets are also supported via the
+ *      bracketed form (e.g., ?fields[posts]=id,slug). A transformer reads the
+ *      fieldset that matches its declared $resourceType, so a nested
+ *      PostTransformer with $resourceType = 'posts' applies ?fields[posts]=...
+ *      while the root resource is unaffected.
  * - include: Comma-separated list of related resources to include
  *      (e.g., ?include=posts,comments)
  *      This looks for methods named `include{Resource}()` on the transformer,
@@ -69,6 +74,11 @@ abstract class BaseTransformer implements TransformerInterface
      */
     private ?array $includes = null;
 
+    /**
+     * Resource type used to resolve per-type sparse fieldsets.
+     */
+    protected ?string $resourceType = null;
+
     protected mixed $resource = null;
 
     public function __construct(
@@ -82,16 +92,65 @@ abstract class BaseTransformer implements TransformerInterface
         $this->request = $request ?? request();
 
         if ($explicitRequest || self::$depth === 0) {
-            $fields       = $this->request->getGet('fields');
-            $this->fields = is_string($fields)
-                ? array_map(trim(...), explode(',', $fields))
-                : $fields;
-
-            $includes       = $this->request->getGet('include');
-            $this->includes = is_string($includes)
-                ? array_map(trim(...), explode(',', $includes))
-                : $includes;
+            $this->fields   = $this->resolveFields(true);
+            $this->includes = $this->resolveIncludes();
+        } elseif ($this->resourceType !== null) {
+            $this->fields = $this->resolveFields(false);
         }
+    }
+
+    /**
+     * Resolves the requested field list for this transformer from the request.
+     *
+     * Supports both the flat `?fields=a,b` form and the per-type sparse
+     * fieldset form `?fields[<type>]=a,b`. The flat form is only honored when
+     * $allowFlat is true (i.e. for the root transformer); a type-specific
+     * fieldset is matched against this transformer's $resourceType at any
+     * nesting level.
+     *
+     * @return list<string>|null
+     */
+    private function resolveFields(bool $allowFlat): ?array
+    {
+        $fields = $this->request->getGet('fields');
+
+        // Sparse fieldsets: ?fields[posts]=id,slug -> ['posts' => 'id,slug']
+        if (is_array($fields)) {
+            $scoped = ($this->resourceType !== null && is_string($fields[$this->resourceType] ?? null))
+                ? $fields[$this->resourceType]
+                : null;
+
+            return $scoped !== null ? $this->splitList($scoped) : null;
+        }
+
+        // Flat fieldset: ?fields=id,slug (applies to the root only)
+        if ($allowFlat && is_string($fields)) {
+            return $this->splitList($fields);
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the requested include list from the request's `include` param.
+     *
+     * @return list<string>|null
+     */
+    private function resolveIncludes(): ?array
+    {
+        $includes = $this->request->getGet('include');
+
+        return is_string($includes) ? $this->splitList($includes) : $includes;
+    }
+
+    /**
+     * Splits a comma-separated query value into a list of trimmed strings.
+     *
+     * @return list<string>
+     */
+    private function splitList(string $value): array
+    {
+        return array_map(trim(...), explode(',', $value));
     }
 
     /**

--- a/tests/_support/API/ChildTransformer.php
+++ b/tests/_support/API/ChildTransformer.php
@@ -21,6 +21,8 @@ use CodeIgniter\API\BaseTransformer;
  */
 class ChildTransformer extends BaseTransformer
 {
+    protected ?string $resourceType = 'child';
+
     public function toArray(mixed $resource): array
     {
         return [

--- a/tests/_support/API/ParentTransformer.php
+++ b/tests/_support/API/ParentTransformer.php
@@ -21,6 +21,8 @@ use CodeIgniter\API\BaseTransformer;
  */
 class ParentTransformer extends BaseTransformer
 {
+    protected ?string $resourceType = 'parent';
+
     public function toArray(mixed $resource): array
     {
         return [

--- a/tests/system/API/TransformerTest.php
+++ b/tests/system/API/TransformerTest.php
@@ -801,4 +801,125 @@ final class TransformerTest extends CIUnitTestCase
 
         $this->assertSame(['child_id' => 42], $result);
     }
+
+    public function testSparseFieldsetScopesNestedChildByType(): void
+    {
+        // ?fields[child]=child_id must scope the nested ChildTransformer
+        // ($resourceType = 'child') automatically, without any explicit request.
+        $request = $this->createMockRequest('include=children&fields[child]=child_id');
+        Services::injectMock('request', $request);
+
+        $transformer = new ParentTransformer($request);
+
+        $result = $transformer->transform(['id' => 1]);
+
+        $this->assertSame([
+            'parent_id' => 1,
+            'children'  => ['child_id' => 99], // 'status' dropped by fields[child]
+        ], $result);
+    }
+
+    public function testSparseFieldsetForOneTypeLeavesOthersUntouched(): void
+    {
+        // ?fields[parent]=parent_id scopes only the root; the child is full.
+        $request = $this->createMockRequest('include=children&fields[parent]=parent_id');
+        Services::injectMock('request', $request);
+
+        $transformer = new ParentTransformer($request);
+
+        $result = $transformer->transform(['id' => 1]);
+
+        $this->assertSame([
+            'parent_id' => 1,
+            'children'  => ['child_id' => 99, 'status' => 'transformed'],
+        ], $result);
+    }
+
+    public function testSparseFieldsetsScopeRootAndChildIndependently(): void
+    {
+        // The headline case: each type gets its own fieldset in one request.
+        $request = $this->createMockRequest('include=children&fields[parent]=parent_id&fields[child]=child_id');
+        Services::injectMock('request', $request);
+
+        $transformer = new ParentTransformer($request);
+
+        $result = $transformer->transform(['id' => 1]);
+
+        $this->assertSame([
+            'parent_id' => 1,
+            'children'  => ['child_id' => 99],
+        ], $result);
+    }
+
+    public function testFlatFieldsDoesNotScopeTypedNestedChild(): void
+    {
+        // A flat ?fields= belongs to the root only and must not leak into a
+        // typed nested child.
+        $request = $this->createMockRequest('include=children&fields=parent_id');
+        Services::injectMock('request', $request);
+
+        $transformer = new ParentTransformer($request);
+
+        $result = $transformer->transform(['id' => 1]);
+
+        $this->assertSame([
+            'parent_id' => 1,
+            'children'  => ['child_id' => 99, 'status' => 'transformed'],
+        ], $result);
+    }
+
+    public function testUnknownSparseFieldsetIsIgnored(): void
+    {
+        // A fieldset for a type not present in the response is simply ignored;
+        // every transformer returns all of its fields.
+        $request = $this->createMockRequest('include=children&fields[unknown]=id');
+        Services::injectMock('request', $request);
+
+        $transformer = new ParentTransformer($request);
+
+        $result = $transformer->transform(['id' => 1]);
+
+        $this->assertSame([
+            'parent_id' => 1,
+            'children'  => ['child_id' => 99, 'status' => 'transformed'],
+        ], $result);
+    }
+
+    public function testSparseFieldsetAppliesToRootWhenTypeMatches(): void
+    {
+        // ?fields[child]=child_id on a root ChildTransformer ($resourceType = 'child').
+        $request = $this->createMockRequest('fields[child]=child_id');
+        Services::injectMock('request', $request);
+
+        $transformer = new ChildTransformer($request);
+
+        $result = $transformer->transform(['id' => 42]);
+
+        $this->assertSame(['child_id' => 42], $result);
+    }
+
+    public function testSparseFieldsetRespectsAllowedFieldsWhitelist(): void
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage(lang('Api.invalidFields', ['secret']));
+
+        $request = $this->createMockRequest('fields[widget]=id,secret');
+        Services::injectMock('request', $request);
+
+        $transformer = new class ($request) extends BaseTransformer {
+            protected ?string $resourceType = 'widget';
+
+            public function toArray(mixed $resource): array
+            {
+                return $resource;
+            }
+
+            protected function getAllowedFields(): array
+            {
+                return ['id', 'name'];
+            }
+        };
+
+        $transformer->transform(['id' => 1, 'name' => 'Test', 'secret' => 'x']);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -179,6 +179,14 @@ Removed Deprecated Items
 Enhancements
 ************
 
+API
+===
+
+- Added per-type sparse fieldsets to API transformers. A transformer may declare a ``$type`` so clients
+  can request ``?fields[<type>]=...`` to filter the fields of that resource type independently, including
+  for nested/related resources, while the flat ``?fields=...`` continues to apply to the root resource only.
+  See :ref:`api_transformers`.
+
 Commands
 ========
 

--- a/user_guide_src/source/outgoing/api_transformers.rst
+++ b/user_guide_src/source/outgoing/api_transformers.rst
@@ -129,6 +129,47 @@ fields are allowed by overriding the ``getAllowedFields()`` method:
 Now, even if a client requests ``/users/1?fields=email``, an ``ApiException`` will be thrown because
 ``email`` is not in the allowed fields list.
 
+Sparse Fieldsets (Per-Type Filtering)
+=====================================
+
+.. versionadded:: 4.8.0
+
+The flat ``fields`` parameter filters the root resource. When a response also embeds
+:ref:`related resources <api_transformers_includes>`, you can filter each related type
+independently using the bracketed *sparse fieldset* form ``fields[<type>]=...``.
+
+To opt a transformer into this, declare its resource type via the ``$resourceType`` property:
+
+.. literalinclude:: api_transformers/024.php
+
+A matching ``fields[<type>]`` fieldset applies whether the transformer is used as the root resource or
+as an included resource. The flat ``fields=...`` form still applies to the root transformer only.
+
+Each transformer reads the fieldset that matches its own ``$resourceType``. Given the ``UserTransformer``
+from :ref:`Including Related Resources <api_transformers_includes>` (which includes posts), a request:
+
+.. code-block:: text
+
+    /users/1?include=posts&fields[posts]=id,slug
+
+scopes the fields **only** for the embedded posts, leaving the user fields untouched:
+
+.. code-block:: json
+
+    {
+        "id": 1,
+        "name": "John Doe",
+        "email": "john@example.com",
+        "posts": [
+            {
+                "id": 1,
+                "slug": "first-post"
+            }
+        ]
+    }
+
+.. _api_transformers_includes:
+
 ***************************
 Including Related Resources
 ***************************
@@ -174,10 +215,11 @@ The response would include:
         ]
     }
 
-.. note:: The ``fields`` and ``include`` query parameters describe the **root** resource only.
+.. note:: The flat ``fields=...`` and ``include`` query parameters describe the **root** resource only.
     Transformers instantiated inside an ``include*()`` method (such as ``PostTransformer`` above)
     are treated as nested resources: when created **without an explicit request** they do **not**
-    inherit the root request's ``fields``/``include`` state. This prevents the parent's query
+    inherit the root request's flat ``fields``/``include`` state. Use ``fields[<type>]=...`` with
+    a matching ``$resourceType`` to filter a nested resource. This prevents the parent's query
     parameters from leaking into related resources, which could otherwise cause incorrect field
     filtering or unexpected/recursive includes. If you deliberately pass a request to a nested
     transformer, that request's scope is honored.
@@ -263,6 +305,17 @@ Class Reference
 .. php:namespace:: CodeIgniter\API
 
 .. php:class:: BaseTransformer
+
+    .. php:attr:: $resourceType
+
+        :type: string|null
+
+        .. versionadded:: 4.8.0
+
+        The resource type this transformer represents. Used to resolve per-type sparse fieldsets from
+        the request (e.g. a type of ``'posts'`` reads ``?fields[posts]=...``). Defaults to ``null``,
+        in which case only the flat ``?fields=...`` parameter applies, and only to the root transformer.
+        See `Sparse Fieldsets (Per-Type Filtering)`_.
 
     .. php:method:: __construct(?IncomingRequest $request = null)
 

--- a/user_guide_src/source/outgoing/api_transformers.rst
+++ b/user_guide_src/source/outgoing/api_transformers.rst
@@ -168,6 +168,9 @@ scopes the fields **only** for the embedded posts, leaving the user fields untou
         ]
     }
 
+When filtering multiple resource types in one request, use the bracketed form for each type, such as
+``fields[users]=id,name&fields[posts]=id,slug``.
+
 .. _api_transformers_includes:
 
 ***************************

--- a/user_guide_src/source/outgoing/api_transformers/024.php
+++ b/user_guide_src/source/outgoing/api_transformers/024.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Transformers;
+
+use CodeIgniter\API\BaseTransformer;
+
+class PostTransformer extends BaseTransformer
+{
+    // Enables ?fields[posts]=... for this resource type.
+    protected ?string $resourceType = 'posts';
+
+    public function toArray(mixed $resource): array
+    {
+        return [
+            'id'      => $resource['id'],
+            'title'   => $resource['title'],
+            'slug'    => $resource['slug'],
+            'body'    => $resource['body'],
+            'user_id' => $resource['user_id'],
+        ];
+    }
+}


### PR DESCRIPTION
**Description**
This PR adds per-type sparse fieldsets for API transformers via `fields[<type>]`.

Transformers can opt in by defining `$resourceType`, allowing nested resources to apply their own field filters without inheriting the root `fields` parameter.

Ref: https://github.com/codeigniter4/CodeIgniter4/pull/10278#issuecomment-4631649474

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
