### PR TITLE
chore: Bump to Rector 2.5.2 and clean up unused skip config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpcov": "^9.0.2 || ^10.0",
         "phpunit/phpunit": "^10.5.16 || ^11.2",
         "predis/predis": "^3.0",
-        "rector/rector": "2.4.6",
+        "rector/rector": "2.5.2",
         "shipmonk/phpstan-baseline-per-identifier": "^2.0"
     },
     "replace": {

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,6 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
@@ -95,10 +94,6 @@ return RectorConfig::configure()
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker
             __DIR__ . '/tests/_support/Test/TestForReflectionHelper.php',
-        ],
-
-        RemoveUnusedConstructorParamRector::class => [
-            __DIR__ . '/system/HTTP/Response.php',
         ],
 
         // Exclude test file because `is_cli()` is mocked and Rector might remove needed parameters.

--- a/rector.php
+++ b/rector.php
@@ -22,6 +22,7 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
@@ -35,6 +36,7 @@ use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
 use Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTestsRector;
+use Rector\PostRector\Rector\UnusedImportRemovingPostRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Rector\Renaming\Rector\ConstFetch\RenameConstantRector;
@@ -94,6 +96,10 @@ return RectorConfig::configure()
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker
             __DIR__ . '/tests/_support/Test/TestForReflectionHelper.php',
+        ],
+
+        RemoveUnusedConstructorParamRector::class => [
+            __DIR__ . '/system/HTTP/Response.php',
         ],
 
         // Exclude test file because `is_cli()` is mocked and Rector might remove needed parameters.
@@ -169,8 +175,10 @@ return RectorConfig::configure()
             __DIR__ . '/tests/system/Models',
         ],
 
-        // buggy on auto import removed
-        __DIR__ . '/system/HTTP/Response.php',
+        UnusedImportRemovingPostRector::class => [
+            // buggy on auto import removed
+            __DIR__ . '/system/HTTP/Response.php',
+        ],
     ])
     // auto import fully qualified class names
     ->withImportNames()

--- a/rector.php
+++ b/rector.php
@@ -24,14 +24,12 @@ use Rector\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
-use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
-use Rector\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
@@ -96,28 +94,16 @@ return RectorConfig::configure()
 
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker
-            __DIR__ . '/tests/system/Test/ReflectionHelperTest.php',
             __DIR__ . '/tests/_support/Test/TestForReflectionHelper.php',
         ],
 
         RemoveUnusedConstructorParamRector::class => [
-            // there are deprecated parameters
-            __DIR__ . '/system/Debug/Exceptions.php',
-            // @TODO remove if deprecated $httpVerb is removed
-            __DIR__ . '/system/Router/AutoRouterImproved.php',
-            // @TODO remove if deprecated $config is removed
-            __DIR__ . '/system/HTTP/Request.php',
             __DIR__ . '/system/HTTP/Response.php',
         ],
 
         // Exclude test file because `is_cli()` is mocked and Rector might remove needed parameters.
         RemoveExtraParametersRector::class => [
             __DIR__ . '/tests/system/Debug/ToolbarTest.php',
-        ],
-
-        // check on constant compare
-        UnwrapFutureCompatibleIfPhpVersionRector::class => [
-            __DIR__ . '/system/Autoloader/Autoloader.php',
         ],
 
         UnderscoreToCamelCaseVariableNameRector::class => [
@@ -130,10 +116,7 @@ return RectorConfig::configure()
             __DIR__ . '/app',
             __DIR__ . '/system/CodeIgniter.php',
             __DIR__ . '/system/Config/BaseConfig.php',
-            __DIR__ . '/system/Commands/Generators/Views',
-            __DIR__ . '/system/Pager/Views',
             __DIR__ . '/system/Test/ControllerTestTrait.php',
-            __DIR__ . '/system/Validation/Views',
             __DIR__ . '/system/View/Parser.php',
             __DIR__ . '/tests/system/Debug/ExceptionsTest.php',
         ],
@@ -149,15 +132,11 @@ return RectorConfig::configure()
             __DIR__ . '/system/Filters/Filters.php',
             __DIR__ . '/system/HTTP/CURLRequest.php',
             __DIR__ . '/system/HTTP/DownloadResponse.php',
-            __DIR__ . '/system/HTTP/IncomingRequest.php',
             __DIR__ . '/system/Security/Security.php',
             __DIR__ . '/system/Session/Session.php',
         ],
 
         ReturnNeverTypeRector::class => [
-            __DIR__ . '/system/Cache/Handlers/BaseHandler.php',
-            __DIR__ . '/system/Cache/Handlers/MemcachedHandler.php',
-            __DIR__ . '/system/Cache/Handlers/WincacheHandler.php',
             __DIR__ . '/system/CodeIgniter.php',
             __DIR__ . '/system/Database/MySQLi/Utils.php',
             __DIR__ . '/system/Database/OCI8/Utils.php',
@@ -166,8 +145,6 @@ return RectorConfig::configure()
             __DIR__ . '/system/Database/SQLite3/Utils.php',
             __DIR__ . '/system/HTTP/DownloadResponse.php',
             __DIR__ . '/system/HTTP/SiteURI.php',
-            __DIR__ . '/system/Helpers/kint_helper.php',
-            __DIR__ . '/tests/_support/Autoloader/FatalLocator.php',
         ],
 
         // Unnecessary (string) is inserted
@@ -195,10 +172,6 @@ return RectorConfig::configure()
             __DIR__ . '/system/Model.php',
             __DIR__ . '/tests/system/Database',
             __DIR__ . '/tests/system/Models',
-        ],
-
-        StaticCallOnNonStaticToInstanceCallRector::class => [
-            __DIR__ . '/tests/_support/Config/Services.php',
         ],
     ])
     // auto import fully qualified class names
@@ -231,4 +204,5 @@ return RectorConfig::configure()
     ->withConfiguredRule(RenameConstantRector::class, [
         'FILTER_DEFAULT' => 'FILTER_UNSAFE_RAW',
     ])
-    ->withCodeQualityLevel(61);
+    ->withCodeQualityLevel(61)
+    ->reportUnusedSkips();

--- a/rector.php
+++ b/rector.php
@@ -173,6 +173,9 @@ return RectorConfig::configure()
             __DIR__ . '/tests/system/Database',
             __DIR__ . '/tests/system/Models',
         ],
+
+        // buggy on auto import removed
+        __DIR__ . '/system/HTTP/Response.php',
     ])
     // auto import fully qualified class names
     ->withImportNames(removeUnusedImports: true)

--- a/rector.php
+++ b/rector.php
@@ -173,7 +173,7 @@ return RectorConfig::configure()
         __DIR__ . '/system/HTTP/Response.php',
     ])
     // auto import fully qualified class names
-    ->withImportNames(removeUnusedImports: true)
+    ->withImportNames()
     ->withRules([
         DeclareStrictTypesRector::class,
         UnderscoreToCamelCaseVariableNameRector::class,

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1012,7 +1012,7 @@ class CLI
                 continue;
             }
 
-            if (mb_strpos($value, ' ') !== false) {
+            if (str_contains($value, ' ')) {
                 $out .= "\"{$value}\" ";
             } elseif ($value !== null) {
                 $out .= "{$value} ";

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -164,7 +164,7 @@ class CLIRequest extends Request
                 continue;
             }
 
-            if (mb_strpos($value, ' ') !== false) {
+            if (str_contains($value, ' ')) {
                 $out .= '"' . $value . '" ';
             } else {
                 $out .= "{$value} ";

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
-use Config\App;
 use Config\Cookie as CookieConfig;
 
 /**

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use Config\App;
 use Config\Cookie as CookieConfig;
 
 /**

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -112,7 +112,7 @@ class DOMParser
         if ($element === null) {
             $content = $this->dom->saveHTML($this->dom->documentElement);
 
-            return mb_strpos($content, $search) !== false;
+            return str_contains($content, $search);
         }
 
         $result = $this->doXPath($search, $element);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

This PR:

- Bump to Rector ~2.5.2
- Apply rector changes
- Clean up configs

Rector 2.5 has reportUnusedSkips() that can report unused skip config that we can clear up.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
