### PR TITLE
fix: use dynamic lockMaxRetries limit in RedisHandler

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -98,8 +98,8 @@ class RedisHandler extends BaseHandler
             $this->keyPrefix .= $this->ipAddress . ':';
         }
 
-        $this->lockRetryInterval = $config->lockRetryInterval ?? $this->lockRetryInterval;
-        $this->lockMaxRetries    = $config->lockMaxRetries ?? $this->lockMaxRetries;
+        $this->lockRetryInterval = $config->lockRetryInterval ?? $this->lockRetryInterval; // @phpstan-ignore nullCoalesce.property
+        $this->lockMaxRetries    = $config->lockMaxRetries ?? $this->lockMaxRetries; // @phpstan-ignore nullCoalesce.property
     }
 
     protected function setSavePath(): void

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -386,10 +386,10 @@ class RedisHandler extends BaseHandler
             break;
         } while (++$attempt < $this->lockMaxRetries);
 
-        if ($attempt === 300) {
+        if ($attempt === $this->lockMaxRetries) {
             $this->logger->error(
                 'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID
-                . ' after 300 attempts, aborting.',
+                . ' after ' . $this->lockMaxRetries . ' attempts, aborting.',
             );
 
             return false;

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -98,8 +98,8 @@ class RedisHandler extends BaseHandler
             $this->keyPrefix .= $this->ipAddress . ':';
         }
 
-        $this->lockRetryInterval = $config->lockWait ?? $this->lockRetryInterval;
-        $this->lockMaxRetries    = $config->lockAttempts ?? $this->lockMaxRetries;
+        $this->lockRetryInterval = $config->lockRetryInterval;
+        $this->lockMaxRetries    = $config->lockMaxRetries;
     }
 
     protected function setSavePath(): void

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -98,8 +98,8 @@ class RedisHandler extends BaseHandler
             $this->keyPrefix .= $this->ipAddress . ':';
         }
 
-        $this->lockRetryInterval = $config->lockRetryInterval;
-        $this->lockMaxRetries    = $config->lockMaxRetries;
+        $this->lockRetryInterval = $config->lockRetryInterval ?? $this->lockRetryInterval;
+        $this->lockMaxRetries    = $config->lockMaxRetries ?? $this->lockMaxRetries;
     }
 
     protected function setSavePath(): void

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -374,7 +374,7 @@ final class RedisHandlerTest extends CIUnitTestCase
         $handler2 = $this->getInstance($options);
         $handler2->open($this->sessionSavePath, $this->sessionName);
 
-        // Before the fix, this would incorrectly return true or empty string (since it falls through).
+        // Before the fix, this would incorrectly return true (since $attempt === 3 !== 300).
         // With the fix, it should return false after 3 attempts.
         $this->assertFalse($handler2->read('lock_test_session'));
 

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -363,8 +363,8 @@ final class RedisHandlerTest extends CIUnitTestCase
     public function testLockMaxRetries(): void
     {
         $options = [
-            'lockWait'     => 10_000, // 10ms
-            'lockAttempts' => 3,
+            'lockRetryInterval' => 10_000, // 10ms
+            'lockMaxRetries'    => 3,
         ];
 
         $handler1 = $this->getInstance($options);

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -15,6 +15,8 @@ namespace CodeIgniter\Session\Handlers\Database;
 
 use CodeIgniter\Session\Handlers\RedisHandler;
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\TestLogger;
+use Config\Logger as LoggerConfig;
 use Config\Session as SessionConfig;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -54,7 +56,10 @@ final class RedisHandlerTest extends CIUnitTestCase
             $sessionConfig->{$key} = $value;
         }
 
-        return new RedisHandler($sessionConfig, $this->userIpAddress);
+        $handler = new RedisHandler($sessionConfig, $this->userIpAddress);
+        $handler->setLogger(new TestLogger(new LoggerConfig()));
+
+        return $handler;
     }
 
     protected function tearDown(): void

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -359,4 +359,26 @@ final class RedisHandlerTest extends CIUnitTestCase
         $handler1->close();
         $handler2->close();
     }
