### PR TITLE
fix: guard against parse_str array injection in CSRF token handling

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -272,13 +272,13 @@ class Security implements SecurityInterface
     /**
      * Remove token in POST or JSON request data
      */
-private function removeTokenInRequest(IncomingRequest $request): void
+    private function removeTokenInRequest(IncomingRequest $request): void
     {
         $tokenName = $this->config->tokenName;
 
         // 1. POST data
         $superglobals = service('superglobals');
-        
+
         if (is_string($superglobals->post($tokenName))) {
             $superglobals->unsetPost($tokenName);
             $request->setGlobal('post', $superglobals->getPostArray());
@@ -288,7 +288,7 @@ private function removeTokenInRequest(IncomingRequest $request): void
 
         // 2. Raw data (Body)
         $body = (string) $request->getBody();
-        
+
         if ($body === '') {
             return;
         }
@@ -296,7 +296,7 @@ private function removeTokenInRequest(IncomingRequest $request): void
         // 3a. JSON payload
         try {
             $json = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
-            
+
             if (is_array($json)) {
                 if (is_string($json[$tokenName] ?? null)) {
                     unset($json[$tokenName]);
@@ -362,6 +362,7 @@ private function removeTokenInRequest(IncomingRequest $request): void
 
         return null;
     }
+
     /**
      * @phpstan-assert-if-true non-empty-string $token
      */

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -272,12 +272,13 @@ class Security implements SecurityInterface
     /**
      * Remove token in POST or JSON request data
      */
-    private function removeTokenInRequest(IncomingRequest $request): void
+private function removeTokenInRequest(IncomingRequest $request): void
     {
-        $superglobals = service('superglobals');
-        $tokenName    = $this->config->tokenName;
+        $tokenName = $this->config->tokenName;
 
-        // If the token is found in POST data, we can safely remove it.
+        // 1. POST data
+        $superglobals = service('superglobals');
+        
         if (is_string($superglobals->post($tokenName))) {
             $superglobals->unsetPost($tokenName);
             $request->setGlobal('post', $superglobals->getPostArray());
@@ -285,89 +286,82 @@ class Security implements SecurityInterface
             return;
         }
 
-        $body = $request->getBody() ?? '';
-
+        // 2. Raw data (Body)
+        $body = (string) $request->getBody();
+        
         if ($body === '') {
             return;
         }
 
-        // If the token is found in JSON data, we can safely remove it.
+        // 3a. JSON payload
         try {
-            $json = json_decode($body, flags: JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            $json = null;
-        }
+            $json = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+            
+            if (is_array($json)) {
+                if (is_string($json[$tokenName] ?? null)) {
+                    unset($json[$tokenName]);
+                    $request->setBody(json_encode($json, JSON_THROW_ON_ERROR));
+                }
 
-        if (is_object($json)) {
-            if (property_exists($json, $tokenName)) {
-                unset($json->{$tokenName});
-                $request->setBody(json_encode($json));
+                return;
             }
+        } catch (JsonException) {
+            // 3b. Form-encoded data
+            parse_str($body, $result);
 
-            return;
+            if (is_string($result[$tokenName] ?? null)) {
+                unset($result[$tokenName]);
+                $request->setBody(http_build_query($result));
+            }
         }
-
-        // If the token is found in form-encoded data, we can safely remove it.
-        parse_str($body, $result);
-
-        unset($result[$tokenName]);
-        $request->setBody(http_build_query($result));
     }
 
     private function getPostedToken(IncomingRequest $request): ?string
     {
-        $tokenName  = $this->config->tokenName;
-        $headerName = $this->config->headerName;
+        $tokenName = $this->config->tokenName;
+        $isValid   = fn (mixed $t): bool => is_string($t) && $this->isNonEmptyTokenString($t);
 
-        // 1. Check POST data first.
+        // 1. POST
         $token = $request->getPost($tokenName);
-
-        if ($this->isNonEmptyTokenString($token)) {
+        if ($isValid($token)) {
             return $token;
         }
 
-        // 2. Check header data next.
+        // 2. Header
+        $headerName = $this->config->headerName;
         if ($request->hasHeader($headerName)) {
             $token = $request->header($headerName)->getValue();
-
-            if ($this->isNonEmptyTokenString($token)) {
+            if ($isValid($token)) {
                 return $token;
             }
         }
 
-        // 3. Finally, check the raw input data for JSON or form-encoded data.
-        $body = $request->getBody() ?? '';
-
+        // 3. Raw Body
+        $body = (string) $request->getBody();
         if ($body === '') {
             return null;
         }
 
-        // 3a. Check if a JSON payload exists and contains the token.
+        // 3a. JSON
         try {
-            $json = json_decode($body, flags: JSON_THROW_ON_ERROR);
+            $json = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+            if (is_array($json)) {
+                $token = $json[$tokenName] ?? null;
+                if ($isValid($token)) {
+                    return $token;
+                }
+            }
         } catch (JsonException) {
-            $json = null;
-        }
-
-        if (is_object($json) && property_exists($json, $tokenName)) {
-            $token = $json->{$tokenName};
-
-            if ($this->isNonEmptyTokenString($token)) {
+            // 3b. Form-encoded
+            parse_str($body, $result);
+            $token = $result[$tokenName] ?? null;
+            if ($isValid($token)) {
                 return $token;
             }
         }
 
-        // 3b. Check if form-encoded data exists and contains the token.
-        parse_str($body, $result);
-        $token = $result[$tokenName] ?? null;
-
-        if ($this->isNonEmptyTokenString($token)) {
-            return $token;
-        }
-
         return null;
     }
-
     /**
      * @phpstan-assert-if-true non-empty-string $token
      */

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -273,6 +273,117 @@ final class SecurityTest extends CIUnitTestCase
         $this->assertSame('foo=bar', $request->getBody());
     }
 
+    public function testCsrfVerifyFormBodyWithArrayTokenThrowsException(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'PUT')
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $request->setBody('csrf_test_name[]=invalid&foo=bar');
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    public function testCsrfVerifyPostWithArrayTokenThrowsException(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', ['injected_array'])
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    public function testCsrfVerifyJsonBodyWithArrayTokenThrowsException(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $request->setBody(json_encode(['csrf_test_name' => ['injected_array']]));
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    public function testCsrfVerifyJsonBodyWithNestedArrayTokenThrowsException(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $request->setBody(json_encode(['csrf_test_name' => [['nested' => 'injection']]]));
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    public function testCsrfVerifyPostWithEmptyStringTokenThrowsException(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', 'POST')
+            ->setPost('csrf_test_name', '')
+            ->setCookie('csrf_cookie_name', self::CORRECT_CSRF_HASH);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $this->expectException(SecurityException::class);
+        $security->verify($request);
+    }
+
+    public function testRemoveTokenInRequestSkipsArrayTokenInFormBody(): void
+    {
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+        $body     = 'csrf_test_name[]=value&foo=bar';
+        $request->setBody($body);
+
+        $removeTokenInRequest = self::getPrivateMethodInvoker($security, 'removeTokenInRequest');
+        $removeTokenInRequest($request);
+
+        $this->assertSame($body, $request->getBody());
+    }
+
+    public function testRemoveTokenInRequestStripsStringTokenFromFormBody(): void
+    {
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+        $request->setBody('csrf_test_name=' . self::CORRECT_CSRF_HASH . '&foo=bar');
+
+        $removeTokenInRequest = self::getPrivateMethodInvoker($security, 'removeTokenInRequest');
+        $removeTokenInRequest($request);
+
+        $this->assertSame('foo=bar', $request->getBody());
+    }
+
+    public function testRemoveTokenInRequestKeepsBodyWhenTokenMissing(): void
+    {
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $request->setBody('foo=bar&baz=qux');
+
+        $removeTokenInRequest = self::getPrivateMethodInvoker($security, 'removeTokenInRequest');
+        $removeTokenInRequest($request);
+
+        $this->assertSame('foo=bar&baz=qux', $request->getBody());
+    }
+
     public function testSanitizeFilename(): void
     {
         $security = $this->createMockSecurity();
@@ -409,14 +520,28 @@ final class SecurityTest extends CIUnitTestCase
 
         yield 'invalid_post_data' => [self::createIncomingRequest()->setGlobal('post', ['csrf_test_name' => ['invalid' => 'data']])];
 
+        yield 'invalid_post_indexed_array' => [self::createIncomingRequest()->setGlobal('post', ['csrf_test_name' => ['value1', 'value2']])];
+
+        yield 'invalid_post_nested_array' => [self::createIncomingRequest()->setGlobal('post', ['csrf_test_name' => [['nested' => 'injection']]])];
+
         yield 'empty_header' => [self::createIncomingRequest()->setHeader('X-CSRF-TOKEN', '')];
 
         yield 'invalid_json_data' => [self::createIncomingRequest()->setBody(json_encode(['csrf_test_name' => ['invalid' => 'data']]))];
+
+        yield 'invalid_json_indexed_array' => [self::createIncomingRequest()->setBody(json_encode(['csrf_test_name' => ['value1', 'value2']]))];
+
+        yield 'invalid_json_nested_array' => [self::createIncomingRequest()->setBody(json_encode(['csrf_test_name' => [['nested' => 'injection']]]))];
 
         yield 'invalid_json' => [self::createIncomingRequest()->setBody('{invalid json}')];
 
         yield 'missing_token_in_body' => [self::createIncomingRequest()->setBody('other=value&another=test')];
 
         yield 'invalid_form_data' => [self::createIncomingRequest()->setBody('csrf_test_name[]=invalid')];
+
+        yield 'invalid_form_data_nested' => [self::createIncomingRequest()->setBody('csrf_test_name[][nested]=injection')];
+
+        yield 'invalid_form_data_mixed' => [self::createIncomingRequest()->setBody('csrf_test_name=valid&csrf_test_name[]=override')];
+
+        yield 'empty_body' => [self::createIncomingRequest()->setBody('')];
     }
 }


### PR DESCRIPTION
`parse_str()` interprets `token[]=value` as an array (`['token' => ['value']]`),
which can lead to type confusion in CSRF validation. While the existing
`isNonEmptyTokenString()` helper checks `is_string()`, the codebase relied on
this single guard — making it fragile.

## Changes

### `system/Security/Security.php`

- **`getPostedToken()`**: Added explicit `is_string()` validation before passing
  the token value to `isNonEmptyTokenString()`, so array-type tokens are
  rejected early regardless of the helper's implementation.
- **`removeTokenInRequest()`**: Guarded `unset` + `http_build_query` with
  `is_string()` check for the form-encoded and JSON body paths, consistent
  with the existing POST data path.
- Refactored JSON decoding to use associative arrays (`json_decode($body, true)`)
  for consistency.
- Introduced `$isValid` closure combining `is_string` + `isNonEmptyTokenString`
  to reduce repetition.

### `tests/system/Security/SecurityTest.php`

Added 13 new test cases covering array injection scenarios:
- Full `verify()` flow: POST, JSON, and JSON nested array tokens
- `removeTokenInRequest()`: array token in form body (skipped), string token
  in form body (cleaned), missing token (body unchanged)
- `DataProvider`: indexed, nested, and mixed array injection in POST, JSON,
  and form-encoded formats; empty body edge case

## Impact

Defense-in-depth hardening. No known exploit path exists in the current code,
but the fix removes reliance on a single `is_string()` check in
`isNonEmptyTokenString()`.