### PR TITLE
refactor: use SQL assertion helper in database tests

### DIFF
--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -39,7 +39,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testTableName(): void
@@ -49,7 +49,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testAliasSupportsArrayOfNames(): void
@@ -58,7 +58,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j", "users" "u"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testAliasSupportsStringOfNames(): void
@@ -67,7 +67,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j", "users" "u"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -82,7 +82,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "db_jobs" LEFT JOIN "db_users" as "u" ON "u"."id" = "db_jobs"."id"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -97,7 +97,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "db_jobs" LEFT JOIN "db_users" as "u" ON "db_users"."id" = "db_jobs"."id"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -113,6 +113,6 @@ final class AliasTest extends CIUnitTestCase
         $expectedSQL = <<<'SQL'
             SELECT * FROM "db_jobs" "j" WHERE "j"."name" LIKE '%veloper%' ESCAPE '!'
             SQL;
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -53,7 +53,7 @@ final class CountTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id:';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     public function testCountAllResultsDoesNotUseLockForUpdate(): void
@@ -65,8 +65,8 @@ final class CountTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id:';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame('SELECT * FROM "jobs" WHERE "id" > 3 FOR UPDATE', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT * FROM "jobs" WHERE "id" > 3 FOR UPDATE', $builder->getCompiledSelect(false));
     }
 
     public function testCountAllResultsWithSQLSRVDoesNotUseLockForUpdate(): void
@@ -80,8 +80,8 @@ final class CountTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "test"."dbo"."jobs" WHERE "id" > :id:';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame('SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) WHERE "id" > 3', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) WHERE "id" > 3', $builder->getCompiledSelect(false));
     }
 
     public function testCountAllResultsWithGroupBy(): void
@@ -94,7 +94,7 @@ final class CountTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT * FROM "jobs" WHERE "id" > :id: GROUP BY "id" ) CI_count_all_results';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     /**
@@ -110,11 +110,11 @@ final class CountTest extends CIUnitTestCase
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT "ci_jobs".* FROM "ci_jobs" WHERE "id" > :id: GROUP BY "id" ) CI_count_all_results';
 
         $answer1 = $builder->countAllResults(false);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer1));
+        $this->assertSameSql($expectedSQL, $answer1);
 
         // We run the query one more time to make sure the DBPrefix is added only once
         $answer2 = $builder->countAllResults(false);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer2));
+        $this->assertSameSql($expectedSQL, $answer2);
     }
 
     public function testCountAllResultsWithGroupByAndHaving(): void
@@ -128,7 +128,7 @@ final class CountTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT * FROM "jobs" WHERE "id" > :id: GROUP BY "id" HAVING 1 = 1 ) CI_count_all_results';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     public function testCountAllResultsWithHavingOnly(): void
@@ -141,6 +141,6 @@ final class CountTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id: HAVING 1 = 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 }

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -41,6 +41,6 @@ final class DistinctTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT DISTINCT "country" FROM "user"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -41,6 +41,6 @@ final class EmptyTest extends CIUnitTestCase
 
         $expectedSQL = 'DELETE FROM "jobs"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 }

--- a/tests/system/Database/Builder/ExistsTest.php
+++ b/tests/system/Database/Builder/ExistsTest.php
@@ -42,7 +42,7 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM "jobs" WHERE "id" > :id:  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     public function testDoesntExistReturnsSqlInTestMode(): void
@@ -54,7 +54,7 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM "jobs" WHERE "id" > :id:  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     public function testExistsDoesNotUseOrderByOrLockForUpdate(): void
@@ -69,11 +69,8 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM "jobs" WHERE "id" > :id:  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame(
-            'SELECT * FROM "jobs" WHERE "id" > 3 ORDER BY "id" DESC FOR UPDATE',
-            str_replace("\n", ' ', $builder->getCompiledSelect(false)),
-        );
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT * FROM "jobs" WHERE "id" > 3 ORDER BY "id" DESC FOR UPDATE', $builder->getCompiledSelect(false));
     }
 
     public function testExistsWithSQLSRVDoesNotUseOrderByOrLockForUpdate(): void
@@ -90,11 +87,8 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM "test"."dbo"."jobs" WHERE "id" > :id:  ORDER BY (SELECT NULL)  OFFSET 0  ROWS FETCH NEXT 1 ROWS ONLY ';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame(
-            'SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) WHERE "id" > 3 ORDER BY "id" DESC',
-            str_replace("\n", ' ', $builder->getCompiledSelect(false)),
-        );
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) WHERE "id" > 3 ORDER BY "id" DESC', $builder->getCompiledSelect(false));
     }
 
     public function testExistsHonorsExistingLimitAndOffset(): void
