### PR TITLE
feat: support objects in remaining dot array helpers

### DIFF
--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -146,9 +146,9 @@ final class ArrayHelper
      *
      * If wildcard `*` is used, all items for the key after it must have the key.
      *
-     * @param array<array-key, mixed> $array
+     * @param array<array-key, mixed>|object $array
      */
-    public static function dotHas(string $index, array $array): bool
+    public static function dotHas(string $index, array|object $array): bool
     {
         self::ensureValidWildcardPattern($index);
 
@@ -164,10 +164,10 @@ final class ArrayHelper
     /**
      * Recursively check key existence by dot path, including wildcard support.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>            $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>                   $indexes
      */
-    private static function hasByDotPath(array $array, array $indexes): bool
+    private static function hasByDotPath(array|object $array, array $indexes): bool
     {
         if ($indexes === []) {
             return true;
@@ -176,8 +176,10 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            foreach ($array as $item) {
-                if (! is_array($item) || ! self::hasByDotPath($item, $indexes)) {
+            $iterable = is_object($array) ? self::toIterable($array) : $array;
+
+            foreach ($iterable as $item) {
+                if ((! is_array($item) && ! is_object($item)) || ! self::hasByDotPath($item, $indexes)) {
                     return false;
                 }
             }
@@ -185,7 +187,7 @@ final class ArrayHelper
             return true;
         }
 
-        if (! array_key_exists($currentIndex, $array)) {
+        if (! self::valueExists($array, $currentIndex)) {
             return false;
         }
 
@@ -193,11 +195,13 @@ final class ArrayHelper
             return true;
         }
 
-        if (! is_array($array[$currentIndex])) {
+        $value = self::value($array, $currentIndex);
+
+        if (! is_array($value) && ! is_object($value)) {
             return false;
         }
 
-        return self::hasByDotPath($array[$currentIndex], $indexes);
+        return self::hasByDotPath($value, $indexes);
     }
 
     /**
@@ -247,12 +251,12 @@ final class ArrayHelper
     /**
      * Gets only the specified keys using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    public static function dotOnly(array $array, array|string $indexes): array
+    public static function dotOnly(array|object $array, array|string $indexes): array
     {
         $indexes = is_string($indexes) ? [$indexes] : $indexes;
         $result  = [];
@@ -261,7 +265,7 @@ final class ArrayHelper
             self::ensureValidWildcardPattern($index, true);
 
             if ($index === '*') {
-                $result = [...$result, ...$array];
+                $result = [...$result, ...(is_object($array) ? self::toIterable($array) : $array)];
 
                 continue;
             }
@@ -280,15 +284,15 @@ final class ArrayHelper
     /**
      * Gets all keys except the specified ones using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    public static function dotExcept(array $array, array|string $indexes): array
+    public static function dotExcept(array|object $array, array|string $indexes): array
     {
         $indexes = is_string($indexes) ? [$indexes] : $indexes;
-        $result  = $array;
+        $result  = self::toArrayView($array);
 
         foreach ($indexes as $index) {
             self::ensureValidWildcardPattern($index, true);
@@ -466,20 +470,20 @@ final class ArrayHelper
     private static function valueExists(array|object $data, string $key): bool
     {
         if (is_array($data)) {
-            return isset($data[$key]);
+            return array_key_exists($key, $data);
         }
 
         $array = self::entityToArray($data);
 
         if ($array !== null) {
-            return isset($array[$key]);
+            return array_key_exists($key, $array);
         }
 
         if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
             return true;
         }
 
-        if (isset(get_object_vars($data)[$key])) {
+        if (array_key_exists($key, get_object_vars($data))) {
             return true;
         }
 
@@ -548,6 +552,26 @@ final class ArrayHelper
         }
 
         return get_object_vars($data);
+    }
+
+    /**
+     * Normalize arrays or objects to an array view safe for dotExcept().
+     *
+     * @param array<array-key, mixed>|object $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function toArrayView(array|object $data): array
+    {
+        $array = is_object($data) ? self::toIterable($data) : $data;
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) || is_object($value)) {
+                $array[$key] = self::toArrayView($value);
+            }
+        }
+
+        return $array;
     }
 
     /**
@@ -688,14 +712,15 @@ final class ArrayHelper
     }
 
     /**
-     * Projects matching paths from source array into result with preserved structure.
+     * Projects matching paths from source into result with preserved structure.
      *
-     * @param list<string>            $indexes
-     * @param list<string>            $prefix
-     * @param array<array-key, mixed> $result
+     * @param array<array-key, mixed>|object $source
+     * @param list<string>                   $indexes
+     * @param list<string>                   $prefix
+     * @param array<array-key, mixed>        $result
      */
     private static function projectByDotPath(
-        mixed $source,
+        array|object $source,
         array $indexes,
         array &$result,
         array $prefix = [],
@@ -709,21 +734,37 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            if (! is_array($source)) {
-                return;
-            }
+            $iterable = is_object($source) ? self::toIterable($source) : $source;
 
-            foreach ($source as $key => $value) {
+            foreach ($iterable as $key => $value) {
+                if (! is_array($value) && ! is_object($value)) {
+                    if ($indexes === []) {
+                        self::setByDotPath($result, [...$prefix, (string) $key], $value);
+                    }
+
+                    continue;
+                }
+
                 self::projectByDotPath($value, $indexes, $result, [...$prefix, (string) $key]);
             }
 
             return;
         }
 
-        if (! is_array($source) || ! array_key_exists($currentIndex, $source)) {
+        if (! self::valueExists($source, $currentIndex)) {
             return;
         }
 
-        self::projectByDotPath($source[$currentIndex], $indexes, $result, [...$prefix, $currentIndex]);
+        $value = self::value($source, $currentIndex);
+
+        if (! is_array($value) && ! is_object($value)) {
+            if ($indexes === []) {
+                self::setByDotPath($result, [...$prefix, $currentIndex], $value);
+            }
+
+            return;
+        }
+
+        self::projectByDotPath($value, $indexes, $result, [...$prefix, $currentIndex]);
     }
 }

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Helpers\Array;
 use ArrayAccess;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\InvalidArgumentException;
+use stdClass;
 use Traversable;
 
 /**
@@ -97,17 +98,12 @@ final class ArrayHelper
         // Grab the current index
         $currentIndex = array_shift($indexes);
 
-        if (! self::valueExists($array, $currentIndex) && $currentIndex !== '*') {
-            return null;
-        }
-
         // Handle Wildcard (*)
         if ($currentIndex === '*') {
-            $answer   = [];
-            $iterable = is_object($array) ? self::toIterable($array) : $array;
+            $answer = [];
 
-            foreach ($iterable as $value) {
-                if (! is_array($value) && ! is_object($value)) {
+            foreach (self::entries($array) as $value) {
+                if (! self::isNavigable($value)) {
                     return null;
                 }
 
@@ -124,13 +120,17 @@ final class ArrayHelper
             return null;
         }
 
+        [$found, $value] = self::resolve($array, $currentIndex);
+
+        if (! $found) {
+            return null;
+        }
+
         // If this is the last index, make sure to return it now,
         // and not try to recurse through things.
         if ($indexes === []) {
-            return self::value($array, $currentIndex);
+            return $value;
         }
-
-        $value = self::value($array, $currentIndex);
 
         // Do we need to recursively search this value?
         if ((is_array($value) && $value !== []) || is_object($value)) {
@@ -176,10 +176,8 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            $iterable = is_object($array) ? self::toIterable($array) : $array;
-
-            foreach ($iterable as $item) {
-                if ((! is_array($item) && ! is_object($item)) || ! self::hasByDotPath($item, $indexes)) {
+            foreach (self::entries($array) as $item) {
+                if (! self::isNavigable($item) || ! self::hasByDotPath($item, $indexes)) {
                     return false;
                 }
             }
@@ -187,7 +185,9 @@ final class ArrayHelper
             return true;
         }
 
-        if (! self::valueExists($array, $currentIndex)) {
+        [$found, $value] = self::resolve($array, $currentIndex);
+
+        if (! $found) {
             return false;
         }
 
@@ -195,9 +195,7 @@ final class ArrayHelper
             return true;
         }
 
-        $value = self::value($array, $currentIndex);
-
-        if (! is_array($value) && ! is_object($value)) {
+        if (! self::isNavigable($value)) {
             return false;
         }
 
@@ -292,7 +290,10 @@ final class ArrayHelper
     public static function dotExcept(array|object $array, array|string $indexes): array
     {
         $indexes = is_string($indexes) ? [$indexes] : $indexes;
-        $result  = self::toArrayView($array);
+
+        // Open only the root into an array view; nested values (including
+        // objects) are preserved until a path actually descends into them.
+        $result = self::entries($array);
 
         foreach ($indexes as $index) {
             self::ensureValidWildcardPattern($index, true);
@@ -303,17 +304,18 @@ final class ArrayHelper
                 continue;
             }
 
+            $segments = self::convertToArray($index);
+            if ($segments === []) {
+                continue;
+            }
+
             if (str_ends_with($index, '*')) {
-                $segments = self::convertToArray($index);
-                self::clearByDotPath($result, $segments);
+                self::excludeChildrenByDotPath($result, $segments);
 
                 continue;
             }
 
-            $segments = self::convertToArray($index);
-            if ($segments !== []) {
-                self::unsetByDotPath($result, $segments);
-            }
+            self::excludeByDotPath($result, $segments);
         }
 
         return $result;
@@ -465,57 +467,70 @@ final class ArrayHelper
     }
 
     /**
-     * @param array<array-key, mixed>|object $data
+     * Resolve a key against an array or object node, walking the access chain
+     * (Entity, ArrayAccess, public properties, magic `__isset`/`__get`) once.
+     *
+     * @param array<array-key, mixed>|object $node
+     *
+     * @return array{bool, mixed} The pair [found, value].
      */
-    private static function valueExists(array|object $data, string $key): bool
+    private static function resolve(array|object $node, string $key): array
     {
-        if (is_array($data)) {
-            return array_key_exists($key, $data);
+        if (is_array($node)) {
+            return array_key_exists($key, $node) ? [true, $node[$key]] : [false, null];
         }
 
-        $array = self::entityToArray($data);
+        $array = self::entityToArray($node);
 
         if ($array !== null) {
-            return array_key_exists($key, $array);
+            return array_key_exists($key, $array) ? [true, $array[$key]] : [false, null];
         }
 
-        if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
-            return true;
+        if ($node instanceof ArrayAccess && $node->offsetExists($key)) {
+            return [true, $node->offsetGet($key)];
         }
 
-        if (array_key_exists($key, get_object_vars($data))) {
-            return true;
+        $properties = get_object_vars($node);
+
+        if (array_key_exists($key, $properties)) {
+            return [true, $properties[$key]];
         }
 
-        return isset($data->{$key});
+        return isset($node->{$key}) ? [true, $node->{$key}] : [false, null];
     }
 
     /**
-     * @param array<array-key, mixed>|object $data
+     * Whether keys can be resolved from this value, i.e. it is an array or an
+     * object that exposes a key surface: an expandable container, an
+     * `ArrayAccess`, or one relying on magic `__get`. Pure value-objects
+     * (e.g. `DateTimeImmutable`) are not navigable.
+     *
+     * Direct key lookup can support more object types than wildcard traversal:
+     * `ArrayAccess` and magic-only objects can resolve `user.id`, but cannot be
+     * enumerated for `user.*` unless they are also expandable.
      */
-    private static function value(array|object $data, string $key): mixed
+    private static function isNavigable(mixed $value): bool
     {
-        if (is_array($data)) {
-            return $data[$key];
+        if (is_array($value)) {
+            return true;
         }
 
-        $array = self::entityToArray($data);
+        return is_object($value)
+            && (self::isExpandable($value)
+                || $value instanceof ArrayAccess
+                || method_exists($value, '__get'));
+    }
 
-        if ($array !== null) {
-            return $array[$key];
-        }
-
-        if ($data instanceof ArrayAccess && $data->offsetExists($key)) {
-            return $data->offsetGet($key);
-        }
-
-        $properties = get_object_vars($data);
-
-        if (array_key_exists($key, $properties)) {
-            return $properties[$key];
-        }
-
-        return $data->{$key};
+    /**
+     * Entries of an array or object node for wildcard traversal.
+     *
+     * @param array<array-key, mixed>|object $node
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function entries(array|object $node): array
+    {
+        return is_object($node) ? self::toIterable($node) : $node;
     }
 
     /**
@@ -535,7 +550,8 @@ final class ArrayHelper
      *
      * Entities are converted via toArray() so internal properties like
      * `_options` or `_cast` are not exposed. Other Traversable objects are
-     * materialized; plain objects fall back to their public properties.
+     * converted to an array with their keys preserved; plain objects fall back
+     * to their public properties.
      *
      * @return array<array-key, mixed>
      */
@@ -548,30 +564,50 @@ final class ArrayHelper
         }
 
         if ($data instanceof Traversable) {
-            return iterator_to_array($data, false);
+            return iterator_to_array($data);
         }
 
         return get_object_vars($data);
     }
 
     /**
-     * Normalize arrays or objects to an array view safe for dotExcept().
+     * Whether an object should be expanded into an array when building output.
      *
-     * @param array<array-key, mixed>|object $data
-     *
-     * @return array<array-key, mixed>
+     * Only enumerable containers are expanded: entities, `stdClass`, other
+     * `Traversable` objects, and plain objects exposing public properties.
+     * Opaque objects with no enumerable key surface (value-objects such as
+     * `DateTimeImmutable`, magic-only or pure `ArrayAccess` objects) are
+     * preserved as-is, since they cannot be faithfully rebuilt as an array.
      */
-    private static function toArrayView(array|object $data): array
+    private static function isExpandable(object $value): bool
     {
-        $array = is_object($data) ? self::toIterable($data) : $data;
+        return $value instanceof Entity
+            || $value instanceof stdClass
+            || $value instanceof Traversable
+            || get_object_vars($value) !== [];
+    }
 
-        foreach ($array as $key => $value) {
-            if (is_array($value) || is_object($value)) {
-                $array[$key] = self::toArrayView($value);
-            }
+    /**
+     * Ensure a value can be descended into for a partial exclusion/projection.
+     *
+     * Arrays pass through; expandable objects are converted to an array view
+     * in place (this is the only point where output structure is fabricated).
+     * Anything else (scalars, value-objects, magic-only or pure `ArrayAccess`
+     * objects) is left untouched and reported as non-descendable.
+     */
+    private static function expandForDescent(mixed &$value): bool
+    {
+        if (is_array($value)) {
+            return true;
         }
 
-        return $array;
+        if (is_object($value) && self::isExpandable($value)) {
+            $value = self::entries($value);
+
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -712,6 +748,90 @@ final class ArrayHelper
     }
 
     /**
+     * Removes a value by dot path for dotExcept(). Objects are expanded to an
+     * array view only when the path descends into them, so untouched branches
+     * keep their original values (including objects).
+     *
+     * @param array<array-key, mixed> $array
+     * @param list<string>            $indexes
+     */
+    private static function excludeByDotPath(array &$array, array $indexes): int
+    {
+        if ($indexes === []) {
+            return 0;
+        }
+
+        $currentIndex = array_shift($indexes);
+
+        if ($currentIndex === '*') {
+            $removed = 0;
+
+            foreach ($array as &$item) {
+                if (self::expandForDescent($item)) {
+                    $removed += self::excludeByDotPath($item, $indexes);
+                }
+            }
+            unset($item);
+
+            return $removed;
+        }
+
+        if ($indexes === []) {
+            if (! array_key_exists($currentIndex, $array)) {
+                return 0;
+            }
+
+            unset($array[$currentIndex]);
+
+            return 1;
+        }
+
+        if (! array_key_exists($currentIndex, $array) || ! self::expandForDescent($array[$currentIndex])) {
+            return 0;
+        }
+
+        return self::excludeByDotPath($array[$currentIndex], $indexes);
+    }
+
+    /**
+     * Clears all children under the specified path for dotExcept(), expanding
+     * objects to an array view only along the descended path.
+     *
+     * @param array<array-key, mixed> $array
+     * @param list<string>            $indexes
+     */
+    private static function excludeChildrenByDotPath(array &$array, array $indexes): int
+    {
+        if ($indexes === []) {
+            $count = count($array);
+            $array = [];
+
+            return $count;
+        }
+
+        $currentIndex = array_shift($indexes);
+
+        if ($currentIndex === '*') {
+            $cleared = 0;
+
+            foreach ($array as &$item) {
+                if (self::expandForDescent($item)) {
+                    $cleared += self::excludeChildrenByDotPath($item, $indexes);
+                }
+            }
+            unset($item);
+
+            return $cleared;
+        }
+
+        if (! array_key_exists($currentIndex, $array) || ! self::expandForDescent($array[$currentIndex])) {
+            return 0;
+        }
+
+        return self::excludeChildrenByDotPath($array[$currentIndex], $indexes);
+    }
+
+    /**
      * Projects matching paths from source into result with preserved structure.
      *
      * @param array<array-key, mixed>|object $source
@@ -726,6 +846,8 @@ final class ArrayHelper
         array $prefix = [],
     ): void {
         if ($indexes === []) {
+            // The whole node was selected: preserve it as-is. Output structure
+            // is only fabricated for the projection skeleton above this leaf.
             self::setByDotPath($result, $prefix, $source);
 
             return;
@@ -734,10 +856,8 @@ final class ArrayHelper
         $currentIndex = array_shift($indexes);
 
         if ($currentIndex === '*') {
-            $iterable = is_object($source) ? self::toIterable($source) : $source;
-
-            foreach ($iterable as $key => $value) {
-                if (! is_array($value) && ! is_object($value)) {
+            foreach (self::entries($source) as $key => $value) {
+                if (! self::isNavigable($value)) {
                     if ($indexes === []) {
                         self::setByDotPath($result, [...$prefix, (string) $key], $value);
                     }
@@ -751,13 +871,13 @@ final class ArrayHelper
             return;
         }
 
-        if (! self::valueExists($source, $currentIndex)) {
+        [$found, $value] = self::resolve($source, $currentIndex);
+
+        if (! $found) {
             return;
         }
 
-        $value = self::value($source, $currentIndex);
-
-        if (! is_array($value) && ! is_object($value)) {
+        if (! self::isNavigable($value)) {
             if ($indexes === []) {
                 self::setByDotPath($result, [...$prefix, $currentIndex], $value);
             }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -34,9 +34,9 @@ if (! function_exists('dot_array_has')) {
     /**
      * Checks if an array key exists using dot syntax.
      *
-     * @param array<array-key, mixed> $array
+     * @param array<array-key, mixed>|object $array
      */
-    function dot_array_has(string $index, array $array): bool
+    function dot_array_has(string $index, array|object $array): bool
     {
         return ArrayHelper::dotHas($index, $array);
     }
@@ -70,12 +70,12 @@ if (! function_exists('dot_array_only')) {
     /**
      * Gets only the specified keys using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    function dot_array_only(array $array, array|string $indexes): array
+    function dot_array_only(array|object $array, array|string $indexes): array
     {
         return ArrayHelper::dotOnly($array, $indexes);
     }
@@ -85,12 +85,12 @@ if (! function_exists('dot_array_except')) {
     /**
      * Gets all keys except the specified ones using dot syntax.
      *
-     * @param array<array-key, mixed> $array
-     * @param list<string>|string     $indexes
+     * @param array<array-key, mixed>|object $array
+     * @param list<string>|string            $indexes
      *
      * @return array<array-key, mixed>
      */
-    function dot_array_except(array $array, array|string $indexes): array
+    function dot_array_except(array|object $array, array|string $indexes): array
     {
         return ArrayHelper::dotExcept($array, $indexes);
     }

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -15,8 +15,8 @@ namespace CodeIgniter\Helpers;
 
 use ArrayObject;
 use CodeIgniter\Exceptions\InvalidArgumentException;
-use DateTimeImmutable;
 use CodeIgniter\Test\CIUnitTestCase;
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Helpers;
 
 use ArrayObject;
 use CodeIgniter\Exceptions\InvalidArgumentException;
+use DateTimeImmutable;
 use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -221,6 +222,32 @@ final class ArrayHelperTest extends CIUnitTestCase
         );
     }
 
+    public function testDotArrayOnlyPreservesWholeSelectedObject(): void
+    {
+        $user = (object) ['id' => 1, 'name' => 'Ada'];
+
+        // Selecting the object as a whole returns it untouched.
+        $this->assertSame(['user' => $user], dot_array_only(['user' => $user], 'user'));
+    }
+
+    public function testDotArrayOnlyProjectsPartialObjectAsArray(): void
+    {
+        $created = new DateTimeImmutable();
+
+        $data = [
+            'user' => (object) [
+                'id'      => 123,
+                'created' => $created,
+            ],
+        ];
+
+        // A partial projection must fabricate array structure for "user"...
+        $this->assertSame(['user' => ['id' => 123]], dot_array_only($data, 'user.id'));
+
+        // ...while the value-object leaf is preserved as-is.
+        $this->assertSame(['user' => ['created' => $created]], dot_array_only($data, 'user.created'));
+    }
+
     public function testDotArrayExcept(): void
     {
         $data = [
@@ -261,22 +288,21 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     public function testDotArrayExceptWithObjectValues(): void
     {
+        $meta = (object) ['request_id' => 'abc'];
         $data = (object) [
             'user' => (object) [
                 'id'   => 123,
                 'name' => 'john',
             ],
-            'meta' => (object) ['request_id' => 'abc'],
+            'meta' => $meta,
         ];
 
-        $expected = [
-            'user' => [
-                'name' => 'john',
-            ],
-            'meta' => ['request_id' => 'abc'],
-        ];
+        $result = dot_array_except($data, 'user.id');
 
-        $this->assertSame($expected, dot_array_except($data, 'user.id'));
+        // "user" is partially excluded, so it is rebuilt as an array...
+        $this->assertSame(['name' => 'john'], $result['user']);
+        // ...but the untouched "meta" object is preserved as-is.
+        $this->assertSame($meta, $result['meta']);
     }
 
     public function testDotArrayExceptWildcardWithObjectValues(): void
@@ -295,6 +321,57 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame($expected, dot_array_except($data, 'user.*'));
+    }
+
+    public function testDotArrayExceptPreservesUntouchedObject(): void
+    {
+        $user = (object) ['id' => 1, 'name' => 'Ada'];
+
+        // The path does not touch "user", so the object is returned untouched.
+        $this->assertSame(['user' => $user], dot_array_except(['user' => $user], 'other'));
+    }
+
+    public function testDotArrayExceptPreservesValueObjects(): void
+    {
+        $created = new DateTimeImmutable();
+
+        $data = [
+            'user'    => ['id' => 1],
+            'created' => $created,
+        ];
+
+        $result = dot_array_except($data, 'user.id');
+
+        $this->assertSame([], $result['user']);
+        // Untouched value-objects must survive instead of collapsing to [].
+        $this->assertSame($created, $result['created']);
+    }
+
+    public function testDotArrayExceptPreservesTraversableKeys(): void
+    {
+        $data = new ArrayObject([
+            'user' => ['id' => 1, 'name' => 'Ada'],
+            'meta' => 'm',
+        ]);
+
+        $expected = [
+            'user' => ['name' => 'Ada'],
+            'meta' => 'm',
+        ];
+
+        $this->assertSame($expected, dot_array_except($data, 'user.id'));
+    }
+
+    public function testDotArrayOnlyAndExceptAgreeOnPublicPropertyObjects(): void
+    {
+        $user = new class () {
+            public int $id      = 1;
+            public string $name = 'Ada';
+        };
+
+        // Both helpers treat a public-property object as a container.
+        $this->assertSame(['user' => ['id' => 1]], dot_array_only(['user' => $user], 'user.id'));
+        $this->assertSame(['user' => ['name' => 'Ada']], dot_array_except(['user' => $user], 'user.id'));
     }
 
     public function testArrayDotTooManyLevels(): void

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -177,6 +177,50 @@ final class ArrayHelperTest extends CIUnitTestCase
         $this->assertSame($expected, dot_array_only($data, 'user.*'));
     }
 
+    public function testDotArrayOnlyWithObjectValues(): void
+    {
+        $data = (object) [
+            'user' => (object) [
+                'id'      => 123,
+                'profile' => (object) [
+                    'name' => 'john',
+                ],
+            ],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $expected = [
+            'user' => [
+                'profile' => [
+                    'name' => 'john',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, dot_array_only($data, 'user.profile.name'));
+    }
+
+    public function testDotArrayOnlyWildcardWithEntityRows(): void
+    {
+        $a      = new SomeEntity();
+        $a->foo = 1;
+        $a->bar = 2;
+
+        $b      = new SomeEntity();
+        $b->foo = 3;
+        $b->bar = 4;
+
+        $this->assertSame(
+            [
+                'rows' => [
+                    ['foo' => 1],
+                    ['foo' => 3],
+                ],
+            ],
+            dot_array_only(['rows' => [$a, $b]], 'rows.*.foo'),
+        );
+    }
+
     public function testDotArrayExcept(): void
     {
         $data = [
@@ -201,6 +245,44 @@ final class ArrayHelperTest extends CIUnitTestCase
     {
         $data = [
             'user' => [
+                'id'   => 123,
+                'name' => 'john',
+            ],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $expected = [
+            'user' => [],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $this->assertSame($expected, dot_array_except($data, 'user.*'));
+    }
+
+    public function testDotArrayExceptWithObjectValues(): void
+    {
+        $data = (object) [
+            'user' => (object) [
+                'id'   => 123,
+                'name' => 'john',
+            ],
+            'meta' => (object) ['request_id' => 'abc'],
+        ];
+
+        $expected = [
+            'user' => [
+                'name' => 'john',
+            ],
+            'meta' => ['request_id' => 'abc'],
+        ];
+
+        $this->assertSame($expected, dot_array_except($data, 'user.id'));
+    }
+
+    public function testDotArrayExceptWildcardWithObjectValues(): void
+    {
+        $data = (object) [
+            'user' => (object) [
                 'id'   => 123,
                 'name' => 'john',
             ],
@@ -456,6 +538,82 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame(['John', 'Maria'], dot_array_search('users.*.name', $data));
+    }
+
+    public function testDotArrayHasWithObjectValues(): void
+    {
+        $data = [
+            'user' => (object) [
+                'profile' => (object) [
+                    'name' => 'Jane',
+                ],
+            ],
+        ];
+
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+        $this->assertFalse(dot_array_has('user.profile.email', $data));
+    }
+
+    public function testDotArrayHasWithMagicObjectValues(): void
+    {
+        $data = [
+            'user' => new class () {
+                /**
+                 * @var array<string, array<string, string>>
+                 */
+                private array $values = [
+                    'profile' => [
+                        'name' => 'Jane',
+                    ],
+                ];
+
+                public function __isset(string $key): bool
+                {
+                    return array_key_exists($key, $this->values);
+                }
+
+                public function __get(string $key): mixed
+                {
+                    return $this->values[$key];
+                }
+            },
+        ];
+
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testDotArrayHasWithArrayAccessValues(): void
+    {
+        $data = [
+            'user' => new ArrayObject([
+                'profile' => [
+                    'name' => 'Jane',
+                ],
+            ]),
+        ];
+
+        $this->assertTrue(dot_array_has('user.profile.name', $data));
+    }
+
+    public function testDotArrayHasWithEntityValues(): void
+    {
+        $entity      = new SomeEntity();
+        $entity->foo = 'value';
+
+        $this->assertTrue(dot_array_has('user.foo', ['user' => $entity]));
+        $this->assertFalse(dot_array_has('user._options', ['user' => $entity]));
+    }
+
+    public function testDotArrayHasWildcardWithEntityValues(): void
+    {
+        $a      = new SomeEntity();
+        $a->foo = 1;
+
+        $b      = new SomeEntity();
+        $b->foo = 2;
+
+        $this->assertTrue(dot_array_has('rows.*.foo', ['rows' => [$a, $b]]));
+        $this->assertFalse(dot_array_has('rows.*._cast', ['rows' => [$a, $b]]));
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -274,6 +274,9 @@ Helpers and Functions
   object rows (including ``Entity``) in :php:func:`dot_array_search()`,
   :php:func:`dot_array_has()`, :php:func:`dot_array_only()`,
   :php:func:`dot_array_except()`, and :php:func:`array_group_by()`.
+  :php:func:`dot_array_only()` and :php:func:`dot_array_except()` still return arrays. If the source itself is an object, 
+  it is read as an array-like value. Object values inside the source are kept unchanged when selected as a whole or left untouched. 
+  Partial object paths are returned as arrays.
 
 HTTP
 ====

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -271,8 +271,9 @@ Helpers and Functions
   :php:func:`dot_array_has()`, :php:func:`dot_array_set()`, :php:func:`dot_array_unset()`,
   :php:func:`dot_array_only()`, and :php:func:`dot_array_except()`.
 - :doc:`Array Helper </helpers/array_helper>` dot-path read operations now support
-  object rows (including ``Entity``) in :php:func:`dot_array_search()` and
-  :php:func:`array_group_by()`.
+  object rows (including ``Entity``) in :php:func:`dot_array_search()`,
+  :php:func:`dot_array_has()`, :php:func:`dot_array_only()`,
+  :php:func:`dot_array_except()`, and :php:func:`array_group_by()`.
 
 HTTP
 ====

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -58,10 +58,10 @@ The following functions are available:
 
 .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
-..  php:function:: dot_array_has(string $search, array $values): bool
+..  php:function:: dot_array_has(string $search, array|object $values): bool
 
     :param  string  $search: The dot-notation string describing how to search the array
-    :param  array   $values: The array to check
+    :param  array|object $values: The array or object to check
     :returns: ``true`` if the key exists, otherwise ``false``
     :rtype: bool
 
@@ -69,6 +69,8 @@ The following functions are available:
 
     Checks if an array key exists using dot syntax.
     This method supports wildcard ``*`` in the same way as ``dot_array_search()``.
+
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
     .. literalinclude:: array_helper/015.php
         :lines: 2-
@@ -105,9 +107,9 @@ The following functions are available:
     .. literalinclude:: array_helper/017.php
         :lines: 2-
 
-..  php:function:: dot_array_only(array $array, array|string $indexes): array
+..  php:function:: dot_array_only(array|object $array, array|string $indexes): array
 
-    :param  array            $array: The source array
+    :param  array|object     $array: The source array or object
     :param  array|string     $indexes: One key or a list of keys using dot notation
     :returns: Nested array containing only the requested keys
     :rtype: array
@@ -119,12 +121,14 @@ The following functions are available:
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
 
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
+
     .. literalinclude:: array_helper/018.php
         :lines: 2-
 
-..  php:function:: dot_array_except(array $array, array|string $indexes): array
+..  php:function:: dot_array_except(array|object $array, array|string $indexes): array
 
-    :param  array            $array: The source array
+    :param  array|object     $array: The source array or object
     :param  array|string     $indexes: One key or a list of keys using dot notation
     :returns: Nested array with the specified keys removed
     :rtype: array
@@ -135,6 +139,8 @@ The following functions are available:
 
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
+
+    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
     .. literalinclude:: array_helper/019.php
         :lines: 2-

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -22,6 +22,17 @@ Available Functions
 
 The following functions are available:
 
+.. note:: Since v4.8.0, the dot-path helpers can read values from arrays or
+    objects, including ``Entity`` objects. This applies to
+    :php:func:`dot_array_search()`, :php:func:`dot_array_has()`,
+    :php:func:`dot_array_only()`, :php:func:`dot_array_except()`, and
+    :php:func:`array_group_by()`.
+
+    :php:func:`dot_array_set()` and :php:func:`dot_array_unset()` still modify
+    arrays only. :php:func:`dot_array_only()` and
+    :php:func:`dot_array_except()` always return arrays. See their descriptions
+    for how object values are handled.
+
 ..  php:function:: dot_array_search(string $search, array|object $values)
 
     :param  string  $search: The dot-notation string describing how to search the array
@@ -56,8 +67,6 @@ The following functions are available:
 .. note:: Prior to v4.2.0, ``dot_array_search('foo.bar.baz', ['foo' => ['bar' => 23]])`` returned ``23``
     due to a bug. v4.2.0 and later returns ``null``.
 
-.. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
-
 ..  php:function:: dot_array_has(string $search, array|object $values): bool
 
     :param  string  $search: The dot-notation string describing how to search the array
@@ -69,8 +78,6 @@ The following functions are available:
 
     Checks if an array key exists using dot syntax.
     This method supports wildcard ``*`` in the same way as ``dot_array_search()``.
-
-    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
     .. literalinclude:: array_helper/015.php
         :lines: 2-
@@ -121,7 +128,12 @@ The following functions are available:
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
 
-    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
+    The result is always an array. If a selected value is an object, that object
+    is kept as the value. If you select a value inside an object, the returned
+    path is built with arrays:
+
+    .. literalinclude:: array_helper/020.php
+        :lines: 2-
 
     .. literalinclude:: array_helper/018.php
         :lines: 2-
@@ -140,7 +152,12 @@ The following functions are available:
     Wildcard ``*`` is supported. Unlike ``dot_array_set()`` and ``dot_array_unset()``,
     this method also allows wildcard at the end (for example ``user.*``).
 
-    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
+    The result is always an array. Object values that are not changed are kept
+    as they are. If a key is removed from inside an object, that part of the
+    result is returned as an array:
+
+    .. literalinclude:: array_helper/021.php
+        :lines: 2-
 
     .. literalinclude:: array_helper/019.php
         :lines: 2-
@@ -152,7 +169,8 @@ The following functions are available:
     :returns: The value found within the array, or null
     :rtype: mixed
 
-    Returns the value of an element with a key value in an array of uncertain depth
+    Returns the value of an element with a key value in an array of uncertain depth.
+    Only nested arrays are searched; object values are not traversed.
 
 ..  php:function:: array_sort_by_multiple_keys(array &$array, array $sortColumns)
 
@@ -195,7 +213,8 @@ The following functions are available:
     :returns: The flattened array
 
     This function flattens a multidimensional array to a single key-value array by using dots
-    as separators for the keys.
+    as separators for the keys. The source may be any ``iterable``. Only nested arrays are
+    flattened; object values are kept as-is, as leaf values.
 
     .. literalinclude:: array_helper/009.php
         :lines: 2-
@@ -223,8 +242,6 @@ The following functions are available:
     This function allows you to group data rows together by index values.
     The depth of returned array equals the number of indexes passed as parameter.
     Data rows may be arrays or objects, and dot syntax can read nested array keys or object properties.
-
-    .. note:: Prior to v4.8.0, only arrays were supported. Support for objects was added in v4.8.0.
 
     The example shows some data (i.e. loaded from an API) with nested arrays.
 

--- a/user_guide_src/source/helpers/array_helper/020.php
+++ b/user_guide_src/source/helpers/array_helper/020.php
@@ -1,0 +1,11 @@
+<?php
+
+$user = (object) ['id' => 123, 'name' => 'John'];
+
+// Selecting the object itself keeps the object as the value.
+$whole = dot_array_only(['user' => $user], 'user');
+// ['user' => $user]
+
+// Selecting a value inside the object builds the path with arrays.
+$partial = dot_array_only(['user' => $user], 'user.id');
+// ['user' => ['id' => 123]]

--- a/user_guide_src/source/helpers/array_helper/021.php
+++ b/user_guide_src/source/helpers/array_helper/021.php
@@ -1,0 +1,11 @@
+<?php
+
+$user = (object) ['id' => 123, 'name' => 'John'];
+
+// An untouched object is kept as it is.
+$untouched = dot_array_except(['user' => $user], 'meta.id');
+// ['user' => $user]
+
+// Removing a key from inside an object returns that part as an array.
+$partial = dot_array_except(['user' => $user], 'user.id');
+// ['user' => ['name' => 'John']]


### PR DESCRIPTION
**Description**
This PR replaces #10269. It extends the remaining dot-path helpers so `dot_array_has()`, `dot_array_only()`, and `dot_array_except()` can read through array-like object values while keeping the existing array return contract for projection helpers.

The code now uses one lookup path for arrays and objects. It preserves keys from traversable objects and does not convert objects that are not part of the requested path. If an object is returned or left untouched, it stays an object. If only part of an object is selected or removed, that part is returned as an array.

Supersedes #10269
Closes #10225

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
