### PR TITLE
refactor: replace type `mixed` with more specific types

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -403,9 +403,9 @@ if (! function_exists('env')) {
      * retrieving values set from the .env file for
      * use in config files.
      *
-     * @param array<int|string, mixed>|bool|float|int|object|string|null $default
+     * @param mixed $default
      *
-     * @return array<int|string, mixed>|bool|float|int|object|string|null
+     * @return mixed
      */
     function env(string $key, $default = null)
     {
@@ -1080,7 +1080,7 @@ if (! function_exists('service')) {
      *  - $timer = service('timer')
      *  - $timer = \CodeIgniter\Config\Services::timer();
      *
-     * @param array|bool|float|int|object|string|null ...$params
+     * @param mixed ...$params
      */
     function service(string $name, ...$params): ?object
     {
@@ -1096,7 +1096,7 @@ if (! function_exists('single_service')) {
     /**
      * Always returns a new instance of the class.
      *
-     * @param array|bool|float|int|object|string|null ...$params
+     * @param mixed ...$params
      */
     function single_service(string $name, ...$params): ?object
     {

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -166,7 +166,7 @@ class BaseConfig
     /**
      * Initialization an environment-specific configuration setting
      *
-     * @param array|bool|float|int|string|null $property
+     * @param array<int|string, mixed>|bool|float|int|string|null $property
      *
      * @return void
      */

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -244,7 +244,7 @@ class BaseService
      *
      * $key must be a name matching a service.
      *
-     * @param array|bool|float|int|object|string|null ...$params
+     * @param mixed ...$params
      *
      * @return object
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2817,7 +2817,7 @@ class BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param array|RawSql|string $where
+     * @param array<int|string, mixed>|RawSql|string $where
      *
      * @return bool|string Returns a SQL string if in test mode.
      *
@@ -3075,7 +3075,7 @@ class BaseBuilder
      * Generates a query string based on which functions were used.
      * Should not be called directly.
      *
-     * @param mixed $selectOverride
+     * @param false|string $selectOverride
      */
     protected function compileSelect($selectOverride = false): string
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1533,7 +1533,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Escapes data based on type.
      * Sets boolean and null types
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return ($str is array ? array : float|int|string)
      */
@@ -2059,7 +2059,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Accessor for properties if they exist.
      *
-     * @return array|bool|float|int|object|resource|string|null
+     * @return mixed
      */
     public function __get(string $key)
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -781,7 +781,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param array|string|null $binds
+     * @param array<int|string, mixed>|string|null $binds
      *
      * @return BaseResult<TConnection, TResult>|bool|Query
      *

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -125,7 +125,7 @@ abstract class BaseUtils
     /**
      * Optimize Database
      *
-     * @return mixed
+     * @return array<string, mixed>|bool
      *
      * @throws DatabaseException
      */
@@ -170,7 +170,7 @@ abstract class BaseUtils
     /**
      * Repair Table
      *
-     * @return mixed
+     * @return array<string, mixed>|bool
      *
      * @throws DatabaseException
      */

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -137,7 +137,7 @@ interface ConnectionInterface
      * Escapes data based on type.
      * Sets boolean and null types.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return ($str is array ? array : float|int|string)
      */
@@ -149,7 +149,7 @@ interface ConnectionInterface
      *
      * @param array ...$params
      *
-     * @return array|bool|float|int|object|resource|string|null
+     * @return mixed
      */
     public function callFunction(string $functionName, ...$params);
 

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -100,7 +100,7 @@ interface ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param array|string|null $binds
+     * @param array<int|string, mixed>|string|null $binds
      *
      * @return BaseResult<TConnection, TResult>|bool|Query
      */

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -150,7 +150,7 @@ class Builder extends BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where
+     * @param array<int|string, mixed>|RawSql|string $where
      *
      * @return bool|string
      *

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -225,7 +225,7 @@ class Builder extends BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where
+     * @param array<int|string, mixed>|RawSql|string $where
      *
      * @return bool|string
      *

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -241,7 +241,7 @@ class Connection extends BaseConnection
      *
      * Escapes data based on type
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return ($str is array ? array : float|int|string)
      */

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -538,7 +538,7 @@ class Builder extends BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where
+     * @param array<int|string, mixed>|RawSql|string $where
      *
      * @return bool|string
      *
@@ -578,7 +578,7 @@ class Builder extends BaseBuilder
      *
      * Generates a query string based on which functions were used.
      *
-     * @param bool $selectOverride
+     * @param false|string $selectOverride
      */
     protected function compileSelect($selectOverride = false): string
     {

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -321,7 +321,7 @@ class Forge extends BaseForge
     /**
      * Drop index for table
      *
-     * @return mixed
+     * @return false|resource
      */
     protected function _dropIndex(string $table, object $indexData)
     {

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -479,7 +479,7 @@ class Toolbar
 
         // Otherwise, if it includes ?debugbar_time, then
         // we should return the entire debugbar.
-        if ($request->getGet('debugbar_time')) {
+        if ($request->getGet('debugbar_time') !== null) {
             helper('security');
 
             // Negotiate the content-type to format the output

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -55,7 +55,7 @@ abstract class BaseHandler implements EncrypterInterface
      *
      * @param string $key Property name
      *
-     * @return array|bool|int|string|null
+     * @return array<int|string, mixed>|bool|int|string|null
      */
     public function __get($key)
     {

--- a/system/Encryption/KeyRotationDecorator.php
+++ b/system/Encryption/KeyRotationDecorator.php
@@ -86,7 +86,7 @@ class KeyRotationDecorator implements EncrypterInterface
     /**
      * Delegate property access to the inner handler.
      *
-     * @return array|bool|int|string|null
+     * @return array<int|string, mixed>|bool|int|string|null
      */
     public function __get(string $key)
     {

--- a/system/Entity/Cast/CastInterface.php
+++ b/system/Entity/Cast/CastInterface.php
@@ -23,20 +23,20 @@ interface CastInterface
     /**
      * Takes a raw value from Entity, returns its value for PHP.
      *
-     * @param array|bool|float|int|object|string|null $value  Data
-     * @param array<int, string>                      $params Additional param
+     * @param mixed              $value  Data
+     * @param array<int, string> $params Additional param
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public static function get($value, array $params = []);
 
     /**
      * Takes a PHP value, returns its raw value for Entity.
      *
-     * @param array|bool|float|int|object|string|null $value  Data
-     * @param array<int, string>                      $params Additional param
+     * @param mixed              $value  Data
+     * @param array<int, string> $params Additional param
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public static function set($value, array $params = []);
 }

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -157,7 +157,7 @@ class Entity implements JsonSerializable
      * properties, using any `setCamelCasedProperty()` methods
      * that may or may not exist.
      *
-     * @param array<string, array<int|string, mixed>|bool|float|int|object|string|null> $data
+     * @param array<string, mixed> $data
      *
      * @return $this
      */
@@ -556,7 +556,7 @@ class Entity implements JsonSerializable
      * @param string                     $attribute Attribute name
      * @param string                     $method    Allowed to "get" and "set"
      *
-     * @return array<int|string, mixed>|bool|float|int|object|string|null
+     * @return mixed
      *
      * @throws CastException
      */
@@ -631,7 +631,7 @@ class Entity implements JsonSerializable
      *  $this->my_property = $p;
      *  $this->setMyProperty() = $p;
      *
-     * @param array<int|string, mixed>|bool|float|int|object|string|null $value
+     * @param mixed $value
      *
      * @return void
      *
@@ -682,7 +682,7 @@ class Entity implements JsonSerializable
      *  $p = $this->my_property
      *  $p = $this->getMyProperty()
      *
-     * @return array<int|string, mixed>|bool|float|int|object|string|null
+     * @return mixed
      *
      * @throws Exception
      */

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -289,7 +289,7 @@ class CURLRequest extends OutgoingRequest
     /**
      * Set JSON data to be sent.
      *
-     * @param array|bool|float|int|object|string|null $data
+     * @param mixed $data
      *
      * @return $this
      */

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -363,7 +363,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter Filter constant
      * @param array|int|null    $flags
      *
-     * @return array|bool|float|int|stdClass|string|null
+     * @return array<int|string, mixed>|bool|float|int|stdClass|string|null
      */
     public function getVar($index = null, $filter = null, $flags = null)
     {
@@ -390,7 +390,7 @@ class IncomingRequest extends Request
      *
      * @see http://php.net/manual/en/function.json-decode.php
      *
-     * @return array|bool|float|int|stdClass|null
+     * @return array<int|string, mixed>|bool|float|int|stdClass|null
      *
      * @throws HTTPException When the body is invalid as JSON.
      */
@@ -417,7 +417,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter Filter Constant
      * @param array|int|null    $flags  Option
      *
-     * @return array|bool|float|int|stdClass|string|null
+     * @return array<int|string, mixed>|bool|float|int|stdClass|string|null
      */
     public function getJsonVar($index = null, bool $assoc = false, ?int $filter = null, $flags = null)
     {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -508,7 +508,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter Filter Constant
      * @param array|int|null    $flags  Option
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function getRawInputVar($index = null, ?int $filter = null, $flags = null)
     {
@@ -562,7 +562,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter A filter name to apply.
      * @param array|int|null    $flags
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function getGet($index = null, $filter = null, $flags = null)
     {
@@ -576,7 +576,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter A filter name to apply
      * @param array|int|null    $flags
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function getPost($index = null, $filter = null, $flags = null)
     {
@@ -590,7 +590,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter A filter name to apply
      * @param array|int|null    $flags
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function getPostGet($index = null, $filter = null, $flags = null)
     {
@@ -613,7 +613,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter A filter name to apply
      * @param array|int|null    $flags
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function getGetPost($index = null, $filter = null, $flags = null)
     {
@@ -636,7 +636,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter A filter name to be applied
      * @param array|int|null    $flags
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function getCookie($index = null, $filter = null, $flags = null)
     {

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -257,7 +257,7 @@ trait RequestTrait
      * @param int|null                                 $filter Filter constant
      * @param array|int|null                           $flags  Options
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     public function fetchGlobal(string $name, $index = null, ?int $filter = null, $flags = null)
     {

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -35,7 +35,7 @@ final class ArrayHelper
      *
      * @param string $index The index as dot array syntax.
      *
-     * @return array|bool|int|object|string|null
+     * @return mixed
      */
     public static function dotSearch(string $index, array $array)
     {
@@ -68,7 +68,7 @@ final class ArrayHelper
      *
      * @used-by dotSearch()
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     private static function arraySearchDot(array $indexes, array $array)
     {

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -20,7 +20,7 @@ if (! function_exists('dot_array_search')) {
      * Searches an array through dot syntax. Supports
      * wildcard searches, like foo.*.bar
      *
-     * @return array|bool|int|object|string|null
+     * @return mixed
      */
     function dot_array_search(string $index, array $array)
     {
@@ -34,7 +34,7 @@ if (! function_exists('array_deep_search')) {
      *
      * @param int|string $key
      *
-     * @return array|bool|float|int|object|string|null
+     * @return mixed
      */
     function array_deep_search($key, array $array)
     {
@@ -43,8 +43,12 @@ if (! function_exists('array_deep_search')) {
         }
 
         foreach ($array as $value) {
-            if (is_array($value) && ($result = array_deep_search($key, $value))) {
-                return $result;
+            if (is_array($value)) {
+                $result = array_deep_search($key, $value);
+
+                if ($result !== null) {
+                    return $result;
+                }
             }
         }
 

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -1211,7 +1211,7 @@ trait TimeTrait
      *
      * @param string $name
      *
-     * @return array|bool|DateTimeInterface|DateTimeZone|int|IntlCalendar|self|string|null
+     * @return array<int|string, mixed>|bool|DateTimeInterface|DateTimeZone|int|IntlCalendar|self|string|null
      */
     public function __get($name)
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -714,7 +714,7 @@ class Model extends BaseModel
     /**
      * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
      *
-     * @return array<int|string, mixed>|BaseBuilder|bool|float|int|object|string|null
+     * @return mixed
      */
     public function __get(string $name)
     {
@@ -741,7 +741,7 @@ class Model extends BaseModel
      * Provides direct access to method in the builder (if available)
      * and the database connection.
      *
-     * @return $this|array<int|string, mixed>|BaseBuilder|bool|float|int|object|string|null
+     * @return mixed
      */
     public function __call(string $name, array $params)
     {

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -70,7 +70,7 @@ class MockConnection extends BaseConnection
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param mixed $binds
+     * @param array<int|string, mixed>|string|null $binds
      *
      * @return BaseResult<object|resource, object|resource>|bool|Query
      *

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -23,7 +23,6 @@ trait ConditionalTrait
      * @param TWhen                        $condition
      * @param callable(self, TWhen): mixed $callback
      * @param (callable(self): mixed)|null $defaultCallback
-     * @param mixed                        $condition
      *
      * @return $this
      */
@@ -46,7 +45,6 @@ trait ConditionalTrait
      * @param TWhenNot                        $condition
      * @param callable(self, TWhenNot): mixed $callback
      * @param (callable(self): mixed)|null    $defaultCallback
-     * @param mixed                           $condition
      *
      * @return $this
      */

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -316,7 +316,7 @@ class Rules
     }
 
     /**
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function required($str = null): bool
     {
@@ -454,10 +454,10 @@ class Rules
     /**
      * The field exists in $data.
      *
-     * @param array|bool|float|int|object|string|null $value The field value.
-     * @param string|null                             $param The rule's parameter.
-     * @param array                                   $data  The data to be validated.
-     * @param string|null                             $field The field name.
+     * @param mixed       $value The field value.
+     * @param string|null $param The rule's parameter.
+     * @param array       $data  The data to be validated.
+     * @param string|null $field The field name.
      */
     public function field_exists(
         $value = null,

--- a/system/Validation/StrictRules/CreditCardRules.php
+++ b/system/Validation/StrictRules/CreditCardRules.php
@@ -42,7 +42,7 @@ class CreditCardRules
      *      'cc_num' => 'valid_cc_number[visa]'
      *  ];
      *
-     * @param array|bool|float|int|object|string|null $ccNumber
+     * @param mixed $ccNumber
      */
     public function valid_cc_number($ccNumber, string $type): bool
     {

--- a/system/Validation/StrictRules/FormatRules.php
+++ b/system/Validation/StrictRules/FormatRules.php
@@ -32,7 +32,7 @@ class FormatRules
     /**
      * Alpha
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function alpha($str = null): bool
     {
@@ -46,7 +46,7 @@ class FormatRules
     /**
      * Alpha with spaces.
      *
-     * @param array|bool|float|int|object|string|null $value Value.
+     * @param mixed $value Value.
      *
      * @return bool True if alpha with spaces, else false.
      */
@@ -62,7 +62,7 @@ class FormatRules
     /**
      * Alphanumeric with underscores and dashes
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function alpha_dash($str = null): bool
     {
@@ -84,7 +84,7 @@ class FormatRules
      * _ underscore, + plus, = equals, | vertical bar, : colon, . period
      * ~ ! # $ % & * - _ + = | : .
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      *
      * @return bool
      */
@@ -104,7 +104,7 @@ class FormatRules
     /**
      * Alphanumeric
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function alpha_numeric($str = null): bool
     {
@@ -122,7 +122,7 @@ class FormatRules
     /**
      * Alphanumeric w/ spaces
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function alpha_numeric_space($str = null): bool
     {
@@ -140,7 +140,7 @@ class FormatRules
     /**
      * Any type of string
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function string($str = null): bool
     {
@@ -150,7 +150,7 @@ class FormatRules
     /**
      * Decimal number
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function decimal($str = null): bool
     {
@@ -168,7 +168,7 @@ class FormatRules
     /**
      * String of hexidecimal characters
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function hex($str = null): bool
     {
@@ -186,7 +186,7 @@ class FormatRules
     /**
      * Integer
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function integer($str = null): bool
     {
@@ -204,7 +204,7 @@ class FormatRules
     /**
      * Is a Natural number  (0,1,2,3, etc.)
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function is_natural($str = null): bool
     {
@@ -222,7 +222,7 @@ class FormatRules
     /**
      * Is a Natural number, but not a zero  (1,2,3, etc.)
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function is_natural_no_zero($str = null): bool
     {
@@ -240,7 +240,7 @@ class FormatRules
     /**
      * Numeric
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function numeric($str = null): bool
     {
@@ -258,7 +258,7 @@ class FormatRules
     /**
      * Compares value against a regular expression pattern.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function regex_match($str, string $pattern): bool
     {
@@ -275,7 +275,7 @@ class FormatRules
      *
      * @see http://php.net/manual/en/datetimezone.listidentifiers.php
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function timezone($str = null): bool
     {
@@ -292,7 +292,7 @@ class FormatRules
      * Tests a string for characters outside of the Base64 alphabet
      * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function valid_base64($str = null): bool
     {
@@ -306,7 +306,7 @@ class FormatRules
     /**
      * Valid JSON
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function valid_json($str = null): bool
     {
@@ -320,7 +320,7 @@ class FormatRules
     /**
      * Checks for a correctly formatted email address
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function valid_email($str = null): bool
     {
@@ -337,7 +337,7 @@ class FormatRules
      * Example:
      *     valid_emails[one@example.com,two@example.com]
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function valid_emails($str = null): bool
     {
@@ -351,8 +351,8 @@ class FormatRules
     /**
      * Validate an IP address (human readable format or binary string - inet_pton)
      *
-     * @param array|bool|float|int|object|string|null $ip
-     * @param string|null                             $which IP protocol: 'ipv4' or 'ipv6'
+     * @param mixed       $ip
+     * @param string|null $which IP protocol: 'ipv4' or 'ipv6'
      */
     public function valid_ip($ip = null, ?string $which = null): bool
     {
@@ -369,7 +369,7 @@ class FormatRules
      * Warning: this rule will pass basic strings like
      * "banana"; use valid_url_strict for a stricter rule.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function valid_url($str = null): bool
     {
@@ -383,8 +383,8 @@ class FormatRules
     /**
      * Checks a URL to ensure it's formed correctly.
      *
-     * @param array|bool|float|int|object|string|null $str
-     * @param string|null                             $validSchemes comma separated list of allowed schemes
+     * @param mixed       $str
+     * @param string|null $validSchemes comma separated list of allowed schemes
      */
     public function valid_url_strict($str = null, ?string $validSchemes = null): bool
     {
@@ -398,7 +398,7 @@ class FormatRules
     /**
      * Checks for a valid date and matches a given date format
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function valid_date($str = null, ?string $format = null): bool
     {

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -33,8 +33,8 @@ class Rules
     /**
      * The value does not match another field in $data.
      *
-     * @param array|bool|float|int|object|string|null $str
-     * @param array                                   $data Other field/value pairs
+     * @param mixed $str
+     * @param array $data Other field/value pairs
      */
     public function differs(
         $str,
@@ -65,7 +65,7 @@ class Rules
     /**
      * Equals the static value provided.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function equals($str, string $val): bool
     {
@@ -76,7 +76,7 @@ class Rules
      * Returns true if $str is $val characters long.
      * $val = "5" (one) | "5,8,12" (multiple values)
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function exact_length($str, string $val): bool
     {
@@ -94,7 +94,7 @@ class Rules
     /**
      * Greater than
      *
-     * @param array|bool|float|int|object|string|null $str expects int|string
+     * @param mixed $str expects int|string
      */
     public function greater_than($str, string $min): bool
     {
@@ -112,7 +112,7 @@ class Rules
     /**
      * Equal to or Greater than
      *
-     * @param array|bool|float|int|object|string|null $str expects int|string
+     * @param mixed $str expects int|string
      */
     public function greater_than_equal_to($str, string $min): bool
     {
@@ -137,7 +137,7 @@ class Rules
      *    is_not_unique[table.field,where_field,where_value]
      *    is_not_unique[menu.id,active,1]
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function is_not_unique($str, string $field, array $data): bool
     {
@@ -151,7 +151,7 @@ class Rules
     /**
      * Value should be within an array of values
      *
-     * @param array|bool|float|int|object|string|null $value
+     * @param mixed $value
      */
     public function in_list($value, string $list): bool
     {
@@ -176,7 +176,7 @@ class Rules
      *    is_unique[table.field,ignore_field,ignore_value]
      *    is_unique[users.email,id,5]
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function is_unique($str, string $field, array $data): bool
     {
@@ -190,7 +190,7 @@ class Rules
     /**
      * Less than
      *
-     * @param array|bool|float|int|object|string|null $str expects int|string
+     * @param mixed $str expects int|string
      */
     public function less_than($str, string $max): bool
     {
@@ -208,7 +208,7 @@ class Rules
     /**
      * Equal to or Less than
      *
-     * @param array|bool|float|int|object|string|null $str expects int|string
+     * @param mixed $str expects int|string
      */
     public function less_than_equal_to($str, string $max): bool
     {
@@ -226,8 +226,8 @@ class Rules
     /**
      * Matches the value of another field in $data.
      *
-     * @param array|bool|float|int|object|string|null $str
-     * @param array                                   $data Other field/value pairs
+     * @param mixed $str
+     * @param array $data Other field/value pairs
      */
     public function matches(
         $str,
@@ -258,7 +258,7 @@ class Rules
     /**
      * Returns true if $str is $val or fewer characters in length.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function max_length($str, string $val): bool
     {
@@ -276,7 +276,7 @@ class Rules
     /**
      * Returns true if $str is at least $val length.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function min_length($str, string $val): bool
     {
@@ -294,7 +294,7 @@ class Rules
     /**
      * Does not equal the static value provided.
      *
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function not_equals($str, string $val): bool
     {
@@ -304,7 +304,7 @@ class Rules
     /**
      * Value should not be within an array of values.
      *
-     * @param array|bool|float|int|object|string|null $value
+     * @param mixed $value
      */
     public function not_in_list($value, string $list): bool
     {
@@ -324,7 +324,7 @@ class Rules
     }
 
     /**
-     * @param array|bool|float|int|object|string|null $str
+     * @param mixed $str
      */
     public function required($str = null): bool
     {
@@ -339,9 +339,9 @@ class Rules
      *
      *     required_with[password]
      *
-     * @param array|bool|float|int|object|string|null $str
-     * @param string|null                             $fields List of fields that we should check if present
-     * @param array                                   $data   Complete list of fields from the form
+     * @param mixed       $str
+     * @param string|null $fields List of fields that we should check if present
+     * @param array       $data   Complete list of fields from the form
      */
     public function required_with($str = null, ?string $fields = null, array $data = []): bool
     {
@@ -356,9 +356,9 @@ class Rules
      *
      *     required_without[id,email]
      *
-     * @param array|bool|float|int|object|string|null $str
-     * @param string|null                             $otherFields The param fields of required_without[].
-     * @param string|null                             $field       This rule param fields aren't present, this field is required.
+     * @param mixed       $str
+     * @param string|null $otherFields The param fields of required_without[].
+     * @param string|null $field       This rule param fields aren't present, this field is required.
      */
     public function required_without(
         $str = null,
@@ -373,10 +373,10 @@ class Rules
     /**
      * The field exists in $data.
      *
-     * @param array|bool|float|int|object|string|null $value The field value.
-     * @param string|null                             $param The rule's parameter.
-     * @param array                                   $data  The data to be validated.
-     * @param string|null                             $field The field name.
+     * @param mixed       $value The field value.
+     * @param string|null $param The rule's parameter.
+     * @param array       $data  The data to be validated.
+     * @param string|null $field The field name.
      */
     public function field_exists(
         $value = null,

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -242,10 +242,10 @@ class Validation implements ValidationInterface
      * Runs the validation process, returning true or false determining whether
      * validation was successful or not.
      *
-     * @param array|bool|float|int|object|string|null $value   The data to validate.
-     * @param array|string                            $rules   The validation rules.
-     * @param list<string>                            $errors  The custom error message.
-     * @param string|null                             $dbGroup The database group to use.
+     * @param mixed        $value   The data to validate.
+     * @param array|string $rules   The validation rules.
+     * @param list<string> $errors  The custom error message.
+     * @param string|null  $dbGroup The database group to use.
      */
     public function check($value, $rules, array $errors = [], $dbGroup = null): bool
     {
@@ -1000,8 +1000,7 @@ class Validation implements ValidationInterface
      * Entry point: allocates a single accumulator and delegates to the
      * recursive collector, so no intermediate arrays are built or unpacked.
      *
-     * @param list<string>                  $segments
-     * @param array<array-key, mixed>|mixed $current
+     * @param list<string> $segments
      *
      * @return list<string>
      */
@@ -1019,10 +1018,9 @@ class Validation implements ValidationInterface
      * paths where the key is genuinely absent are recorded - intermediate
      * missing segments are silently skipped so `*` never appears in a result.
      *
-     * @param list<string>                  $segments
-     * @param int<0, max>                   $segmentCount
-     * @param array<array-key, mixed>|mixed $current
-     * @param list<string>                  $result
+     * @param list<string> $segments
+     * @param int<0, max>  $segmentCount
+     * @param list<string> $result
      */
     private function collectMissingPaths(
         array $segments,

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -35,10 +35,10 @@ interface ValidationInterface
      * Check; runs the validation process, returning true or false
      * determining whether or not validation was successful.
      *
-     * @param array|bool|float|int|object|string|null $value   Value to validate.
-     * @param array|string                            $rules
-     * @param list<string>                            $errors
-     * @param string|null                             $dbGroup The database group to use.
+     * @param mixed        $value   Value to validate.
+     * @param array|string $rules
+     * @param list<string> $errors
+     * @param string|null  $dbGroup The database group to use.
      *
      * @return bool True if valid, else false.
      */

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -748,7 +748,7 @@ class Parser extends View
      * Converts an object to an array, respecting any
      * toArray() methods on an object.
      *
-     * @param array<string, mixed>|bool|float|int|object|string|null $value
+     * @param mixed $value
      *
      * @return array<string, mixed>|bool|float|int|string|null
      */

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 214 errors
+# total 213 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1931 errors
+# total 1839 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1944 errors
+# total 1931 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/method.childParameterType.neon
+++ b/utils/phpstan-baseline/method.childParameterType.neon
@@ -18,22 +18,22 @@ parameters:
             path: ../../system/Database/BaseResult.php
 
         -
-            message: '#^Parameter \#1 \$value \(bool\|int\|string\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:set\(\) should be contravariant with parameter \$value \(array\|bool\|float\|int\|object\|string\|null\) of method CodeIgniter\\Entity\\Cast\\BaseCast\:\:set\(\)$#'
+            message: '#^Parameter \#1 \$value \(bool\|int\|string\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:set\(\) should be contravariant with parameter \$value \(mixed\) of method CodeIgniter\\Entity\\Cast\\BaseCast\:\:set\(\)$#'
             count: 1
             path: ../../system/Entity/Cast/IntBoolCast.php
 
         -
-            message: '#^Parameter \#1 \$value \(bool\|int\|string\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:set\(\) should be contravariant with parameter \$value \(array\|bool\|float\|int\|object\|string\|null\) of method CodeIgniter\\Entity\\Cast\\CastInterface\:\:set\(\)$#'
+            message: '#^Parameter \#1 \$value \(bool\|int\|string\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:set\(\) should be contravariant with parameter \$value \(mixed\) of method CodeIgniter\\Entity\\Cast\\CastInterface\:\:set\(\)$#'
             count: 1
             path: ../../system/Entity/Cast/IntBoolCast.php
 
         -
-            message: '#^Parameter \#1 \$value \(int\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:get\(\) should be contravariant with parameter \$value \(array\|bool\|float\|int\|object\|string\|null\) of method CodeIgniter\\Entity\\Cast\\BaseCast\:\:get\(\)$#'
+            message: '#^Parameter \#1 \$value \(int\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:get\(\) should be contravariant with parameter \$value \(mixed\) of method CodeIgniter\\Entity\\Cast\\BaseCast\:\:get\(\)$#'
             count: 1
             path: ../../system/Entity/Cast/IntBoolCast.php
 
         -
-            message: '#^Parameter \#1 \$value \(int\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:get\(\) should be contravariant with parameter \$value \(array\|bool\|float\|int\|object\|string\|null\) of method CodeIgniter\\Entity\\Cast\\CastInterface\:\:get\(\)$#'
+            message: '#^Parameter \#1 \$value \(int\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:get\(\) should be contravariant with parameter \$value \(mixed\) of method CodeIgniter\\Entity\\Cast\\CastInterface\:\:get\(\)$#'
             count: 1
             path: ../../system/Entity/Cast/IntBoolCast.php
 

--- a/utils/phpstan-baseline/method.childParameterType.neon
+++ b/utils/phpstan-baseline/method.childParameterType.neon
@@ -1,4 +1,4 @@
-# total 12 errors
+# total 11 errors
 
 parameters:
     ignoreErrors:
@@ -16,11 +16,6 @@ parameters:
             message: '#^Parameter \#1 \$className \(class\-string\) of method CodeIgniter\\Database\\BaseResult\:\:getCustomResultObject\(\) should be contravariant with parameter \$className \(string\) of method CodeIgniter\\Database\\ResultInterface\<TConnection,TResult\>\:\:getCustomResultObject\(\)$#'
             count: 1
             path: ../../system/Database/BaseResult.php
-
-        -
-            message: '#^Parameter \#1 \$selectOverride \(bool\) of method CodeIgniter\\Database\\SQLSRV\\Builder\:\:compileSelect\(\) should be contravariant with parameter \$selectOverride \(mixed\) of method CodeIgniter\\Database\\BaseBuilder\:\:compileSelect\(\)$#'
-            count: 1
-            path: ../../system/Database/SQLSRV/Builder.php
 
         -
             message: '#^Parameter \#1 \$value \(bool\|int\|string\) of method CodeIgniter\\Entity\\Cast\\IntBoolCast\:\:set\(\) should be contravariant with parameter \$value \(array\|bool\|float\|int\|object\|string\|null\) of method CodeIgniter\\Entity\\Cast\\BaseCast\:\:set\(\)$#'

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1257 errors
+# total 1246 errors
 
 parameters:
     ignoreErrors:
@@ -204,11 +204,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Config\\BaseConfig\:\:__set_state\(\) has parameter \$array with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Config/BaseConfig.php
-
-        -
-            message: '#^Method CodeIgniter\\Config\\BaseConfig\:\:initEnvValue\(\) has parameter \$property with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Config/BaseConfig.php
 
@@ -444,11 +439,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Database\\BaseBuilder\:\:deleteBatch\(\) has parameter \$set with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/BaseBuilder.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\BaseBuilder\:\:delete\(\) has parameter \$where with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/BaseBuilder.php
 
@@ -838,11 +828,6 @@ parameters:
             path: ../../system/Database/BaseConnection.php
 
         -
-            message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:query\(\) has parameter \$binds with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/BaseConnection.php
-
-        -
             message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:setAliasedTables\(\) has parameter \$aliases with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/BaseConnection.php
@@ -1044,11 +1029,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:escape\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/ConnectionInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:query\(\) has parameter \$binds with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/ConnectionInterface.php
 
@@ -2133,11 +2113,6 @@ parameters:
             path: ../../system/Encryption/Encryption.php
 
         -
-            message: '#^Method CodeIgniter\\Encryption\\Handlers\\BaseHandler\:\:__get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/BaseHandler.php
-
-        -
             message: '#^Method CodeIgniter\\Encryption\\Handlers\\OpenSSLHandler\:\:decrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Encryption/Handlers/OpenSSLHandler.php
@@ -2166,11 +2141,6 @@ parameters:
             message: '#^Method CodeIgniter\\Encryption\\Handlers\\SodiumHandler\:\:parseParams\(\) has parameter \$params with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Encryption/Handlers/SodiumHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\KeyRotationDecorator\:\:__get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/KeyRotationDecorator.php
 
         -
             message: '#^Method CodeIgniter\\Encryption\\KeyRotationDecorator\:\:decrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
@@ -2728,22 +2698,12 @@ parameters:
             path: ../../system/HTTP/IncomingRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getJSON\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getJsonVar\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
         -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getJsonVar\(\) has parameter \$index with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getJsonVar\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
@@ -2809,11 +2769,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getVar\(\) has parameter \$index with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getVar\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
@@ -3586,16 +3541,6 @@ parameters:
             message: '#^Property CodeIgniter\\HotReloader\\IteratorFilter\:\:\$watchedExtensions type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HotReloader/IteratorFilter.php
-
-        -
-            message: '#^Method CodeIgniter\\I18n\\Time\:\:__get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/I18n/Time.php
-
-        -
-            message: '#^Method CodeIgniter\\I18n\\TimeLegacy\:\:__get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/I18n/TimeLegacy.php
 
         -
             message: '#^Method CodeIgniter\\Images\\Handlers\\BaseHandler\:\:__call\(\) has parameter \$args with no value type specified in iterable type array\.$#'

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1246 errors
+# total 1153 errors
 
 parameters:
     ignoreErrors:
@@ -173,16 +173,6 @@ parameters:
             path: ../../system/Common.php
 
         -
-            message: '#^Function service\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function single_service\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
             message: '#^Function stringify_attributes\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Common.php
@@ -224,11 +214,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Config\\BaseService\:\:__callStatic\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Config/BaseService.php
-
-        -
-            message: '#^Method CodeIgniter\\Config\\BaseService\:\:getSharedInstance\(\) has parameter \$params with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Config/BaseService.php
 
@@ -778,11 +763,6 @@ parameters:
             path: ../../system/Database/BaseConnection.php
 
         -
-            message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:__get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/BaseConnection.php
-
-        -
             message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:callFunction\(\) has parameter \$params with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/BaseConnection.php
@@ -794,11 +774,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:escapeIdentifiers\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/BaseConnection.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\BaseConnection\:\:escape\(\) has parameter \$str with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/BaseConnection.php
 
@@ -1014,16 +989,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:callFunction\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/ConnectionInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:callFunction\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/ConnectionInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\ConnectionInterface\:\:escape\(\) has parameter \$str with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/ConnectionInterface.php
 
@@ -1396,11 +1361,6 @@ parameters:
             message: '#^Property CodeIgniter\\Database\\Postgre\\Builder\:\:\$randomKeyword type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/Postgre/Builder.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\Postgre\\Connection\:\:escape\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/Postgre/Connection.php
 
         -
             message: '#^Method CodeIgniter\\Database\\Postgre\\Connection\:\:escape\(\) return type has no value type specified in iterable type array\.$#'
@@ -2153,144 +2113,14 @@ parameters:
             path: ../../system/Encryption/KeyRotationDecorator.php
 
         -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\ArrayCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/ArrayCast.php
-
-        -
             message: '#^Method CodeIgniter\\Entity\\Cast\\ArrayCast\:\:get\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Entity/Cast/ArrayCast.php
 
         -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\ArrayCast\:\:set\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/ArrayCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\BaseCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/BaseCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\BaseCast\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/BaseCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\BaseCast\:\:set\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/BaseCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\BaseCast\:\:set\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/BaseCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\BooleanCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/BooleanCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\CSVCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/CSVCast.php
-
-        -
             message: '#^Method CodeIgniter\\Entity\\Cast\\CSVCast\:\:get\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Entity/Cast/CSVCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\CSVCast\:\:set\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/CSVCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\CastInterface\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/CastInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\CastInterface\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/CastInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\CastInterface\:\:set\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/CastInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\CastInterface\:\:set\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/CastInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\DatetimeCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/DatetimeCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\EnumCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/EnumCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\EnumCast\:\:set\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/EnumCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\FloatCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/FloatCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\IntegerCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/IntegerCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\JsonCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/JsonCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\JsonCast\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/JsonCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\JsonCast\:\:set\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/JsonCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\ObjectCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/ObjectCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\StringCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/StringCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\TimestampCast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/TimestampCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\TimestampCast\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/TimestampCast.php
-
-        -
-            message: '#^Method CodeIgniter\\Entity\\Cast\\URICast\:\:get\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Entity/Cast/URICast.php
 
         -
             message: '#^Method CodeIgniter\\Exceptions\\PageNotFoundException\:\:lang\(\) has parameter \$args with no value type specified in iterable type array\.$#'
@@ -2578,11 +2408,6 @@ parameters:
             path: ../../system/HTTP/CURLRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\CURLRequest\:\:setJSON\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/CURLRequest.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\CURLRequest\:\:setResponseHeaders\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/CURLRequest.php
@@ -2653,11 +2478,6 @@ parameters:
             path: ../../system/HTTP/IncomingRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getCookie\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getFileMultiple\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
@@ -2678,22 +2498,12 @@ parameters:
             path: ../../system/HTTP/IncomingRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getGetPost\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getGet\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
         -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getGet\(\) has parameter \$index with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getGet\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
@@ -2723,11 +2533,6 @@ parameters:
             path: ../../system/HTTP/IncomingRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getPostGet\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getPost\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
@@ -2738,22 +2543,12 @@ parameters:
             path: ../../system/HTTP/IncomingRequest.php
 
         -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getPost\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getRawInputVar\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
         -
             message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getRawInputVar\(\) has parameter \$index with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequest\:\:getRawInputVar\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/IncomingRequest.php
 
@@ -2904,11 +2699,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\HTTP\\Request\:\:fetchGlobal\(\) has parameter \$index with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/HTTP/Request.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\Request\:\:fetchGlobal\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/HTTP/Request.php
 
@@ -3068,22 +2858,12 @@ parameters:
             path: ../../system/Helpers/Array/ArrayHelper.php
 
         -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:arraySearchDot\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
             message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:dotKeyExists\(\) has parameter \$array with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/Array/ArrayHelper.php
 
         -
             message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:dotSearch\(\) has parameter \$array with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/Array/ArrayHelper.php
-
-        -
-            message: '#^Method CodeIgniter\\Helpers\\Array\\ArrayHelper\:\:dotSearch\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/Array/ArrayHelper.php
 
@@ -3128,11 +2908,6 @@ parameters:
             path: ../../system/Helpers/array_helper.php
 
         -
-            message: '#^Function array_deep_search\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/array_helper.php
-
-        -
             message: '#^Function array_flatten_with_dots\(\) has parameter \$array with no value type specified in iterable type iterable\.$#'
             count: 1
             path: ../../system/Helpers/array_helper.php
@@ -3169,11 +2944,6 @@ parameters:
 
         -
             message: '#^Function dot_array_search\(\) has parameter \$array with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/array_helper.php
-
-        -
-            message: '#^Function dot_array_search\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/array_helper.php
 
@@ -4113,11 +3883,6 @@ parameters:
             path: ../../system/Validation/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\Rules\:\:field_exists\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/Rules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\Rules\:\:is_not_unique\(\) has parameter \$data with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/Rules.php
@@ -4133,11 +3898,6 @@ parameters:
             path: ../../system/Validation/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\Rules\:\:required\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/Rules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\Rules\:\:required_with\(\) has parameter \$data with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/Rules.php
@@ -4148,142 +3908,7 @@ parameters:
             path: ../../system/Validation/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\CreditCardRules\:\:valid_cc_number\(\) has parameter \$ccNumber with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/CreditCardRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:alpha\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:alpha_dash\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:alpha_numeric\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:alpha_numeric_punct\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:alpha_numeric_space\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:alpha_space\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:decimal\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:hex\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:integer\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:is_natural\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:is_natural_no_zero\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:numeric\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:regex_match\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:string\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:timezone\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_base64\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_date\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_email\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_emails\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_ip\(\) has parameter \$ip with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_json\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_url\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\FormatRules\:\:valid_url_strict\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/FormatRules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:differs\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:differs\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:equals\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:exact_length\(\) has parameter \$str with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/StrictRules/Rules.php
 
@@ -4293,32 +3918,7 @@ parameters:
             path: ../../system/Validation/StrictRules/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:field_exists\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:greater_than\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:greater_than_equal_to\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:in_list\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:is_not_unique\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:is_not_unique\(\) has parameter \$str with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/StrictRules/Rules.php
 
@@ -4328,52 +3928,7 @@ parameters:
             path: ../../system/Validation/StrictRules/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:is_unique\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:less_than\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:less_than_equal_to\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:matches\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:matches\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:max_length\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:min_length\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:not_equals\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:not_in_list\(\) has parameter \$value with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:required\(\) has parameter \$str with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/StrictRules/Rules.php
 
@@ -4383,27 +3938,12 @@ parameters:
             path: ../../system/Validation/StrictRules/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:required_with\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:required_without\(\) has parameter \$data with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/StrictRules/Rules.php
 
         -
-            message: '#^Method CodeIgniter\\Validation\\StrictRules\\Rules\:\:required_without\(\) has parameter \$str with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/StrictRules/Rules.php
-
-        -
             message: '#^Method CodeIgniter\\Validation\\Validation\:\:check\(\) has parameter \$rules with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/Validation.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\Validation\:\:check\(\) has parameter \$value with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/Validation.php
 
@@ -4569,11 +4109,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Validation\\ValidationInterface\:\:check\(\) has parameter \$rules with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Validation/ValidationInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Validation\\ValidationInterface\:\:check\(\) has parameter \$value with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Validation/ValidationInterface.php
 

--- a/utils/phpstan-baseline/return.type.neon
+++ b/utils/phpstan-baseline/return.type.neon
@@ -1,4 +1,4 @@
-# total 2 errors
+# total 3 errors
 
 parameters:
     ignoreErrors:
@@ -6,6 +6,11 @@ parameters:
             message: '#^Method CodeIgniter\\Database\\BaseBuilder\:\:cleanClone\(\) should return \$this\(CodeIgniter\\Database\\BaseBuilder\) but returns static\(CodeIgniter\\Database\\BaseBuilder\)\.$#'
             count: 1
             path: ../../system/Database/BaseBuilder.php
+
+        -
+            message: '#^Method CodeIgniter\\Entity\\Cast\\DatetimeCast\:\:get\(\) should return CodeIgniter\\I18n\\Time but returns mixed\.$#'
+            count: 1
+            path: ../../system/Entity/Cast/DatetimeCast.php
 
         -
             message: '#^Method CodeIgniter\\Router\\Router\:\:getRouteAttributes\(\) should return array\{class\: list\<string\>, method\: list\<string\>\} but returns array\{class\: list\<CodeIgniter\\Router\\Attributes\\RouteAttributeInterface\>, method\: list\<CodeIgniter\\Router\\Attributes\\RouteAttributeInterface\>\}\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

Fixes #6310.

Reviews every `mixed` PHPDoc (and its long-form spelling `array|bool|float|int|object|string|null`) across `system/`, and for each one decides whether `mixed` is appropriate, narrows it when the runtime type is provable, or collapses the verbose union to a plain `mixed` when the value is genuinely any type. Where the chosen type contains `array`, key/value information is added (`array<int|string, mixed>`) instead of a bare `array`. Split into two commits:

**1. Narrowing + array refinements**

- Narrowed `mixed` to deducible types.
- Refined bare `array` to `array<key, value>` in kept narrower unions.
- Removed a redundant duplicate `@param mixed $condition` in `ConditionalTrait` (the `@template`-typed tag remains).
- Left genuinely any-type sites as `mixed`, and kept PSR-3 / PHPUnit contract params as `mixed` to honor those interfaces.

**2. Collapsing verbose unions**

- Collapsed about 90 long-form `array|bool|float|int|object|string|null` unions (genuinely any-type) to bare `mixed`, mostly in `Validation/StrictRules`, plus `Common`, `Database` escape/magic methods, `Entity`/`CastInterface`, `HTTP` request accessors, the array helpers, `Model`, and `View\Parser`.
- Kept precise non-`mixed` unions: the `json_decode` `stdClass` shapes and `Parser::objectToArray()`'s return, which provably excludes `object`.
- Two call sites that relied on the unions being treated as uncertain under `treatPhpDocTypesAsCertain: false` were made explicit with `!== null`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide