### PR TITLE
fix(Filters): check both keys and values in `InvalidChars` arrays

### DIFF
--- a/system/Filters/InvalidChars.php
+++ b/system/Filters/InvalidChars.php
@@ -87,11 +87,18 @@ class InvalidChars implements FilterInterface
      * @param array|string $value
      *
      * @return array|string
+     *
+     * @throws SecurityException
      */
     protected function checkEncoding($value)
     {
         if (is_array($value)) {
-            array_map($this->checkEncoding(...), $value);
+            foreach ($value as $key => $item) {
+                if (is_string($key)) {
+                    $this->checkEncoding($key);
+                }
+                $this->checkEncoding($item);
+            }
 
             return $value;
         }
@@ -113,7 +120,12 @@ class InvalidChars implements FilterInterface
     protected function checkControl($value)
     {
         if (is_array($value)) {
-            array_map($this->checkControl(...), $value);
+            foreach ($value as $key => $item) {
+                if (is_string($key)) {
+                    $this->checkControl($key);
+                }
+                $this->checkControl($item);
+            }
 
             return $value;
         }

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -116,15 +116,24 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
-    public function testBeforeInvalidControlCharCausesException(): void
+    #[DataProvider('provideBeforeInvalidControlCharCausesException')]
+    public function testBeforeInvalidControlCharCausesException(string $invalidString): void
     {
         $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('Invalid Control characters in cookie:');
 
-        $stringWithNullChar = "String contains null char and line break.\0\n";
-        service('superglobals')->setCookie('val', $stringWithNullChar);
+        service('superglobals')->setCookie('val', $invalidString);
 
         $this->invalidChars->before($this->request);
+    }
+
+    public static function provideBeforeInvalidControlCharCausesException(): iterable
+    {
+        yield 'null byte' => ["String with null char \0"];
+
+        yield 'backspace' => ["String with backspace \x08"];
+
+        yield 'escape' => ["String with escape \x1b"];
     }
 
     public function testBeforeInvalidControlCharInArrayKeyCausesException(): void

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -103,6 +103,19 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
+    public function testBeforeInvalidUTF8StringInArrayKeyCausesException(): void
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('Invalid UTF-8 characters in post:');
+
+        $sjisString = mb_convert_encoding('SJISの文字列です。', 'SJIS');
+        service('superglobals')->setPost('val', [
+            $sjisString => 'valid string',
+        ]);
+
+        $this->invalidChars->before($this->request);
+    }
+
     public function testBeforeInvalidControlCharCausesException(): void
     {
         $this->expectException(SecurityException::class);
@@ -110,6 +123,19 @@ final class InvalidCharsTest extends CIUnitTestCase
 
         $stringWithNullChar = "String contains null char and line break.\0\n";
         service('superglobals')->setCookie('val', $stringWithNullChar);
+
+        $this->invalidChars->before($this->request);
+    }
+
+    public function testBeforeInvalidControlCharInArrayKeyCausesException(): void
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('Invalid Control characters in cookie:');
+
+        $stringWithNullChar = "String contains null char and line break.\0\n";
+        service('superglobals')->setCookie('val', [
+            $stringWithNullChar => 'valid string',
+        ]);
 
         $this->invalidChars->before($this->request);
     }

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -127,6 +127,9 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
+    /**
+     * @return iterable<string, list<string>>
+     */
     public static function provideBeforeInvalidControlCharCausesException(): iterable
     {
         yield 'null byte' => ["String with null char \0"];

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -32,6 +32,7 @@ Bugs Fixed
 
 - **API:** Fixed a bug in Transformers where the root request's ``fields`` and ``include`` query parameters leaked into nested transformers created inside ``include*()`` methods, causing incorrect field filtering, unexpected includes, or infinite recursion.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
+- **Filters:** Fixed a bug in ``InvalidChars`` filter where invalid UTF-8 or control characters in array keys were not checked.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
 


### PR DESCRIPTION
This PR fixes a bug in the `InvalidChars` filter where array keys were not being validated.
Previously, `checkControl()` used `array_map()`, which only applied the callback to the array's values while ignoring the array's keys entirely. Due to this, any control characters or invalid UTF-8 sequences passed through array keys (e.g. `$_POST['bad_key']`) bypassed the filter.