### PR TITLE
fix: required_without() premature return inside foreach loop

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -414,30 +414,44 @@ class Rules
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
         foreach (explode(',', $otherFields) as $otherField) {
-            if (
-                (! str_contains($otherField, '.'))
-                && (! array_key_exists($otherField, $data)
-                    || empty($data[$otherField]))
-            ) {
-                return false;
+            if (! str_contains($otherField, '.')) {
+                if (! array_key_exists($otherField, $data) || empty($data[$otherField])) {
+                    return false;
+                }
+
+                continue;
             }
 
-            if (str_contains($otherField, '.')) {
-                if ($field === null) {
-                    throw new InvalidArgumentException('You must supply the parameters: field.');
+            if ($field === null) {
+                throw new InvalidArgumentException('You must supply the parameters: field.');
+            }
+
+            $fieldSplitArray = explode('.', $field);
+            $fieldKey        = $fieldSplitArray[1] ?? null;
+
+            if ($fieldKey === null) {
+                throw new InvalidArgumentException('Invalid field format for dot-path required_without.');
+            }
+
+            $fieldData = dot_array_search($otherField, $data);
+
+            if (is_array($fieldData)) {
+                $searched = dot_array_search($otherField, $data);
+
+                if (! is_array($searched) || ! array_key_exists($fieldKey, $searched)) {
+                    return false;
                 }
 
-                $fieldData       = dot_array_search($otherField, $data);
-                $fieldSplitArray = explode('.', $field);
-                $fieldKey        = $fieldSplitArray[1];
-
-                if (is_array($fieldData)) {
-                    return ! empty(dot_array_search($otherField, $data)[$fieldKey]);
+                if (empty($searched[$fieldKey])) {
+                    return false;
                 }
+            } else {
                 $nowField      = str_replace('*', $fieldKey, $otherField);
-                $nowFieldVaule = dot_array_search($nowField, $data);
+                $nowFieldValue = dot_array_search($nowField, $data);
 
-                return null !== $nowFieldVaule;
+                if ($nowFieldValue === null) {
+                    return false;
+                }
             }
         }
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1854,6 +1854,46 @@ class ValidationTest extends CIUnitTestCase
         );
     }
 
+    public function testRequireWithoutWithMultipleAsterisk(): void
+    {
+        $data = [
+            'a' => [
+                ['b' => 1, 'c' => 2, 'd' => 3],
+                ['c' => '', 'd' => 4],
+                ['b' => 5],
+            ],
+        ];
+
+        $this->validation->setRules([
+            'a.*.c' => 'required_without[a.*.b, a.*.d]',
+        ])->run($data);
+
+        $this->assertSame(
+            'The a.*.c field is required when a.*.b, a.*.d is not present.',
+            $this->validation->getError('a.1.c'),
+        );
+        $this->assertArrayNotHasKey('a.0.c', $this->validation->getErrors(), 'Row 0: both b and d present');
+        $this->assertArrayHasKey('a.2.c', $this->validation->getErrors(), 'Row 2: c missing, d missing → field required');
+    }
+
+    public function testRequireWithoutWithMultipleAsteriskLastMissing(): void
+    {
+        $data = [
+            'a' => [
+                ['b' => 1, 'c' => ''],
+            ],
+        ];
+
+        $this->validation->setRules([
+            'a.*.c' => 'required_without[a.*.b, a.*.nonexistent]',
+        ])->run($data);
+
+        $this->assertSame(
+            'The a.*.c field is required when a.*.b, a.*.nonexistent is not present.',
+            $this->validation->getError('a.0.c'),
+        );
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/8128
      */


### PR DESCRIPTION
### Bug

In `Rules::required_without()`, the `foreach` loop over `$otherFields`
contained early `return` statements in the dot-path branch (lines 435, 440).
This caused only the **first** field in a comma-separated list to be evaluated;
all subsequent fields were silently ignored.

For example, `required_without[a.*.b, a.*.c]` would only check `a.*.b`
and return immediately, never inspecting `a.*.c`.

### Fix

- Refactored the `foreach` body so no iteration contains a `return` statement.
  Each field is independently evaluated, and `false` is returned only when
  a missing dependency is found.
- Added `?? null` coalescing for `$fieldSplitArray[1]` with a validation
  guard against malformed dot-path fields.
- Added explicit `is_array()` check before array-key access on the result
  of `dot_array_search()`, preventing a PHP Warning when it returns `null`.

### Tests

- `testRequireWithoutWithMultipleAsterisk` – verifies that both `a.*.b` and
  `a.*.d` are checked when using `required_without[a.*.b, a.*.d]`.
- `testRequireWithoutWithMultipleAsteriskLastMissing` – verifies that
  validation fails when the last dot-path field is absent.