### PR TITLE
docs: add PHP built-in server limitations for `SSEResponse`

### DIFF
--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -284,7 +284,7 @@ Possible symptoms include:
 - frontend requests remaining in a pending state
 
 For more realistic testing, prefer a server stack that handles concurrent
-requests better, such as Apache, Nginx with PHP-FPM, or FrankenPHP.
+requests better, such as Apache, nginx with PHP-FPM, or FrankenPHP.
 
 This behavior is a limitation of the development server environment, not of
 ``SSEResponse`` itself.

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -266,6 +266,29 @@ use comments for keep-alive and configure the client retry interval:
 
 .. literalinclude:: response/037.php
 
+Development Server Limitations
+------------------------------
+
+When testing SSE locally, keep in mind that PHP's built-in development server
+(used by ``php spark serve``) is not designed to handle long-lived streaming
+connections effectively.
+
+Because an SSE connection remains open for an extended period, the built-in
+server may spend most of its capacity serving the stream. As a result, other
+requests may appear slow, blocked, or delayed while the SSE connection is active.
+
+Possible symptoms include:
+
+- normal HTTP requests appearing to hang or time out
+- API requests responding slowly
+- frontend requests remaining in a pending state
+
+For more realistic testing, prefer a server stack that handles concurrent
+requests better, such as Apache, Nginx with PHP-FPM, or FrankenPHP.
+
+This behavior is a limitation of the development server environment, not of
+``SSEResponse`` itself.
+
 Production Considerations
 -------------------------
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This PR adds a documentation note for `SSEResponse` about local development limitations when using PHP's built-in server via `php spark serve`.

Because SSE keeps HTTP connections open for a long time, the built-in server may become busy serving the stream, causing other requests to appear slow, blocked, or delayed during development.

The new note clarifies that this behavior is an environment limitation, not an issue with `SSEResponse`, and recommends testing SSE with a server stack that handles concurrent requests more effectively.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
