### PR TITLE
fix: Unify casing in BaseService::injectMock

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -442,8 +442,9 @@ class BaseService
      */
     public static function injectMock(string $name, $mock)
     {
-        static::$instances[$name]         = $mock;
-        static::$mocks[strtolower($name)] = $mock;
+        $name                     = strtolower($name);
+        static::$instances[$name] = $mock;
+        static::$mocks[$name]     = $mock;
     }
 
     /**


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
The BaseService::injectMock method only applied the strtolower function to the name in regard to the mock-list, but not to the instance-list: 
```php
public static function injectMock(string $name, $mock)
{
    static::$instances[$name]         = $mock;
    static::$mocks[strtolower($name)] = $mock;
}
```

Every other method in the BaseService applies strtolower to the name argument before doing anything else, e.g. resetSingle:
```php
public static function resetSingle(string $name)
{
    $name = strtolower($name);
    unset(static::$mocks[$name], static::$instances[$name]);
}
```
... or getSharedInstance:
```php
protected static function getSharedInstance(string $key, ...$params)
{
    $key = strtolower($key);

    // Returns mock if exists
    if (isset(static::$mocks[$key])) {
        return static::$mocks[$key];
    }

    if (! isset(static::$instances[$key])) {
        // Make sure $getShared is false
        $params[] = false;

        static::$instances[$key] = AppServices::$key(...$params);
    }

    return static::$instances[$key];
}
```

This results in two different instance entries when injectMock gets called with "fooBar" and with "foobar" respectively, but only one of them (namely "foobar") is ever to be resolved or reset again. 
When not using all-lowercase while calling injectMock, any existing instance that is meant to be replaced is therefore not being replaced. 

<img width="549" height="51" alt="image" src="https://github.com/user-attachments/assets/1da56629-f026-49b2-9236-73fd38c1dcbf" />


**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
