### PR TITLE
fix: preserve enclosing stream filter when using `MockInputOutput`

### DIFF
--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -93,6 +93,22 @@ class CITestStreamFilter extends php_user_filter
     }
 
     /**
+     * Whether an output filter is currently attached to STDOUT.
+     */
+    public static function hasOutputFilter(): bool
+    {
+        return self::$out !== null;
+    }
+
+    /**
+     * Whether an error filter is currently attached to STDERR.
+     */
+    public static function hasErrorFilter(): bool
+    {
+        return self::$err !== null;
+    }
+
+    /**
      * @param resource|null $stream
      *
      * @param-out null $stream

--- a/system/Test/Mock/MockInputOutput.php
+++ b/system/Test/Mock/MockInputOutput.php
@@ -36,6 +36,16 @@ final class MockInputOutput extends InputOutput
     private array $outputs = [];
 
     /**
+     * Snapshot of the shared CITestStreamFilter state captured before this
+     * object attaches its own filters, restored once it is done. Lets a test
+     * combine MockInputOutput with an enclosing StreamFilterTrait without the
+     * latter's filters being torn down.
+     *
+     * @var array{output: bool, error: bool, buffer: string}|null
+     */
+    private ?array $priorFilterState = null;
+
+    /**
      * Sets user inputs.
      *
      * @param list<string> $inputs
@@ -88,6 +98,12 @@ final class MockInputOutput extends InputOutput
 
     private function addStreamFilters(): void
     {
+        $this->priorFilterState = [
+            'output' => CITestStreamFilter::hasOutputFilter(),
+            'error'  => CITestStreamFilter::hasErrorFilter(),
+            'buffer' => CITestStreamFilter::$buffer,
+        ];
+
         CITestStreamFilter::registration();
         CITestStreamFilter::addOutputFilter();
         CITestStreamFilter::addErrorFilter();
@@ -97,6 +113,22 @@ final class MockInputOutput extends InputOutput
     {
         CITestStreamFilter::removeOutputFilter();
         CITestStreamFilter::removeErrorFilter();
+
+        if ($this->priorFilterState === null) {
+            return;
+        }
+
+        CITestStreamFilter::$buffer = $this->priorFilterState['buffer'];
+
+        if ($this->priorFilterState['output']) {
+            CITestStreamFilter::addOutputFilter();
+        }
+
+        if ($this->priorFilterState['error']) {
+            CITestStreamFilter::addErrorFilter();
+        }
+
+        $this->priorFilterState = null;
     }
 
     public function input(?string $prefix = null): string

--- a/tests/system/Test/Mock/MockInputOutputTest.php
+++ b/tests/system/Test/Mock/MockInputOutputTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Test\Mock;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class MockInputOutputTest extends CIUnitTestCase
+{
+    use StreamFilterTrait;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        CLI::resetInputOutput();
+    }
+
+    public function testFwriteThroughMockPreservesEnclosingStreamFilter(): void
+    {
+        CLI::write('before mock');
+        $this->assertStringContainsString('before mock', $this->getStreamFilterBuffer());
+
+        $io = new MockInputOutput();
+        CLI::setInputOutput($io);
+        CLI::write('through mock');
+        CLI::resetInputOutput();
+
+        // The mock captured its own write into its own buffer...
+        $this->assertStringContainsString('through mock', $io->getOutput());
+        // ...and left the enclosing StreamFilterTrait buffer untouched.
+        $this->assertStringNotContainsString('through mock', $this->getStreamFilterBuffer());
+
+        // The enclosing filter is still attached, so later writes are captured.
+        CLI::write('after mock');
+        $this->assertStringContainsString('before mock', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('after mock', $this->getStreamFilterBuffer());
+    }
+
+    public function testInputThroughMockPreservesEnclosingStreamFilter(): void
+    {
+        $io = new MockInputOutput();
+        $io->setInputs(['y']);
+        CLI::setInputOutput($io);
+        CLI::prompt('Continue?', ['y', 'n']);
+        CLI::resetInputOutput();
+
+        CLI::write('after prompt');
+        $this->assertStringContainsString('after prompt', $this->getStreamFilterBuffer());
+    }
+}

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -34,6 +34,7 @@ Bugs Fixed
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
+- **Testing:** Fixed a bug where using ``MockInputOutput`` within a test that also uses ``StreamFilterTrait`` tore down the trait's stream filters, so CLI output produced after the ``MockInputOutput`` interaction (such as in ``tearDown()``) was no longer captured and leaked to the console.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

When a test uses `MockInputOutput` while it (or its base) also uses `StreamFilterTrait`, the mock's internal `addStreamFilters()` / `removeStreamFilters()` calls tore down the trait's `STDOUT`/`STDERR` filters and left them removed. Any CLI output produced *after* the `MockInputOutput` interaction (for example in `tearDown()`) then bypassed capture and leaked to the console.

`MockInputOutput` now snapshots the shared `CITestStreamFilter` state (filter presence and buffer) before attaching its own filters and restores it afterward, so an enclosing `StreamFilterTrait` keeps capturing once the mock is done. Adds `CITestStreamFilter::hasOutputFilter()` / `hasErrorFilter()` accessors and a regression test covering both the `fwrite` and `input` paths.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide