### PR TITLE
fix(Validation): correct required_without logic and prevent array key warnings

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -429,15 +429,22 @@ class Rules
 
                 $fieldData       = dot_array_search($otherField, $data);
                 $fieldSplitArray = explode('.', $field);
-                $fieldKey        = $fieldSplitArray[1];
+                $fieldKey        = $fieldSplitArray[1] ?? null;
 
                 if (is_array($fieldData)) {
-                    return ! empty(dot_array_search($otherField, $data)[$fieldKey]);
+                    if (empty($fieldData[$fieldKey])) {
+                        return false;
+                    }
+
+                    continue;
                 }
-                $nowField      = str_replace('*', $fieldKey, $otherField);
+
+                $nowField      = str_replace('*', (string) $fieldKey, $otherField);
                 $nowFieldVaule = dot_array_search($nowField, $data);
 
-                return null !== $nowFieldVaule;
+                if (null === $nowFieldVaule) {
+                    return false;
+                }
             }
         }
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1855,6 +1855,28 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
+     * Test that `required_without` checks all fields in dot-notation when there are multiple fields.
+     */
+    public function testRequireWithoutMultipleWithAsterisk(): void
+    {
+        $data = [
+            'a' => [
+                ['b' => 1, 'c' => 2, 'd' => ''],
+                ['b' => 1, 'c' => '', 'd' => ''],
+            ],
+        ];
+
+        $this->validation->setRules([
+            'a.*.d' => 'required_without[a.*.b,a.*.c]',
+        ])->run($data);
+
+        $this->assertSame(
+            'The a.*.d field is required when a.*.b,a.*.c is not present.',
+            $this->validation->getError('a.1.d'),
+        );
+    }
+
+    /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/8128
      */
     public function testRuleWithAsteriskToMultiDimensionalArray(): void


### PR DESCRIPTION
**Description**
This PR fixes two bugs in the `required_without` validation rule when used with array dot notation.

1. **Early return bug:** Previously, when multiple fields were provided to the `required_without` rule (e.g., `required_without[a.*.b,a.*.c]`), the `foreach` loop inside the method would prematurely return `true` as soon as it found the first present field. This caused the rule to completely ignore any subsequent fields in the array, leading to incorrect validation passes even if the subsequent fields were missing. This has been fixed by continuing the loop to check all declared fields.
2. **Undefined array key warning:** When resolving dot notation, if the intermediate `dot_array_search` returned `null` or a non-array, trying to access `[$fieldKey]` directly resulted in an `Undefined array key` warning. Added the null coalescing operator (`?? null`) and a safe check with `empty()` to prevent PHP warnings when the array key is not set.

Added `testRequireWithoutMultipleWithAsterisk` to `ValidationTest.php` to prove the bug was resolved.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPunit tests
- [x] Binaries, fluffs, etc. are ignored
- [x] Debug codes are removed
- [x] A descriptive pull request title
- [x] Code modifications have been well commented
- [x] Code follows the project's coding standards