+
+    public function testLockMaxRetries(): void
+    {
+        $options = [
+            'lockWait'     => 10_000, // 10ms
+            'lockAttempts' => 3,
+        ];
+
+        $handler1 = $this->getInstance($options);
+        $handler1->open($this->sessionSavePath, $this->sessionName);
+        $handler1->read('lock_test_session'); // Acquires lock
+
+        $handler2 = $this->getInstance($options);
+        $handler2->open($this->sessionSavePath, $this->sessionName);
+
+        // Before the fix, this would incorrectly return true or empty string (since it falls through).
+        // With the fix, it should return false after 3 attempts.
+        $this->assertFalse($handler2->read('lock_test_session'));
+
+        $handler1->close();
+        $handler2->close();
+    }
 }

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -33,8 +33,8 @@ Bugs Fixed
 - **API:** Fixed a bug in Transformers where the root request's ``fields`` and ``include`` query parameters leaked into nested transformers created inside ``include*()`` methods, causing incorrect field filtering, unexpected includes, or infinite recursion.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
-- **Session:** Fixed a bug in ``RedisHandler`` where the configured ``$lockRetryInterval`` and ``$lockMaxRetries`` values were not respected when acquiring session locks.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
+- **Session:** Fixed a bug in ``RedisHandler`` where the configured ``$lockMaxRetries`` and ``$lockRetryInterval`` values were not respected when acquiring session locks.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -33,6 +33,7 @@ Bugs Fixed
 - **API:** Fixed a bug in Transformers where the root request's ``fields`` and ``include`` query parameters leaked into nested transformers created inside ``include*()`` methods, causing incorrect field filtering, unexpected includes, or infinite recursion.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
+- **Session:** Fixed a bug in ``RedisHandler`` where missing ``$lockRetryInterval`` and ``$lockMaxRetries`` properties in a custom ``Session`` configuration file could trigger an ``Undefined property`` warning or error.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -33,7 +33,7 @@ Bugs Fixed
 - **API:** Fixed a bug in Transformers where the root request's ``fields`` and ``include`` query parameters leaked into nested transformers created inside ``include*()`` methods, causing incorrect field filtering, unexpected includes, or infinite recursion.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
-- **Session:** Fixed a bug in ``RedisHandler`` where missing ``$lockRetryInterval`` and ``$lockMaxRetries`` properties in a custom ``Session`` configuration file could trigger an ``Undefined property`` warning or error.
+- **Session:** Fixed a bug in ``RedisHandler`` where the configured ``$lockRetryInterval`` and ``$lockMaxRetries`` values were not respected when acquiring session locks.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
 
 See the repo's

--- a/utils/phpstan-baseline/property.notFound.neon
+++ b/utils/phpstan-baseline/property.notFound.neon
@@ -1,4 +1,4 @@
-# total 49 errors
+# total 47 errors
 
 parameters:
     ignoreErrors:
@@ -16,16 +16,6 @@ parameters:
             message: '#^Access to an undefined property CodeIgniter\\Database\\BaseConnection\:\:\$schema\.$#'
             count: 14
             path: ../../system/Database/SQLSRV/Forge.php
-
-        -
-            message: '#^Access to an undefined property Config\\Session\:\:\$lockAttempts\.$#'
-            count: 1
-            path: ../../system/Session/Handlers/RedisHandler.php
-
-        -
-            message: '#^Access to an undefined property Config\\Session\:\:\$lockWait\.$#'
-            count: 1
-            path: ../../system/Session/Handlers/RedisHandler.php
 
         -
             message: '#^Access to an undefined property CodeIgniter\\Database\\BaseConnection\:\:\$mysqli\.$#'


### PR DESCRIPTION
## Description

In `RedisHandler::lockSession()`, there was a bug where a hardcoded value of `300` was used to check if the maximum lock acquisition attempts were reached:

```php
if ($attempt === 300) {

```

This bypassed the actual `$this->lockMaxRetries` property configured by the user. As a result, if a developer configured a smaller `lockAttempts` limit (e.g., `3`), the check would fail to trigger because `3 !== 300`, causing the method to incorrectly return `true` (success) despite not acquiring the lock. Conversely, it would hardcode the failure point to exactly `300` attempts regardless of higher configurations.

This PR replaces the hardcoded `300` with `$this->lockMaxRetries` in the condition and the associated error log message, ensuring the configured limits are appropriately enforced. A test has also been added to verify that the failure condition is triggered correctly after the maximum configured attempts.

## Checklist:

* [x] Secure coding practices
* [x] Tests have been added to cover this change
* [x] All tests pass

