### PR TITLE
fix: prevent PHP Object Injection in Entity ArrayCast

### DIFF
--- a/system/Entity/Cast/ArrayCast.php
+++ b/system/Entity/Cast/ArrayCast.php
@@ -18,7 +18,7 @@ class ArrayCast extends BaseCast
     public static function get($value, array $params = []): array
     {
         if (is_string($value) && (str_starts_with($value, 'a:') || str_starts_with($value, 's:'))) {
-            $value = unserialize($value);
+            $value = unserialize($value, ['allowed_classes' => false]);
         }
 
         return (array) $value;

--- a/tests/system/Entity/Cast/ArrayCastTest.php
+++ b/tests/system/Entity/Cast/ArrayCastTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Entity\Cast;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use stdClass;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class ArrayCastTest extends CIUnitTestCase
+{
+    public function testGetPreventsObjectInjection(): void
+    {
+        $payload = serialize([new stdClass()]);
+
+        $result = ArrayCast::get($payload);
+
+        $this->assertInstanceOf('__PHP_Incomplete_Class', $result[0]);
+    }
+}


### PR DESCRIPTION
**Description**
Fixes a PHP Object Injection vulnerability in `CodeIgniter\Entity\Cast\ArrayCast::get()`. 

The `unserialize()` call was missing the `['allowed_classes' => false]` restriction. This could allow an attacker to instantiate arbitrary classes (POP chains) if they pass a serialized object wrapped in an array payload. The fix disables object instantiation during unserialization and adds a unit test to verify the behavior.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
