### PR TITLE
refactor: display default values for options in `spark help`

### DIFF
--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -17,6 +17,7 @@ use CodeIgniter\CLI\AbstractCommand;
 use CodeIgniter\CLI\Attributes\Command;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\Input\Argument;
+use CodeIgniter\CLI\Input\Option;
 
 /**
  * Displays the basic usage information for a given command.
@@ -76,11 +77,9 @@ class Help extends AbstractCommand
             CLI::write(lang('CLI.helpArguments'), 'yellow');
 
             foreach ($command->getArgumentsDefinition() as $argument => $definition) {
-                $default = '';
-
-                if (! $definition->required) {
-                    $default = sprintf(' [default: %s]', $this->formatDefaultValue($definition->default));
-                }
+                $default = ! $definition->required && $this->shouldShowDefault($definition->default)
+                    ? sprintf(' [default: %s]', $this->formatDefaultValue($definition->default))
+                    : '';
 
                 CLI::write(sprintf(
                     '%s%s%s',
@@ -118,10 +117,15 @@ class Help extends AbstractCommand
                     $definition->negation !== null ? sprintf('|--%s', $definition->negation) : '',
                 );
 
+                $default = $this->shouldShowOptionDefault($definition)
+                    ? sprintf(' [default: %s]', $this->formatDefaultValue($definition->default))
+                    : '';
+
                 CLI::write(sprintf(
-                    '%s%s%s',
+                    '%s%s%s%s',
                     CLI::color($this->addPadding($optionString, 2, $maxPadding), 'green'),
                     $definition->description,
+                    CLI::color($default, 'yellow'),
                     $definition->isArray ? CLI::color(' (multiple values allowed)', 'yellow') : '',
                 ));
             }
@@ -153,6 +157,31 @@ class Help extends AbstractCommand
         }
 
         return $max + 4; // Account for the extra padding around the option/argument.
+    }
+
+    /**
+     * Decides whether an option's default value is worth displaying.
+     */
+    private function shouldShowOptionDefault(Option $definition): bool
+    {
+        // Only value-accepting options carry a meaningful default. Plain flags
+        // and negatable toggles are boolean by nature.
+        if (! $definition->acceptsValue) {
+            return false;
+        }
+
+        return $this->shouldShowDefault($definition->default);
+    }
+
+    /**
+     * Whether a default value is concrete enough to display. `null` and the
+     * empty string are treated as "no default".
+     *
+     * @param list<string>|string|null $value
+     */
+    private function shouldShowDefault(array|string|null $value): bool
+    {
+        return $value !== null && $value !== '';
     }
 
     /**

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -87,9 +87,9 @@ final class HelpCommandTest extends CIUnitTestCase
                   array                 Unused array argument. [default: ["a", "b"]]
 
                 Options:
-                  -f, --foo=FOO         Option that requires a value.
+                  -f, --foo=FOO         Option that requires a value. [default: "qux"]
                   -a, --bar[=BAR]       Option that optionally accepts a value.
-                  -b, --baz=BAZ         Option that allows multiple values. (multiple values allowed)
+                  -b, --baz=BAZ         Option that allows multiple values. [default: ["a"]] (multiple values allowed)
                       --quux|--no-quux  Negatable option.
                   -h, --help            Display help for the given command.
                       --no-header       Do not display the banner when running the command.
@@ -117,6 +117,32 @@ final class HelpCommandTest extends CIUnitTestCase
                   driver                The cache driver to use. [default: "file"]
 
                 Options:
+                  -h, --help            Display help for the given command.
+                      --no-header       Do not display the banner when running the command.
+                  -N, --no-interaction  Do not ask any interactive questions.
+
+                EOT,
+            $this->getUndecoratedBuffer(),
+        );
+    }
+
+    public function testEmptyStringOptionDefaultIsNotDisplayed(): void
+    {
+        // `migrate:status` declares `--group` with an empty-string default,
+        // which must be suppressed the same way a null default is.
+        command('help migrate:status');
+
+        $this->assertSame(
+            <<<'EOT'
+
+                Usage:
+                  migrate:status [options]
+
+                Description:
+                  Displays a list of all migrations and whether they've been run or not.
+
+                Options:
+                  -g, --group=GROUP     Set database group.
                   -h, --help            Display help for the given command.
                       --no-header       Do not display the banner when running the command.
                   -N, --no-interaction  Do not ask any interactive questions.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -190,6 +190,8 @@ Commands
   ``isInteractive()`` / ``setInteractive()`` methods on ``AbstractCommand``. ``isInteractive()`` also auto-detects piped or
   CI environments by probing STDIN for a TTY, and the state cascades to sub-commands invoked via ``$this->call(...)``.
   See :ref:`non-interactive-mode`.
+- ``spark help <command>`` now shows the default value of each option that accepts a value (e.g., ``[default: "file"]``),
+  the same way argument defaults are already displayed. Boolean flags and negatable toggles, which have no meaningful default to show, are unaffected.
 - You can now retrieve the last executed command in the console using the new ``Console::getCommand()`` method. This is useful for logging, debugging, or any situation where you need to know which command was run.
 - ``CLI`` now supports the ``--`` separator to mean that what follows are arguments, not options. This allows you to have arguments that start with ``-`` without them being treated as options.
   For example: ``spark my:command -- --myarg`` will pass ``--myarg`` as an argument instead of an option.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
The modern `spark help` prints the default value for an argument if its value is optional. For parity, this PR adds the same default value printing for **value-accepting** options. Flag options and negatable options still do not show the defaults because their sentinel values are meaningless in help output.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
