### PR TITLE
refactor: narrow `Image` original dimension types to `int`

### DIFF
--- a/system/Images/Image.php
+++ b/system/Images/Image.php
@@ -26,14 +26,14 @@ class Image extends File
     /**
      * The original image width in pixels.
      *
-     * @var float|int
+     * @var int
      */
     public $origWidth;
 
     /**
      * The original image height in pixels.
      *
-     * @var float|int
+     * @var int
      */
     public $origHeight;
 


### PR DESCRIPTION
**Description**
This PR updates the PHPDoc for `Image::$origWidth` and `Image::$origHeight` from `float|int` to `int`.

These values are populated from `getimagesize()`, whose width and height values come from PHP image dimension handling as integers. This follows the discussion in https://github.com/codeigniter4/CodeIgniter4/pull/10319#issuecomment-4745778902 and avoids adding unnecessary defensive `0.0` handling to `reproportion()`.

Closes #10319

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
