### PR TITLE
docs: clarify mutable and immutable URI query methods

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -817,6 +817,8 @@ class URI implements Stringable
      * to clean the various parts of the query keys and values.
      *
      * @return $this
+     *
+     * @TODO Deprecated in the next major version. Use withQuery() instead for immutability.
      */
     public function setQuery(string $query)
     {
@@ -859,6 +861,8 @@ class URI implements Stringable
      * portion of the URI.
      *
      * @return $this
+     *
+     * @TODO Deprecated in the next major version. Use withQueryArray() instead for immutability.
      */
     public function setQueryArray(array $query)
     {
@@ -891,6 +895,8 @@ class URI implements Stringable
      * @param int|string|null $value
      *
      * @return $this
+     *
+     * @TODO Deprecated in the next major version. Use withQueryVar() or withQueryVars() instead for immutability.
      */
     public function addQuery(string $key, $value = null)
     {
@@ -939,6 +945,8 @@ class URI implements Stringable
      * @param string ...$params
      *
      * @return $this
+     *
+     * @TODO Deprecated in the next major version. Use withoutQueryVars() instead for immutability.
      */
     public function stripQuery(...$params)
     {
@@ -972,6 +980,8 @@ class URI implements Stringable
      * @param string ...$params
      *
      * @return $this
+     *
+     * @TODO Deprecated in the next major version. Use withOnlyQueryVars() instead for immutability.
      */
     public function keepQuery(...$params)
     {

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -193,6 +193,25 @@ Changing Query Values Without Mutation
 
 .. versionadded:: 4.8.0
 
+The immutable query methods provide alternatives to the older mutable methods:
+
++-----------------------+--------------------------------------------+
+| Mutable method        | Immutable alternative                      |
++=======================+============================================+
+| ``setQuery()``        | ``withQuery()``                            |
++-----------------------+--------------------------------------------+
+| ``setQueryArray()``   | ``withQueryArray()``                       |
++-----------------------+--------------------------------------------+
+| ``addQuery()``        | ``withQueryVar()`` / ``withQueryVars()``   |
++-----------------------+--------------------------------------------+
+| ``stripQuery()``      | ``withoutQueryVars()``                     |
++-----------------------+--------------------------------------------+
+| ``keepQuery()``       | ``withOnlyQueryVars()``                    |
++-----------------------+--------------------------------------------+
+
+The ``with*()`` methods return a cloned URI instance and do not modify the original URI.
+The older mutable methods change the current URI instance.
+
 You can return a new URI instance with its query variables replaced by using the
 ``withQuery()`` and ``withQueryArray()`` methods:
 
@@ -204,12 +223,10 @@ are replaced:
 
 .. literalinclude:: uri/028.php
 
-You can also return a new URI instance with query variables removed or filtered by using the
+You can return a new URI instance with query variables removed or filtered by using the
 ``withoutQueryVars()`` and ``withOnlyQueryVars()`` methods:
 
 .. literalinclude:: uri/030.php
-
-The original URI instance is not modified.
 
 Filtering Query Values
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
**Description**

This follows up on #10268 and @michalsn’s [suggestion](https://github.com/codeigniter4/CodeIgniter4/pull/10268#pullrequestreview-4540046526) to make the URI query docs clearer.

The URI user guide now lists the mutable query methods next to their immutable alternatives, and explicitly notes that the `with*()` helpers return cloned URI instances while the older methods mutate the current instance.

I also added non-runtime TODO notes to the mutable query method docblocks for the future major-version deprecation direction. These are not runtime deprecations and do not add `@deprecated` tags.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide