### PR TITLE
docs: warn against user-controlled image paths

### DIFF
--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -42,6 +42,14 @@ The available Handlers are as follows:
    On Windows, the ImageMagick handler requires **absolute file paths** when
    loading images (for example, using ``WRITEPATH`` or ``FCPATH``).
 
+.. warning::
+    Do not let user input directly decide the image source path, storage
+    directory, or filename. This includes values passed to methods like
+    ``save()``, ``copy()`` and others, and any path or filename used to store
+    processed images. Use directories controlled by your application, and
+    generate filenames yourself or sanitize them with
+    :php:func:`sanitize_filename`.
+
 *******************
 Processing an Image
 *******************


### PR DESCRIPTION
**Description**
This PR adds a warning to the Image user guide advising developers not to let user input directly determine image source paths, storage directories, or filenames.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
