### PR TITLE
fix: skip already-translated keys in `spark lang:find`

### DIFF
--- a/system/Commands/Translation/LocalizationFinder.php
+++ b/system/Commands/Translation/LocalizationFinder.php
@@ -133,13 +133,17 @@ class LocalizationFinder extends BaseCommand
                 $languageStoredKeys = require $languageFilePath;
             }
 
-            $languageDiff = ArrayHelper::recursiveDiff($foundLanguageKeys[$langFileName], $languageStoredKeys);
+            // Keys already resolvable from any namespace's language file (framework, packages, or app)
+            // are not new and must not be re-reported or written.
+            $resolvedKeys = $this->findResolvedTranslations($langFileName, $currentLocale);
+
+            $languageDiff = ArrayHelper::recursiveDiff($foundLanguageKeys[$langFileName], $resolvedKeys);
             $countNewKeys += ArrayHelper::recursiveCount($languageDiff);
 
             if ($this->showNew) {
                 $tableRows = array_merge($this->arrayToTableRows($langFileName, $languageDiff), $tableRows);
             } else {
-                $newLanguageKeys = array_replace_recursive($foundLanguageKeys[$langFileName], $languageStoredKeys);
+                $newLanguageKeys = array_replace_recursive($languageDiff, $languageStoredKeys);
 
                 if ($languageDiff !== []) {
                     if (file_put_contents($languageFilePath, $this->templateFile($newLanguageKeys)) === false) {
@@ -175,6 +179,35 @@ class LocalizationFinder extends BaseCommand
 
             CLI::table($tableBadRows, ['Bad Key', 'Filepath']);
         }
+    }
+
+    /**
+     * Loads the translations already resolvable for the given file and locale
+     * from every registered namespace (framework, packages, and app).
+     *
+     * @return array<string, mixed>
+     */
+    private function findResolvedTranslations(string $langFileName, string $currentLocale): array
+    {
+        $translations = [];
+
+        foreach (service('locator')->search("Language/{$currentLocale}/{$langFileName}.php", 'php', false) as $file) {
+            if (! is_file($file)) {
+                continue;
+            }
+
+            $keys = require $file;
+
+            if (is_array($keys)) {
+                $translations[] = $keys;
+            }
+        }
+
+        if ($translations === []) {
+            return [];
+        }
+
+        return array_replace_recursive(...$translations);
     }
 
     /**

--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -30,6 +30,7 @@ final class LocalizationFinderTest extends CIUnitTestCase
     private static string $locale;
     private static string $languageTestPath;
     private string $originalLocale;
+    private ?string $tempSourceDir = null;
 
     /**
      * @var list<string>
@@ -57,6 +58,7 @@ final class LocalizationFinderTest extends CIUnitTestCase
         parent::tearDown();
 
         $this->clearGeneratedFiles();
+        $this->clearSourceFixture();
         Locale::setDefault($this->originalLocale);
         config(App::class)->supportedLocales = $this->originalSupportedLocales;
     }
@@ -129,6 +131,39 @@ final class LocalizationFinderTest extends CIUnitTestCase
         command('lang:find --dir Translation --verbose');
 
         $this->assertStringContainsString($this->getActualTableWithBadKeys(), $this->getStreamFilterBuffer());
+    }
+
+    public function testShowNewSkipsKeysAlreadyTranslatedByFramework(): void
+    {
+        $this->makeLocaleDirectory();
+        $this->makeSourceFixture(
+            'ResolvedKeys',
+            "<?php\nlang('Errors.pageNotFound');\nlang('Errors.thisKeyIsBrandNew');\n",
+        );
+
+        command('lang:find --dir ResolvedKeys --show-new');
+
+        $buffer = $this->getStreamFilterBuffer();
+        $this->assertStringNotContainsString('Errors.pageNotFound', $buffer);
+        $this->assertStringContainsString('Errors.thisKeyIsBrandNew', $buffer);
+    }
+
+    public function testWriteSkipsKeysAlreadyTranslatedByFramework(): void
+    {
+        $this->makeLocaleDirectory();
+        $this->makeSourceFixture(
+            'ResolvedKeys',
+            "<?php\nlang('Errors.pageNotFound');\nlang('Errors.thisKeyIsBrandNew');\n",
+        );
+
+        command('lang:find --dir ResolvedKeys');
+
+        $generatedFile = self::$languageTestPath . self::$locale . '/Errors.php';
+        $this->assertFileExists($generatedFile);
+
+        $generatedKeys = require $generatedFile;
+        $this->assertArrayHasKey('thisKeyIsBrandNew', $generatedKeys);
+        $this->assertArrayNotHasKey('pageNotFound', $generatedKeys);
     }
 
     private function getActualTranslationOneKeys(): array
@@ -261,6 +296,32 @@ final class LocalizationFinderTest extends CIUnitTestCase
         @mkdir(self::$languageTestPath . self::$locale, 0777, true);
     }
 
+    private function makeSourceFixture(string $dirName, string $contents): void
+    {
+        $this->tempSourceDir = SUPPORTPATH . 'Services' . DIRECTORY_SEPARATOR . $dirName;
+        @mkdir($this->tempSourceDir, 0777, true);
+        file_put_contents($this->tempSourceDir . DIRECTORY_SEPARATOR . 'Source.php', $contents);
+    }
+
+    private function clearSourceFixture(): void
+    {
+        if ($this->tempSourceDir === null) {
+            return;
+        }
+
+        $sourceFile = $this->tempSourceDir . DIRECTORY_SEPARATOR . 'Source.php';
+
+        if (is_file($sourceFile)) {
+            unlink($sourceFile);
+        }
+
+        if (is_dir($this->tempSourceDir)) {
+            rmdir($this->tempSourceDir);
+        }
+
+        $this->tempSourceDir = null;
+    }
+
     private function clearGeneratedFiles(): void
     {
         if (is_file(self::$languageTestPath . self::$locale . '/TranslationOne.php')) {
@@ -273,6 +334,10 @@ final class LocalizationFinderTest extends CIUnitTestCase
 
         if (is_file(self::$languageTestPath . self::$locale . '/Translation-Four.php')) {
             unlink(self::$languageTestPath . self::$locale . '/Translation-Four.php');
+        }
+
+        if (is_file(self::$languageTestPath . self::$locale . '/Errors.php')) {
+            unlink(self::$languageTestPath . self::$locale . '/Errors.php');
         }
 
         if (is_dir(self::$languageTestPath . '/test_locale_incorrect')) {

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -31,6 +31,7 @@ Bugs Fixed
 **********
 
 - **API:** Fixed a bug in Transformers where the root request's ``fields`` and ``include`` query parameters leaked into nested transformers created inside ``include*()`` methods, causing incorrect field filtering, unexpected includes, or infinite recursion.
+- **Commands:** Fixed a bug where ``spark lang:find`` treated translation keys already provided by the framework or another namespace (such as ``Errors.*`` in ``system/Language``) as new, listing them under ``--show-new`` and writing untranslated placeholders into ``app/Language`` that overrode the existing translations.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -317,6 +317,10 @@ After the operation, you need to translate the language keys yourself.
 The command is able to recognize nested keys normally ``File.array.nested.text``.
 Previously saved keys do not change.
 
+.. note:: Keys that ``lang()`` can already resolve (for example ``Errors.*``
+    from **system/Language**) are treated as already translated, so they are
+    neither listed by ``--show-new`` nor written into **app/Language**.
+
 .. code-block:: console
 
     php spark lang:find


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

`spark lang:find` decided whether a key was "new" by loading only `app/Language/<locale>/<File>.php`. But at runtime `lang()` resolves a key through the FileLocator across **every** namespace (framework, packages, and app). As a result, keys already shipped by the framework or a package (for example `Errors.*` from `system/Language`) were treated as new:

- `--show-new` listed them as missing translations.
- In write mode they were materialized into `app/Language` as untranslated placeholders (the dotted key string), which then **overrode** the framework's real translations at runtime (e.g. error pages rendering the literal `Errors.pageNotFound`).

This PR makes the finder compare found keys against the translations resolvable from **all** namespaces, mirroring how `lang()` resolves at runtime. A key is now considered new only when it cannot be resolved from any loaded language file. Write mode writes only genuinely-new keys plus the app's own existing keys, so framework- or package-provided translations are never copied into `app/Language`.

Added regression tests for both the `--show-new` and write paths, and a note in the localization guide.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