@@ -108,11 +102,8 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM ( SELECT * FROM "jobs" WHERE "id" > :id:  LIMIT 20, 10 ) CI_exists  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame(
-            'SELECT * FROM "jobs" WHERE "id" > 3  LIMIT 20, 10',
-            str_replace("\n", ' ', $builder->getCompiledSelect(false)),
-        );
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT * FROM "jobs" WHERE "id" > 3  LIMIT 20, 10', $builder->getCompiledSelect(false));
     }
 
     public function testExistsHonorsLimitZero(): void
@@ -131,7 +122,7 @@ final class ExistsTest extends CIUnitTestCase
 
             $expectedSQL = 'SELECT 1 FROM "jobs" WHERE "id" > :id:  LIMIT 0';
 
-            $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+            $this->assertSameSql($expectedSQL, $answer);
         } finally {
             $config->limitZeroAsAll = $limitZeroAsAll;
         }
@@ -150,11 +141,8 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM ( SELECT COUNT("id") AS "total" FROM "jobs" WHERE "id" > :id: GROUP BY "id" HAVING "total" > :total: ) CI_exists  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame(
-            'SELECT COUNT("id") AS "total" FROM "jobs" WHERE "id" > 3 GROUP BY "id" HAVING "total" > 1',
-            str_replace("\n", ' ', $builder->getCompiledSelect(false)),
-        );
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT COUNT("id") AS "total" FROM "jobs" WHERE "id" > 3 GROUP BY "id" HAVING "total" > 1', $builder->getCompiledSelect(false));
     }
 
     public function testExistsWithAggregateSelection(): void
@@ -168,11 +156,8 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM ( SELECT COUNT("id") AS "total" FROM "jobs" WHERE "id" > :id: ) CI_exists  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame(
-            'SELECT COUNT("id") AS "total" FROM "jobs" WHERE "id" > 3',
-            str_replace("\n", ' ', $builder->getCompiledSelect(false)),
-        );
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT COUNT("id") AS "total" FROM "jobs" WHERE "id" > 3', $builder->getCompiledSelect(false));
     }
 
     public function testExistsWithUnion(): void
@@ -184,11 +169,8 @@ final class ExistsTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT 1 FROM ( SELECT * FROM (SELECT * FROM "jobs") "uwrp0" UNION SELECT * FROM (SELECT * FROM "jobs") "uwrp1" ) CI_exists  LIMIT 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
-        $this->assertSame(
-            'SELECT * FROM (SELECT * FROM "jobs") "uwrp0" UNION SELECT * FROM (SELECT * FROM "jobs") "uwrp1"',
-            str_replace("\n", ' ', $builder->getCompiledSelect(false)),
-        );
+        $this->assertSameSql($expectedSQL, $answer);
+        $this->assertSameSql('SELECT * FROM (SELECT * FROM "jobs") "uwrp0" UNION SELECT * FROM (SELECT * FROM "jobs") "uwrp1"', $builder->getCompiledSelect(false));
     }
 
     public function testExistsResetsByDefault(): void
@@ -198,7 +180,7 @@ final class ExistsTest extends CIUnitTestCase
 
         $builder->where('id >', 3)->exists();
 
-        $this->assertSame('SELECT * FROM "jobs"', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql('SELECT * FROM "jobs"', $builder->getCompiledSelect(false));
         $this->assertSame([], $builder->getBinds());
     }
 
@@ -209,7 +191,7 @@ final class ExistsTest extends CIUnitTestCase
 
         $builder->where('id >', 3)->exists(false);
 
