### PR TITLE
test: add SQL equality assertion helper

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -506,7 +506,7 @@ abstract class CIUnitTestCase extends TestCase
      */
     public function assertSameSql(string $expected, string $actual, string $message = ''): void
     {
-        $this->assertSame($expected, str_replace("\n", ' ', $actual), $message);
+        $this->assertSame($expected, str_replace(["\r\n", "\r", "\n"], ' ', $actual), $message);
     }
 
     // --------------------------------------------------------------------

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -504,7 +504,7 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Asserts that two SQL strings are the same, ignoring newlines in the actual SQL.
      */
-    public function assertSqlEquals(string $expected, string $actual, string $message = ''): void
+    public function assertSameSql(string $expected, string $actual, string $message = ''): void
     {
         $this->assertSame($expected, str_replace("\n", ' ', $actual), $message);
     }

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -501,6 +501,14 @@ abstract class CIUnitTestCase extends TestCase
         return null;
     }
 
+    /**
+     * Asserts that two SQL strings are the same, ignoring newlines in the actual SQL.
+     */
+    public function assertSqlEquals(string $expected, string $actual, string $message = ''): void
+    {
+        $this->assertSame($expected, str_replace("\n", ' ', $actual), $message);
+    }
+
     // --------------------------------------------------------------------
     // Utility
     // --------------------------------------------------------------------

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -46,7 +46,7 @@ final class DeleteTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSqlEquals($expectedSQL, $answer);
+        $this->assertSameSql($expectedSQL, $answer);
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -46,7 +46,7 @@ final class DeleteTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSqlEquals($expectedSQL, $answer);
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -51,7 +51,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->where($where);
 
-        $this->assertSqlEquals($expectedSQL, $builder->getCompiledSelect());
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -64,7 +64,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->whereColumn('users.created_at <', 'users.updated_at');
 
-        $this->assertSqlEquals($expectedSQL, $builder->getCompiledSelect());
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -86,7 +86,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->whereBetween('users.created_at', [1, 10]);
 
-        $this->assertSqlEquals($expectedSQL, $builder->getCompiledSelect());
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -51,7 +51,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->where($where);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSqlEquals($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -64,7 +64,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->whereColumn('users.created_at <', 'users.updated_at');
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSqlEquals($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -86,7 +86,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->whereBetween('users.created_at', [1, 10]);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSqlEquals($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -93,4 +93,15 @@ final class TestCaseTest extends CIUnitTestCase
         $result = $this->assertCloseEnoughString('apples & oranges', 'apples');
         $this->assertFalse($result, 'Different string lengths should have returned false');
     }
+
+    public function testAssertSqlEqualsIgnoresNewlinesInActualSql(): void
+    {
+        $expected = 'SELECT * FROM "jobs" WHERE "id" = 1';
+        $actual   = <<<'SQL'
+            SELECT * FROM "jobs"
+            WHERE "id" = 1
+            SQL;
+
+        $this->assertSqlEquals($expected, $actual);
+    }
 }

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -104,4 +104,12 @@ final class TestCaseTest extends CIUnitTestCase
 
         $this->assertSameSql($expected, $actual);
     }
+
+    public function testAssertSameSqlIgnoresCrLfInActualSql(): void
+    {
+        $expected = 'SELECT * FROM "jobs" WHERE "id" = 1';
+        $actual   = "SELECT * FROM \"jobs\"\r\nWHERE \"id\" = 1";
+
+        $this->assertSameSql($expected, $actual);
+    }
 }

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -94,7 +94,7 @@ final class TestCaseTest extends CIUnitTestCase
         $this->assertFalse($result, 'Different string lengths should have returned false');
     }
 
-    public function testAssertSqlEqualsIgnoresNewlinesInActualSql(): void
+    public function testAssertSameSqlIgnoresNewlinesInActualSql(): void
     {
         $expected = 'SELECT * FROM "jobs" WHERE "id" = 1';
         $actual   = <<<'SQL'
@@ -102,6 +102,6 @@ final class TestCaseTest extends CIUnitTestCase
             WHERE "id" = 1
             SQL;
 
-        $this->assertSqlEquals($expected, $actual);
+        $this->assertSameSql($expected, $actual);
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -213,7 +213,7 @@ Commands
 Testing
 =======
 
-- Added ``assertSqlEquals()`` to ``CIUnitTestCase`` to compare generated SQL while ignoring newlines in the actual SQL.
+- Added ``assertSameSql()`` to ``CIUnitTestCase`` to compare generated SQL while ignoring newlines in the actual SQL.
 
 Database
 ========

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -213,6 +213,8 @@ Commands
 Testing
 =======
 
+- Added ``assertSqlEquals()`` to ``CIUnitTestCase`` to compare generated SQL while ignoring newlines in the actual SQL.
+
 Database
 ========
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -202,6 +202,13 @@ between expected and actual time, formatted as strings, is within the prescribed
 
 The above test will allow the actual time to be either 660 or 661 seconds.
 
+assertSqlEquals($expected, $actual, $message = '')
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Asserts that two SQL strings are the same, ignoring newlines in the actual SQL:
+
+.. literalinclude:: overview/023.php
+
 Accessing Protected/Private Properties
 --------------------------------------
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -202,8 +202,8 @@ between expected and actual time, formatted as strings, is within the prescribed
 
 The above test will allow the actual time to be either 660 or 661 seconds.
 
-assertSqlEquals($expected, $actual, $message = '')
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+assertSameSql($expected, $actual, $message = '')
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Asserts that two SQL strings are the same, ignoring newlines in the actual SQL:
 

--- a/user_guide_src/source/testing/overview/023.php
+++ b/user_guide_src/source/testing/overview/023.php
@@ -1,0 +1,6 @@
+<?php
+
+$expected = 'SELECT * FROM "jobs" WHERE "id" = 1';
+$actual   = $builder->where('id', 1)->getCompiledSelect();
+
+$this->assertSqlEquals($expected, $actual);

--- a/user_guide_src/source/testing/overview/023.php
+++ b/user_guide_src/source/testing/overview/023.php
@@ -3,4 +3,4 @@
 $expected = 'SELECT * FROM "jobs" WHERE "id" = 1';
 $actual   = $builder->where('id', 1)->getCompiledSelect();
 
-$this->assertSqlEquals($expected, $actual);
+$this->assertSameSql($expected, $actual);


### PR DESCRIPTION
**Description**

This PR adds `assertSameSql()` to `CIUnitTestCase`.

This follows up on @datamweb's [suggestion](https://github.com/codeigniter4/CodeIgniter4/pull/10256#issuecomment-4596207849) to introduce this helper.

The helper keeps a small pattern we already use in many Query Builder tests in one place:

```php
$this->assertSameSql($expected, $builder->getCompiledSelect());
```

It intentionally stays conservative and only ignores newlines in the actual SQL. It does not lowercase, trim, or normalize whitespace more broadly, so SQL assertions remain strict while avoiding the repeated `str_replace("\n", ' ', ...)` calls.

I also updated the testing docs and converted a few representative Query Builder assertions to show the intended usage. Broader migration of existing SQL assertions can happen separately after the helper is available.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide