### PR TITLE
refactor: move `ValidatedInput` to the `Input` namespace

### DIFF
--- a/structarmed.php
+++ b/structarmed.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use CodeIgniter\Cache\ResponseCache;
 use CodeIgniter\HTTP\CLIRequest;
-use CodeIgniter\HTTP\FormRequest;
 use CodeIgniter\HTTP\Header;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SSEResponse;
@@ -27,7 +26,6 @@ use CodeIgniter\Entity\Cast\URICast;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Log\Handlers\ChromeLoggerHandler;
 use CodeIgniter\Security\CheckPhpIni;
-use CodeIgniter\Validation\ValidatedInput;
 use CodeIgniter\View\Table;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\View\Plugins;
@@ -101,6 +99,7 @@ return Architecture::define()
         'Filters'       => ['HTTP'],
         'Honeypot'      => ['Filters', 'HTTP'],
         'HTTP'          => ['Cookie', 'Files', 'I18n', 'Input', 'Security', 'URI'],
+        'Input'         => ['I18n'],
         'Images'        => ['Files', 'I18n'],
         'Lock'          => ['Cache'],
         'Model'         => ['Database', 'DataCaster', 'DataConverter', 'Entity', 'I18n', 'Pager', 'Validation'],
@@ -135,9 +134,6 @@ return Architecture::define()
     ])
     ->skipClassViolation(URICast::class, [
         URI::class,
-    ])
-    ->skipClassViolation(FormRequest::class, [
-        ValidatedInput::class,
     ])
     ->skipClassViolation(ChromeLoggerHandler::class, [
         ResponseInterface::class,

--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Exceptions\RuntimeException;
-use CodeIgniter\Validation\ValidatedInput;
+use CodeIgniter\Input\ValidatedInput;
 use ReflectionNamedType;
 use ReflectionParameter;
 

--- a/system/Input/InputDataFactory.php
+++ b/system/Input/InputDataFactory.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Input;
 
-use CodeIgniter\Validation\ValidatedInput;
-
 /**
  * @see \CodeIgniter\Input\InputDataFactoryTest
  */

--- a/system/Input/ValidatedInput.php
+++ b/system/Input/ValidatedInput.php
@@ -11,11 +11,10 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Validation;
+namespace CodeIgniter\Input;
 
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Input\InputData;
 use DateTimeZone;
 use Exception;
 use ReflectionEnum;
@@ -27,7 +26,7 @@ use UnitEnum;
  * This class is stricter than InputData: missing values may use defaults and
  * null values remain null, but invalid present values throw.
  *
- * @see \CodeIgniter\Validation\ValidatedInputTest
+ * @see \CodeIgniter\Input\ValidatedInputTest
  */
 class ValidatedInput extends InputData
 {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -21,6 +21,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\Input\ValidatedInput;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use CodeIgniter\View\RendererInterface;
 

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Validation;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\Input\ValidatedInput;
 
 /**
  * Expected behavior of a validator

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -15,10 +15,10 @@ namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\RuntimeException;
+use CodeIgniter\Input\ValidatedInput;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
-use CodeIgniter\Validation\ValidatedInput;
 use Config\App;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;

--- a/tests/system/Input/InputDataFactoryTest.php
+++ b/tests/system/Input/InputDataFactoryTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Input;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Validation\ValidatedInput;
 use PHPUnit\Framework\Attributes\Group;
 
 /**

--- a/tests/system/Input/ValidatedInputTest.php
+++ b/tests/system/Input/ValidatedInputTest.php
@@ -11,11 +11,10 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Validation;
+namespace CodeIgniter\Input;
 
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Input\InputData;
 use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Enum\ColorEnum;

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -19,6 +19,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Input\ValidatedInput;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -54,7 +54,7 @@ update your implementations to include the new methods or method changes to ensu
 - **Database:** ``CodeIgniter\Database\ConnectionInterface`` now requires the ``afterCommit()``, ``afterRollback()``, ``inTransaction()``, and ``transaction()`` methods.
 - **Logging:** ``CodeIgniter\Log\Handlers\HandlerInterface::handle()`` now requires a third parameter ``array $context = []``. Any custom log handler that overrides ``handle()`` - whether implementing ``HandlerInterface`` directly or extending a built-in handler class - must add the parameter to its ``handle()`` method signature.
 - **Security:** The ``SecurityInterface``'s ``verify()`` method now has a native return type of ``static``.
-- **Validation:** ``CodeIgniter\Validation\ValidationInterface`` now requires the ``getValidatedInput()`` method, which returns a ``CodeIgniter\Validation\ValidatedInput`` instance.
+- **Validation:** ``CodeIgniter\Validation\ValidationInterface`` now requires the ``getValidatedInput()`` method, which returns a ``CodeIgniter\Input\ValidatedInput`` instance.
 
 Method Signature Changes
 ========================
@@ -333,7 +333,7 @@ Others
 ======
 
 - **Float and Double Casting:** Added support for precision and rounding mode when casting to float or double in entities.
-- Added ``CodeIgniter\Input\InputData`` and ``InputDataFactory`` for reusable typed input data objects.
+- Added ``CodeIgniter\Input\InputData``, ``ValidatedInput``, and ``InputDataFactory`` for reusable typed input data objects.
 - Float and Double casting now throws ``CastException::forInvalidFloatRoundingMode()`` if an rounding mode other than up, down, even or odd is provided.
 - **Filters:** Added ``RequestId`` filter for request tracing and correlation logging. The filter stores the request ID in the request context and automatically adds the ``X-Request-ID`` response header. Incoming ``X-Request-ID`` headers are used when valid. See :ref:`requestid` for details.
 - **Environment:** Added ``CodeIgniter\EnvironmentDetector`` class and corresponding ``environment`` service as a mockable wrapper around the ``ENVIRONMENT`` constant.

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -484,7 +484,7 @@ Typed Validated Input
 ---------------------
 
 ``getValidatedInput()`` returns the same validated data as a
-``CodeIgniter\Validation\ValidatedInput`` object. Use it after validation
+``CodeIgniter\Input\ValidatedInput`` object. Use it after validation
 succeeds when you want to read common controller values as strings, integers,
 floats, booleans, arrays, dates, or enums:
 


### PR DESCRIPTION
**Description**
This PR moves `ValidatedInput` from `CodeIgniter\Validation` to `CodeIgniter\Input`. The class is a typed input data object, not a validator or a validation rule, so it belongs with the other input types. Validation and FormRequest still expose validated data through `getValidatedInput()`. The difference is that the returned object now sits next to `InputData` and `InputDataFactory` instead of among the validation classes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