-        $this->assertSame('SELECT * FROM "jobs" WHERE "id" > 3', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql('SELECT * FROM "jobs" WHERE "id" > 3', $builder->getCompiledSelect(false));
         $this->assertSame([
             'id' => [
                 3,

--- a/tests/system/Database/Builder/ExplainTest.php
+++ b/tests/system/Database/Builder/ExplainTest.php
@@ -46,7 +46,7 @@ final class ExplainTest extends CIUnitTestCase
 
         $expectedSQL = 'EXPLAIN SELECT * FROM "jobs" WHERE "id" > 3';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     public function testSQLiteExplainUsesQueryPlanInTestMode(): void
@@ -58,7 +58,7 @@ final class ExplainTest extends CIUnitTestCase
 
         $expectedSQL = 'EXPLAIN QUERY PLAN SELECT * FROM "jobs" WHERE "id" > 3';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSameSql($expectedSQL, $answer);
     }
 
     public function testExplainResetsByDefault(): void
@@ -68,7 +68,7 @@ final class ExplainTest extends CIUnitTestCase
 
         $builder->where('id >', 3)->explain();
 
-        $this->assertSame('SELECT * FROM "jobs"', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql('SELECT * FROM "jobs"', $builder->getCompiledSelect(false));
         $this->assertSame([], $builder->getBinds());
     }
 
@@ -79,7 +79,7 @@ final class ExplainTest extends CIUnitTestCase
 
         $builder->where('id >', 3)->explain(false);
 
-        $this->assertSame('SELECT * FROM "jobs" WHERE "id" > 3', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql('SELECT * FROM "jobs" WHERE "id" > 3', $builder->getCompiledSelect(false));
         $this->assertSame([
             'id' => [
                 3,
@@ -96,7 +96,7 @@ final class ExplainTest extends CIUnitTestCase
         $builder = new BaseBuilder('jobs', $db);
 
         $this->assertFalse($builder->where('id >', 3)->explain());
-        $this->assertSame('SELECT * FROM "jobs"', str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql('SELECT * FROM "jobs"', $builder->getCompiledSelect(false));
         $this->assertSame([], $builder->getBinds());
     }
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -42,7 +42,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromThatOverwrites(): void
@@ -53,7 +53,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromWithMultipleTables(): void
@@ -64,7 +64,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromWithMultipleTablesAsString(): void
@@ -75,7 +75,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromReset(): void
@@ -86,23 +86,23 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedSQL = 'SELECT * FROM "user"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedSQL = 'SELECT *';
 
         $builder->from(null, true);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedSQL = 'SELECT * FROM "jobs"';
 
         $builder->from('jobs');
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromSubquery(): void
@@ -111,19 +111,19 @@ final class FromTest extends CIUnitTestCase
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias');
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") "users_1"';
         $subquery    = (new BaseBuilder('users', $this->db))->select('id, name');
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") "alias", "some_table"';
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias')->from('some_table');
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromWithMultipleTablesAsStringWithSQLSRV(): void
@@ -136,7 +136,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."user", "test"."dbo"."jobs", "test"."dbo"."roles"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testFromSubqueryWithSQLSRV(): void
@@ -151,7 +151,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs", (SELECT * FROM "test"."dbo"."users") "users_1"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -165,7 +165,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "database"."dbo"."table"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -179,6 +179,6 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."table"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -39,7 +39,7 @@ final class GetTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "users"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -43,7 +43,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingBy(): void
@@ -56,7 +56,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) > 2';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingBy(): void
@@ -70,7 +70,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" > 3 OR SUM(id) > 2';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     #[DataProvider('provideHavingBetweenMethods')]
@@ -94,7 +94,7 @@ final class GroupTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -121,7 +121,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "active" = 1 OR "total" ' . $sql . ' 10 AND 20';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -149,7 +149,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING   ( "total" BETWEEN 10 AND 20 OR "score" NOT BETWEEN 30 AND 40  ) AND "active" = 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingBetweenNoEscape(): void
@@ -172,7 +172,7 @@ final class GroupTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -211,7 +211,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (1,2)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingInClosure(): void
@@ -224,7 +224,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingIn(): void
@@ -238,7 +238,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (1,2) OR "group_id" IN (5,6)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingInClosure(): void
@@ -252,7 +252,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3) OR "group_id" IN (SELECT "group_id" FROM "groups" WHERE "group_id" = 6)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingNotIn(): void
@@ -265,7 +265,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (1,2)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingNotInClosure(): void
@@ -278,7 +278,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingNotIn(): void
@@ -292,7 +292,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (1,2) OR "group_id" NOT IN (5,6)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingNotInClosure(): void
@@ -306,7 +306,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3) OR "group_id" NOT IN (SELECT "group_id" FROM "groups" WHERE "group_id" = 6)';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingLike(): void
@@ -319,7 +319,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingLikeBefore(): void
@@ -332,7 +332,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingLikeAfter(): void
@@ -345,7 +345,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testNotHavingLike(): void
@@ -358,7 +358,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'%a%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testNotHavingLikeBefore(): void
@@ -371,7 +371,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'%a\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testNotHavingLikeAfter(): void
@@ -384,7 +384,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'a%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingLike(): void
@@ -398,7 +398,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\' OR  "pet_color" LIKE \'%b%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingLikeBefore(): void
@@ -412,7 +412,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\' OR  "pet_color" LIKE \'%b\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrHavingLikeAfter(): void
@@ -426,7 +426,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\' OR  "pet_color" LIKE \'b%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrNotHavingLike(): void
@@ -440,7 +440,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'%b%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrNotHavingLikeBefore(): void
@@ -454,7 +454,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'%b\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrNotHavingLikeAfter(): void
@@ -468,7 +468,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'b%\' ESCAPE \'!\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingAndGroup(): void
@@ -485,7 +485,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 AND   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testHavingOrGroup(): void
@@ -502,7 +502,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) > 3 OR   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testNotHavingAndGroup(): void
@@ -519,7 +519,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 AND NOT   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testNotHavingOrGroup(): void
@@ -536,7 +536,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 OR NOT   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testAndGroups(): void
@@ -551,7 +551,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE   ( "id" > 3 AND "name" != \'Luke\'  ) AND "name" = \'Darth\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrGroups(): void
@@ -566,7 +566,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' OR   ( "id" > 3 AND "name" != \'Luke\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testNotGroups(): void
@@ -581,7 +581,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' AND NOT   ( "id" > 3 AND "name" != \'Luke\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrNotGroups(): void
@@ -596,6 +596,6 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' OR NOT   ( "id" > 3 AND "name" != \'Luke\'  )';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -62,7 +62,7 @@ final class InsertTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledInsert());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -77,7 +77,7 @@ final class InsertTest extends CIUnitTestCase
 
         $expectedSQL = 'INSERT INTO "jobs" ("id", "status") VALUES (1, \'active\')';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledInsert());
     }
 
     public function testInsertObjectWithBackedEnum(): void
@@ -91,7 +91,7 @@ final class InsertTest extends CIUnitTestCase
 
         $expectedSQL = 'INSERT INTO "jobs" ("id", "status") VALUES (1, \'active\')';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledInsert());
     }
 
     public function testInsertObject(): void
