### PR TITLE
fix: Catch ValueError from hex2bin() in Security::derandomize() on PHP 8

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -27,6 +27,7 @@ use Config\Security as SecurityConfig;
 use ErrorException;
 use JsonException;
 use SensitiveParameter;
+use ValueError;
 
 /**
  * Class Security
@@ -419,7 +420,7 @@ class Security implements SecurityInterface
 
         try {
             return bin2hex((string) hex2bin($value) ^ (string) hex2bin($key));
-        } catch (ErrorException $e) {
+        } catch (ErrorException|ValueError $e) {
             // "hex2bin(): Hexadecimal input string must have an even length"
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Security;
 
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
@@ -418,5 +419,16 @@ final class SecurityTest extends CIUnitTestCase
         yield 'missing_token_in_body' => [self::createIncomingRequest()->setBody('other=value&another=test')];
 
         yield 'invalid_form_data' => [self::createIncomingRequest()->setBody('csrf_test_name[]=invalid')];
+    }
+
+    public function testDerandomizeThrowsInvalidArgumentExceptionOnInvalidHex(): void
+    {
+        $security    = $this->createMockSecurity();
+        $derandomize = self::getPrivateMethodInvoker($security, 'derandomize');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        // 'G' is not a valid hexadecimal character, which will trigger hex2bin's ValueError/Warning
+        $derandomize(str_repeat('G', 64));
     }
 }


### PR DESCRIPTION
**Description**
This PR fixes an issue where providing a malformed CSRF token crashes the application on newer PHP versions (particularly PHP 8.4+) instead of gracefully rejecting it.

Inside `Security::derandomize()`, the `hex2bin()` function is used to decode the randomized token. If the provided hex string is invalid (e.g., contains non-hexadecimal characters or has an odd length), older PHP versions emitted an `E_WARNING` which the framework's error handler converted to an `ErrorException`.

However, in newer PHP 8 releases, `hex2bin()` natively throws a `ValueError` for invalid input strings. Because the `try/catch` block was only capturing `ErrorException`, the `ValueError` escaped unhandled, resulting in a fatal crash.

**Changes:**
- Updated the `try/catch` block in `Security::derandomize()` to catch `ValueError` alongside `ErrorException`.
- Added `testDerandomizeThrowsInvalidArgumentExceptionOnInvalidHex()` to the test suite, which intentionally passes a strictly invalid hexadecimal string to verify that the `InvalidArgumentException` is correctly re-thrown without a fatal error.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdoc fully completed
- [x] Unit testing, with >80% coverage
- [x] User guide updated (if applicable)
