### PR TITLE
fix: protect internal session variables against user overwrite

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -303,6 +303,10 @@ class Session implements SessionInterface
         }
 
         foreach ($data as $sessionKey => $sessionValue) {
+            if (is_string($sessionKey) && str_starts_with($sessionKey, '__ci_')) {
+                continue;
+            }
+
             $_SESSION[$sessionKey] = $sessionValue;
         }
     }
@@ -370,6 +374,10 @@ class Session implements SessionInterface
      */
     public function __set(string $key, $value)
     {
+        if (str_starts_with($key, '__ci_')) {
+            return;
+        }
+
         $_SESSION[$key] = $value;
     }
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -304,6 +304,9 @@ class Session implements SessionInterface
 
         foreach ($data as $sessionKey => $sessionValue) {
             if (is_string($sessionKey) && str_starts_with($sessionKey, '__ci_')) {
+                log_message('warning', 'Session key "{key}" is reserved for framework use and was not set.', [
+                    'key' => $key,
+                ]);
                 continue;
             }
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -305,8 +305,9 @@ class Session implements SessionInterface
         foreach ($data as $sessionKey => $sessionValue) {
             if (is_string($sessionKey) && str_starts_with($sessionKey, '__ci_')) {
                 log_message('warning', 'Session key "{key}" is reserved for framework use and was not set.', [
-                    'key' => $key,
+                    'key' => $sessionKey,
                 ]);
+
                 continue;
             }
 

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -345,7 +345,7 @@ final class SessionTest extends CIUnitTestCase
         $session = $this->getInstance();
         $session->start();
 
-        $session->__ci_vars = 'malicious'; // @phpstan-ignore property.notFound
+        $session->__ci_vars            = 'malicious'; // @phpstan-ignore property.notFound
         $session->__ci_last_regenerate = 'malicious'; // @phpstan-ignore property.notFound
 
         $this->assertArrayNotHasKey('__ci_vars', $_SESSION);

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -328,6 +328,30 @@ final class SessionTest extends CIUnitTestCase
         $this->assertSame('bar', $_SESSION['foo']);
     }
 
+    public function testSetIgnoresCiVars(): void
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->set('__ci_vars', 'malicious');
+        $session->set('__ci_last_regenerate', 'malicious');
+
+        $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
+        $this->assertNotSame('malicious', $_SESSION['__ci_last_regenerate']);
+    }
+
+    public function testSetMagicMethodIgnoresCiVars(): void
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->__ci_vars = 'malicious'; // @phpstan-ignore property.notFound
+        $session->__ci_last_regenerate = 'malicious'; // @phpstan-ignore property.notFound
+
+        $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
+        $this->assertNotSame('malicious', $_SESSION['__ci_last_regenerate']);
+    }
+
     public function testCanFlashData(): void
     {
         $session = $this->getInstance();


### PR DESCRIPTION
**Description**
Currently, the `Session` class lacks protection against overwriting internal framework session keys. If a developer sets session values directly from user input (e.g., using `$session->set($this->request->getPost())`), a malicious user can inject the `__ci_vars` or `__ci_last_regenerate` parameters. 

Depending on the injected payload, this can lead to:
- **Denial of Service (DoS):** If `__ci_vars` is set to a string, the next session initialization will throw a `TypeError` when `initVars()` attempts to iterate over it with `foreach`. This effectively breaks the session and locks the user out until the session expires or cookies are cleared.
- **Session Tampering:** If `__ci_vars` is crafted as an array, it can trick the garbage collection in `initVars()` into `unset()`-ting arbitrary session keys within the user's session.

This PR adds a straightforward validation rule inside the `set()` and `__set()` methods to silently ignore setting any keys that start with the framework's internal prefix `__ci_`. 

*Note: The built-in methods for handling flashdata and tempdata (like `markAsFlashdata`) modify `$_SESSION['__ci_vars']` directly as superglobals and are completely unaffected by this change. It ensures full backwards compatibility.*

**Checklist:**
- [x] Secure coding practices
- [x] Tests have been added to cover this change
- [x] All tests pass