@@ -116,7 +116,7 @@ final class InsertTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledInsert());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -132,7 +132,7 @@ final class InsertTest extends CIUnitTestCase
 
         $expectedSQL = 'INSERT INTO "jobs" ("id", "name") VALUES (1, CONCAT("id", \'Grocery Sales\'))';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledInsert());
     }
 
     /**
@@ -160,7 +160,7 @@ final class InsertTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledInsert());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -200,10 +200,10 @@ final class InsertTest extends CIUnitTestCase
         $raw = <<<'SQL'
             INSERT INTO "jobs" ("description", "id", "name") VALUES ('There''s something in your teeth',2,'Commedian'), ('I am yellow',3,'Cab Driver')
             SQL;
-        $this->assertSame($raw, str_replace("\n", ' ', $query->getOriginalQuery()));
+        $this->assertSameSql($raw, $query->getOriginalQuery());
 
         $expected = "INSERT INTO \"jobs\" (\"description\", \"id\", \"name\") VALUES ('There''s something in your teeth',2,'Commedian'), ('I am yellow',3,'Cab Driver')";
-        $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
+        $this->assertSameSql($expected, $query->getQuery());
     }
 
     /**
@@ -235,12 +235,12 @@ final class InsertTest extends CIUnitTestCase
         $raw = <<<'SQL'
             INSERT IGNORE INTO "jobs" ("description", "id", "name") VALUES ('I am yellow',3,'Cab Driver')
             SQL;
-        $this->assertSame($raw, str_replace("\n", ' ', $query->getOriginalQuery()));
+        $this->assertSameSql($raw, $query->getOriginalQuery());
 
         $expected = <<<'SQL'
             INSERT IGNORE INTO "jobs" ("description", "id", "name") VALUES ('I am yellow',3,'Cab Driver')
             SQL;
-        $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
+        $this->assertSameSql($expected, $query->getQuery());
     }
 
     public function testInsertBatchWithoutEscape(): void
@@ -267,7 +267,7 @@ final class InsertTest extends CIUnitTestCase
         $this->assertInstanceOf(Query::class, $query);
 
         $expected = 'INSERT INTO "jobs" ("description", "id", "name") VALUES (1 + 2,2,1 + 1), (2 + 2,3,2 + 1)';
-        $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
+        $this->assertSameSql($expected, $query->getQuery());
     }
 
     /**
@@ -291,7 +291,7 @@ final class InsertTest extends CIUnitTestCase
         $this->assertInstanceOf(Query::class, $query);
 
         $expected = "INSERT INTO \"ip_table\" (\"ip\", \"ip2\") VALUES ('1.1.1.0','1.1.1.2'), ('2.2.2.0','2.2.2.2'), ('3.3.3.0','3.3.3.2'), ('4.4.4.0','4.4.4.2')";
-        $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
+        $this->assertSameSql($expected, $query->getQuery());
     }
 
     public function testInsertBatchThrowsExceptionOnNoData(): void

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -44,7 +44,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" JOIN "job" ON "user"."id" = "job"."id"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testJoinIsNull(): void
@@ -55,7 +55,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "table1" JOIN "table2" ON "field" IS NULL';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testJoinIsNotNull(): void
@@ -66,7 +66,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "table1" JOIN "table2" ON "field" IS NOT NULL';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testJoinMultipleConditions(): void
@@ -77,7 +77,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = "SELECT * FROM \"table1\" LEFT JOIN \"table2\" ON \"table1\".\"field1\" = \"table2\".\"field2\" AND \"table1\".\"field1\" = 'foo' AND \"table2\".\"field2\" = 0";
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -96,7 +96,7 @@ final class JoinTest extends CIUnitTestCase
         // @TODO Should be `... CURDATE() BETWEEN "lease_start_date" AND "lease_exp_date"`
         $expectedSQL = 'SELECT * FROM "table1" LEFT JOIN "leases" ON "units"."unit_id" = "leases"."unit_id" AND CURDATE() BETWEEN lease_start_date AND lease_exp_date';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -129,7 +129,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" FULL OUTER JOIN "users" as "u" ON "users"."id" = "jobs"."id"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testJoinWithAlias(): void
@@ -142,7 +142,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs" LEFT JOIN "test"."dbo"."users" "u" ON "u"."id" = "jobs"."id"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testSqlsrvJoinMultipleConditions(): void
@@ -155,7 +155,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs" LEFT JOIN "test"."dbo"."users" "u" ON "u"."id" = "jobs"."id" AND "u"."status" = \'active\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testSqlsrvJoinRawSql(): void
@@ -168,6 +168,6 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs" LEFT JOIN "test"."dbo"."users" "u" ON u.id = jobs.id AND u.deleted_at IS NULL';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -50,7 +50,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -191,7 +191,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -209,7 +209,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -227,7 +227,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -245,7 +245,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -267,7 +267,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -285,7 +285,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -307,7 +307,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -325,7 +325,7 @@ final class LikeTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -348,7 +348,7 @@ final class LikeTest extends CIUnitTestCase
                 true,
             ],
         ];
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 }

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -41,7 +41,7 @@ final class LimitTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user"  LIMIT 5';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testLimitAndOffset(): void
@@ -52,7 +52,7 @@ final class LimitTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user"  LIMIT 1, 5';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testLimitAndOffsetMethod(): void
@@ -63,6 +63,6 @@ final class LimitTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user"  LIMIT 1, 5';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -41,7 +41,7 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" ORDER BY "name" ASC';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrderDescending(): void
@@ -52,7 +52,7 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" ORDER BY "name" DESC';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrderRandom(): void
@@ -63,7 +63,7 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" ORDER BY RAND()';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrderRandomWithRandomColumn(): void
@@ -76,6 +76,6 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "fail_user" ORDER BY "SYSTEM"."RANDOM"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -48,7 +48,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectOnlyOneColumn(): void
@@ -59,7 +59,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectAcceptsArray(): void
@@ -70,7 +70,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     /**
@@ -83,7 +83,7 @@ final class SelectTest extends CIUnitTestCase
 
         $builder->select($select);
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     /**
@@ -140,7 +140,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectKeepsAliases(): void
@@ -151,7 +151,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" as "myRole" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectWorksWithComplexSelects(): void
@@ -162,7 +162,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT (SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectNullAsInString(): void
@@ -173,7 +173,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT NULL as field_alias, "name" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectNullAsInArray(): void
@@ -184,7 +184,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT NULL as field_alias, "name" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     /**
@@ -198,7 +198,7 @@ final class SelectTest extends CIUnitTestCase
         $builder->select(new RawSql($sql));
 
         $expected = 'SELECT ' . $sql . ' FROM "users"';
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     /**
@@ -212,7 +212,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "numericValue1" + "numericValue2" AS "numericResult" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     /**
@@ -242,7 +242,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MIN("payments") AS "payments" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectMinWithAlias(): void
@@ -253,7 +253,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MIN("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectMaxWithNoAlias(): void
@@ -264,7 +264,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MAX("payments") AS "payments" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectMaxWithAlias(): void
@@ -275,7 +275,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MAX("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectAvgWithNoAlias(): void
@@ -286,7 +286,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT AVG("payments") AS "payments" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectAvgWithAlias(): void
@@ -297,7 +297,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT AVG("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectSumWithNoAlias(): void
@@ -308,7 +308,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT SUM("payments") AS "payments" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectSumWithAlias(): void
@@ -319,7 +319,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT SUM("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectCountWithNoAlias(): void
@@ -330,7 +330,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT COUNT("payments") AS "payments" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectCountWithAlias(): void
@@ -341,7 +341,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT COUNT("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectMinThrowsExceptionOnEmptyValue(): void
@@ -362,7 +362,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MAX("db"."payments") AS "payments" FROM "invoices"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectMinThrowsExceptionOnMultipleColumn(): void
@@ -383,7 +383,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "test"."dbo"."users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testLockForUpdate(): void
@@ -394,7 +394,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "users" WHERE "id" = 1 ORDER BY "id" ASC  LIMIT 1 FOR UPDATE';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testLockForUpdatePersistsWhenSelectIsNotReset(): void
@@ -405,8 +405,8 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "users" FOR UPDATE';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect(false)));
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql($expected, $builder->getCompiledSelect(false));
+        $this->assertSameSql($expected, $builder->getCompiledSelect(false));
     }
 
     public function testLockForUpdateResetsWithSelect(): void
@@ -415,8 +415,8 @@ final class SelectTest extends CIUnitTestCase
 
         $builder->lockForUpdate();
 
-        $this->assertSame('SELECT * FROM "users" FOR UPDATE', str_replace("\n", ' ', $builder->getCompiledSelect()));
-        $this->assertSame('SELECT * FROM "users"', str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql('SELECT * FROM "users" FOR UPDATE', $builder->getCompiledSelect());
+        $this->assertSameSql('SELECT * FROM "users"', $builder->getCompiledSelect());
     }
 
     public function testLockForUpdateThrowsExceptionWithUnion(): void
@@ -462,7 +462,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "users" FOR UPDATE';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->lockForUpdate()->getCompiledSelect());
     }
 
     public function testLockForUpdateThrowsExceptionWithOCI8Limit(): void
@@ -494,7 +494,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "users" FOR UPDATE';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->lockForUpdate()->getCompiledSelect());
     }
 
     #[DataProvider('provideLockForUpdateUnsupportedSelectClauses')]
@@ -553,7 +553,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "test"."dbo"."users" WITH (UPDLOCK, ROWLOCK)';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->lockForUpdate()->getCompiledSelect());
     }
 
     public function testLockForUpdateWithSQLSRVAlias(): void
@@ -564,7 +564,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "test"."dbo"."users" "u" WITH (UPDLOCK, ROWLOCK)';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->lockForUpdate()->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->lockForUpdate()->getCompiledSelect());
     }
 
     public function testLockForUpdateWithSQLSRVLimit(): void
@@ -590,7 +590,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "test"."dbo"."jobs" WITH (UPDLOCK, ROWLOCK) LEFT JOIN "test"."dbo"."users" "u" ON "u"."id" = "jobs"."id"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testLockForUpdateThrowsExceptionOnSQLSRVWithoutFromTable(): void
@@ -632,7 +632,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", (SELECT "name" FROM "countries" WHERE "id" = 1) "country" FROM "users"';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 
     public function testSelectResetQuery(): void
@@ -643,10 +643,7 @@ final class SelectTest extends CIUnitTestCase
         $builder->resetQuery();
 
         $sql = $builder->getCompiledSelect();
-        $this->assertSame(
-            'SELECT * FROM "users"',
-            str_replace("\n", ' ', $sql),
-        );
+        $this->assertSameSql('SELECT * FROM "users"', $sql);
     }
 
     /**
@@ -660,12 +657,12 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" FROM "users" ORDER BY "name" DESC';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+        $this->assertSameSql($expected, $builder->getCompiledSelect(false));
 
         $builder->orderBy('role', 'desc');
 
         $expected = 'SELECT "name", "role" FROM "users" ORDER BY "name" DESC, "role" DESC';
 
-        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expected, $builder->getCompiledSelect());
     }
 }

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -57,7 +57,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -80,7 +80,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -102,7 +102,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -124,7 +124,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -146,7 +146,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -168,7 +168,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -198,7 +198,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -366,7 +366,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -392,7 +392,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -417,7 +417,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -441,7 +441,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -467,7 +467,7 @@ final class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledUpdate());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 }

--- a/tests/system/Database/Builder/WhenTest.php
+++ b/tests/system/Database/Builder/WhenTest.php
@@ -42,14 +42,14 @@ final class WhenTest extends CIUnitTestCase
         $builder = $this->db->table('jobs');
 
         $expectedSQL = 'SELECT * FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $builder = $builder->when(true, static function ($query): void {
             $query->select('id');
         });
 
         $expectedSQL = 'SELECT "id" FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenTruthy(): void
@@ -61,7 +61,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT "id" FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenRunsDefaultWhenFalse(): void
@@ -75,7 +75,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT "name" FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenDoesntModifyWhenFalse(): void
@@ -87,7 +87,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT * FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenPassesParemeters(): void
@@ -100,7 +100,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "name" = \'developer\'';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     #[DataProvider('provideConditionValues')]
@@ -117,7 +117,7 @@ final class WhenTest extends CIUnitTestCase
         $expected    = $expectDefault ? 'name' : 'id';
         $expectedSQL = 'SELECT "' . $expected . '" FROM "jobs"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenNotFalse(): void
@@ -125,14 +125,14 @@ final class WhenTest extends CIUnitTestCase
         $builder = $this->db->table('jobs');
 
         $expectedSQL = 'SELECT * FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $builder = $builder->whenNot(false, static function ($query): void {
             $query->select('id');
         });
 
         $expectedSQL = 'SELECT "id" FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenNotFalsey(): void
@@ -144,7 +144,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT "id" FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenNotRunsDefaultWhenTrue(): void
@@ -158,7 +158,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT "name" FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenNotDoesntModifyWhenFalse(): void
@@ -170,7 +170,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT * FROM "jobs"';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhenNotPassesParemeters(): void
@@ -183,7 +183,7 @@ final class WhenTest extends CIUnitTestCase
         });
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "name" = \'0\'';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     #[DataProvider('provideConditionValues')]
@@ -200,7 +200,7 @@ final class WhenTest extends CIUnitTestCase
         $expected    = $expectDefault ? 'id' : 'name';
         $expectedSQL = 'SELECT "' . $expected . '" FROM "jobs"';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -59,7 +59,7 @@ final class WhereTest extends CIUnitTestCase
         ];
 
         $builder->where('id', 3);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -76,7 +76,7 @@ final class WhereTest extends CIUnitTestCase
         ];
 
         $builder->where('id', 3, false);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -93,7 +93,7 @@ final class WhereTest extends CIUnitTestCase
         ];
 
         $builder->where('id !=', 3);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -119,7 +119,7 @@ final class WhereTest extends CIUnitTestCase
         ];
 
         $builder->where($where);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -135,7 +135,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedBinds = [];
 
         $builder->where($where);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -150,7 +150,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where($where);
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "id" < 100 AND "col1" LIKE \'%gmail%\'';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -164,7 +164,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where($key, $value);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -210,7 +210,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedBinds = [];
 
         $builder->where($where);
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -222,7 +222,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where($where, null, false);
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedBinds = [];
         $this->assertSame($expectedBinds, $builder->getBinds());
@@ -236,7 +236,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where($where, "''", false);
 
         $expectedSQL = "SELECT * FROM \"jobs\" WHERE REPLACE(column, 'somestring', '') = ''";
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedBinds = [
             "REPLACE(column, 'somestring', '')" => [
@@ -255,7 +255,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where($where, null, false);
 
         $expectedSQL = "SELECT * FROM \"jobs\" WHERE created_on BETWEEN '2022-07-01 00:00:00' AND '2022-12-31 23:59:59'";
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         $expectedBinds = [];
         $this->assertSame($expectedBinds, $builder->getBinds());
@@ -271,7 +271,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL   = "SELECT * FROM \"jobs\" WHERE id > 2 AND name != 'Accountant'";
         $expectedBinds = [];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -344,7 +344,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where('advance_amount <', static fn (BaseBuilder $builder) => $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         // Builder
         $builder = $this->db->table('neworder');
@@ -355,7 +355,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where('advance_amount <', $subQuery);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrWhere(): void
@@ -376,7 +376,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -398,7 +398,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -410,7 +410,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "status" = \'active\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereBetweenWithBackedEnums(): void
@@ -421,7 +421,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "role" BETWEEN 0 AND 2';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     #[DataProvider('provideWhereColumnWithOperators')]
@@ -434,7 +434,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL   = sprintf('SELECT * FROM "users" WHERE "created_at" %s "updated_at"', $operator);
         $expectedBinds = [];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -464,7 +464,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL   = 'SELECT * FROM "users" "u" WHERE "u"."updated_at" > "u"."created_at"';
         $expectedBinds = [];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -483,7 +483,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -499,7 +499,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "users" WHERE   ( "created_at" = "updated_at" OR "updated_at" > "created_at"  ) AND "active" = 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereColumnNoEscape(): void
@@ -511,7 +511,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL   = 'SELECT * FROM "users" WHERE LOWER(users.email) = normalized_email';
         $expectedBinds = [];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -524,7 +524,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL   = 'SELECT * FROM "users" WHERE "created_at" = "like"';
         $expectedBinds = [];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -537,7 +537,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL   = 'SELECT * FROM "users" WHERE JSON_EXTRACT(data, \'$.a>b\') = updated_at';
         $expectedBinds = [];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -573,7 +573,7 @@ final class WhereTest extends CIUnitTestCase
             ->from('orders')
             ->whereColumn('orders.user_id', 'users.id'));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         // Builder
         $builder = $this->db->table('users');
@@ -584,7 +584,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->whereExists($subQuery);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     #[DataProvider('provideWhereExistsVariants')]
@@ -599,7 +599,7 @@ final class WhereTest extends CIUnitTestCase
             ->from('orders')
             ->whereColumn('orders.user_id', 'users.id'));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -636,7 +636,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "users" WHERE   ( EXISTS (SELECT 1 FROM "orders" WHERE "orders"."user_id" = "users"."id") OR NOT EXISTS (SELECT 1 FROM "jobs" WHERE "jobs"."user_id" = "users"."id")  ) AND "active" = 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereExistsWithOuterAndInnerBinds(): void
@@ -658,7 +658,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -715,7 +715,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -740,7 +740,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "active" = 1 OR "created_at" ' . $sql . " '2026-01-01' AND '2026-01-31'";
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -766,7 +766,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE   ( "created_at" BETWEEN \'2026-01-01\' AND \'2026-01-31\' OR "updated_at" NOT BETWEEN \'2026-02-01\' AND \'2026-02-28\'  ) AND "active" = 1';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereBetweenNoEscape(): void
@@ -787,7 +787,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -800,7 +800,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "users" "u" WHERE "u"."created_at" BETWEEN \'2026-01-01\' AND \'2026-01-31\'';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -859,7 +859,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -871,7 +871,7 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "status" IN (\'active\',\'inactive\')';
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereInSubQuery(): void
@@ -883,7 +883,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->whereIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         // Builder
         $builder = $this->db->table('jobs');
@@ -894,7 +894,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->whereIn('id', $subQuery);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -955,7 +955,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -968,7 +968,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->whereNotIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         // Builder
         $builder = $this->db->table('jobs');
@@ -979,7 +979,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->whereNotIn('id', $subQuery);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrWhereIn(): void
@@ -1003,7 +1003,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -1016,7 +1016,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where('deleted_at', null)->orWhereIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         // Builder
         $builder = $this->db->table('jobs');
@@ -1027,7 +1027,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where('deleted_at', null)->orWhereIn('id', $subQuery);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testOrWhereNotIn(): void
@@ -1051,7 +1051,7 @@ final class WhereTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
@@ -1064,7 +1064,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where('deleted_at', null)->orWhereNotIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
 
         // Builder
         $builder = $this->db->table('jobs');
@@ -1075,7 +1075,7 @@ final class WhereTest extends CIUnitTestCase
 
         $builder->where('deleted_at', null)->orWhereNotIn('id', $subQuery);
 
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -1087,7 +1087,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where('LOWER(jobs.name)', 'accountant');
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE LOWER(jobs.name) = \'accountant\'';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereValueIsString(): void
@@ -1099,7 +1099,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL = <<<'SQL'
             SELECT * FROM "users" WHERE "id" = '1'
             SQL;
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     public function testWhereValueIsFloat(): void
@@ -1111,7 +1111,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL = <<<'SQL'
             SELECT * FROM "users" WHERE "id" = 1.234
             SQL;
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -1126,7 +1126,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where('id', true);
 
         $expectedSQL = 'SELECT * FROM "users" WHERE "id" = 1';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -1141,7 +1141,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where('id', false);
 
         $expectedSQL = 'SELECT * FROM "users" WHERE "id" = 0';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -1157,7 +1157,7 @@ final class WhereTest extends CIUnitTestCase
         $expectedSQL = <<<'SQL'
             SELECT * FROM "users" WHERE "id" = ('a','b')
             SQL;
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**
@@ -1197,7 +1197,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->where('id', null);
 
         $expectedSQL = 'SELECT * FROM "users" WHERE "id" IS NULL';
-        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSameSql($expectedSQL, $builder->getCompiledSelect());
     }
 
     /**

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -92,6 +92,6 @@ final class OrderTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM ' . $table . ' ORDER BY ' . $key;
 
-        $this->assertSame($expected, str_replace("\n", ' ', $sql));
+        $this->assertSameSql($expected, $sql);
     }
 }


### PR DESCRIPTION
**Description**

Follow-up to #10299.

This PR replaces direct SQL equality assertions with the new `assertSameSql()` helper.

A few non-direct cases were left unchanged, such as assertions with extra normalization, prefix checks, or test-mode return types that are not statically plain strings.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide