### PR TITLE
fix(Session): clear session data on destroy in testing environment

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -274,6 +274,8 @@ class Session implements SessionInterface
     public function destroy()
     {
         if (ENVIRONMENT === 'testing') {
+            $_SESSION = [];
+
             return;
         }
 

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -328,6 +328,19 @@ final class SessionTest extends CIUnitTestCase
         $this->assertSame('bar', $_SESSION['foo']);
     }
 
+    public function testDestroyClearsSessionInTesting(): void
+    {
+        $session = $this->getInstance();
+        $session->start();
+
+        $session->set('foo', 'bar');
+        $this->assertSame('bar', $_SESSION['foo']);
+
+        $session->destroy();
+
+        $this->assertSame([], $_SESSION);
+    }
+
     public function testCanFlashData(): void
     {
         $session = $this->getInstance();


### PR DESCRIPTION
**Description**
In the `testing` environment, `Session::destroy()` returned early without calling `session_destroy()`. While avoiding raw PHP session functions in CLI/testing is expected, doing nothing meant that the mock session data stored in the `$_SESSION` superglobal remained completely intact. This caused session state to leak between test cases, leading to test pollution.

This PR addresses the issue by resetting the `$_SESSION` array (`$_SESSION = []`) when `destroy()` is called under the `testing` environment. A unit test has also been added to verify this behavior.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
