### PR TITLE
feat: add insert-only fields to Model

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -160,7 +160,7 @@ abstract class BaseModel
      *
      * @var list<string>
      */
-    protected $insertOnlyFields = [];
+    protected array $insertOnlyFields = [];
 
     /**
      * If true, will set created_at, and updated_at
@@ -1171,7 +1171,7 @@ abstract class BaseModel
                 // strip out updated_at values.
                 $ignoredFields = $index === null ? [] : [$index];
 
-                $this->ensureNoInsertOnlyFields($row, $ignoredFields);
+                $row = $this->doProtectInsertOnlyFieldsForUpdate($row, $ignoredFields);
                 $this->ensureNoDisallowedFields($row, $ignoredFields);
                 $row = $this->doProtectFields($row);
 
@@ -1487,17 +1487,19 @@ abstract class BaseModel
     }
 
     /**
-     * Throws when update data contains fields that may only be inserted.
+     * Removes fields from update data when they may only be inserted.
      *
      * @param row_array    $row
      * @param list<string> $ignoredFields
      *
+     * @return row_array
+     *
      * @throws DataException
      */
-    protected function ensureNoInsertOnlyFields(array $row, array $ignoredFields = []): void
+    protected function doProtectInsertOnlyFieldsForUpdate(array $row, array $ignoredFields = []): array
     {
         if (! $this->protectFields || $this->allowedFields === [] || $this->insertOnlyFields === []) {
-            return;
+            return $row;
         }
 
         $insertOnlyFields = [];
@@ -1509,12 +1511,15 @@ abstract class BaseModel
 
             if (in_array($key, $this->insertOnlyFields, true)) {
                 $insertOnlyFields[] = $key;
+                unset($row[$key]);
             }
         }
 
-        if ($insertOnlyFields !== []) {
+        if ($insertOnlyFields !== [] && $this->throwOnDisallowedFields) {
             throw DataException::forInsertOnlyFields(static::class, $insertOnlyFields);
         }
+
+        return $row;
     }
 
     /**
@@ -1551,7 +1556,7 @@ abstract class BaseModel
      */
     protected function doProtectFieldsForUpdate(array $row): array
     {
-        $this->ensureNoInsertOnlyFields($row);
+        $row = $this->doProtectInsertOnlyFieldsForUpdate($row);
         $this->ensureNoDisallowedFields($row);
 
         return $this->doProtectFields($row);

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -156,6 +156,13 @@ abstract class BaseModel
     protected $allowedFields = [];
 
     /**
+     * Fields that may be inserted but not updated through Model write methods.
+     *
+     * @var list<string>
+     */
+    protected $insertOnlyFields = [];
+
+    /**
      * If true, will set created_at, and updated_at
      * values during insert and update routines.
      *
@@ -1162,7 +1169,10 @@ abstract class BaseModel
 
                 // Must be called first so we don't
                 // strip out updated_at values.
-                $this->ensureNoDisallowedFields($row, $index === null ? [] : [$index]);
+                $ignoredFields = $index === null ? [] : [$index];
+
+                $this->ensureNoInsertOnlyFields($row, $ignoredFields);
+                $this->ensureNoDisallowedFields($row, $ignoredFields);
                 $row = $this->doProtectFields($row);
 
                 // Restore updateIndex value in case it was wiped out
@@ -1376,6 +1386,20 @@ abstract class BaseModel
     }
 
     /**
+     * Sets the fields that may be inserted but not updated.
+     *
+     * @param list<string> $insertOnlyFields
+     *
+     * @return $this
+     */
+    public function setInsertOnlyFields(array $insertOnlyFields)
+    {
+        $this->insertOnlyFields = $insertOnlyFields;
+
+        return $this;
+    }
+
+    /**
      * Sets whether or not we should whitelist data set during
      * updates or inserts against $this->availableFields.
      *
@@ -1463,6 +1487,37 @@ abstract class BaseModel
     }
 
     /**
+     * Throws when update data contains fields that may only be inserted.
+     *
+     * @param row_array    $row
+     * @param list<string> $ignoredFields
+     *
+     * @throws DataException
+     */
+    protected function ensureNoInsertOnlyFields(array $row, array $ignoredFields = []): void
+    {
+        if (! $this->protectFields || $this->allowedFields === [] || $this->insertOnlyFields === []) {
+            return;
+        }
+
+        $insertOnlyFields = [];
+
+        foreach (array_keys($row) as $key) {
+            if (in_array($key, $ignoredFields, true)) {
+                continue;
+            }
+
+            if (in_array($key, $this->insertOnlyFields, true)) {
+                $insertOnlyFields[] = $key;
+            }
+        }
+
+        if ($insertOnlyFields !== []) {
+            throw DataException::forInsertOnlyFields(static::class, $insertOnlyFields);
+        }
+    }
+
+    /**
      * Ensures that only the fields that are allowed to be inserted are in
      * the data array.
      *
@@ -1496,6 +1551,7 @@ abstract class BaseModel
      */
     protected function doProtectFieldsForUpdate(array $row): array
     {
+        $this->ensureNoInsertOnlyFields($row);
         $this->ensureNoDisallowedFields($row);
 
         return $this->doProtectFields($row);

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -16,6 +16,7 @@ class {class} extends Model
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
     protected $allowedFields    = [];
+    protected $insertOnlyFields = [];
 
     protected bool $throwOnDisallowedFields = false;
     protected bool $allowEmptyInserts = false;

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -7,16 +7,16 @@ use CodeIgniter\Model;
 class {class} extends Model
 {
 <?php if (is_string($dbGroup)): ?>
-    protected $DBGroup          = '{dbGroup}';
+    protected $DBGroup                = '{dbGroup}';
 <?php endif; ?>
-    protected $table            = '{table}';
-    protected $primaryKey       = 'id';
-    protected $useAutoIncrement = true;
-    protected $returnType       = {return};
-    protected $useSoftDeletes   = false;
-    protected $protectFields    = true;
-    protected $allowedFields    = [];
-    protected $insertOnlyFields = [];
+    protected $table                  = '{table}';
+    protected $primaryKey             = 'id';
+    protected $useAutoIncrement       = true;
+    protected $returnType             = {return};
+    protected $useSoftDeletes         = false;
+    protected $protectFields          = true;
+    protected $allowedFields          = [];
+    protected array $insertOnlyFields = [];
 
     protected bool $throwOnDisallowedFields = false;
     protected bool $allowEmptyInserts = false;

--- a/system/Database/Exceptions/DataException.php
+++ b/system/Database/Exceptions/DataException.php
@@ -84,6 +84,16 @@ class DataException extends RuntimeException implements ExceptionInterface
     }
 
     /**
+     * @param list<string> $fields
+     *
+     * @return DataException
+     */
+    public static function forInsertOnlyFields(string $model, array $fields)
+    {
+        return new static(lang('Database.insertOnlyFields', [$model, implode(', ', $fields)]));
+    }
+
+    /**
      * @return DataException
      */
     public static function forTableNotFound(string $table)

--- a/system/Language/en/Database.php
+++ b/system/Language/en/Database.php
@@ -17,6 +17,7 @@ return [
     'invalidArgument'                  => 'You must provide a valid "{0}".',
     'invalidAllowedFields'             => 'Allowed fields must be specified for model: "{0}"',
     'disallowedFields'                 => 'Fields are not allowed for model "{0}": {1}',
+    'insertOnlyFields'                 => 'Fields cannot be updated for model "{0}": {1}',
     'emptyDataset'                     => 'There is no data to {0}.',
     'emptyPrimaryKey'                  => 'There is no primary key defined when trying to make {0}.',
     'failGetFieldData'                 => 'Failed to get field data from database.',

--- a/system/Model.php
+++ b/system/Model.php
@@ -785,7 +785,7 @@ class Model extends BaseModel
 
     protected function doProtectFieldsForUpdate(array $row): array
     {
-        $this->ensureNoInsertOnlyFields($row, [$this->primaryKey]);
+        $row = $this->doProtectInsertOnlyFieldsForUpdate($row, [$this->primaryKey]);
         $this->ensureNoDisallowedFields($row, [$this->primaryKey]);
 
         return $this->doProtectFields($row);

--- a/system/Model.php
+++ b/system/Model.php
@@ -785,6 +785,7 @@ class Model extends BaseModel
 
     protected function doProtectFieldsForUpdate(array $row): array
     {
+        $this->ensureNoInsertOnlyFields($row, [$this->primaryKey]);
         $this->ensureNoDisallowedFields($row, [$this->primaryKey]);
 
         return $this->doProtectFields($row);

--- a/tests/system/Commands/Generators/ModelGeneratorTest.php
+++ b/tests/system/Commands/Generators/ModelGeneratorTest.php
@@ -53,8 +53,8 @@ final class ModelGeneratorTest extends CIUnitTestCase
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends Model', $this->getFileContent($file));
-        $this->assertStringContainsString('protected $table            = \'users\';', $this->getFileContent($file));
-        $this->assertStringContainsString('protected $returnType       = \'array\';', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $table                  = \'users\';', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $returnType             = \'array\';', $this->getFileContent($file));
     }
 
     public function testGenerateModelWithOptionTable(): void
@@ -63,7 +63,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/Cars.php';
         $this->assertFileExists($file);
-        $this->assertStringContainsString('protected $table            = \'utilisateur\';', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $table                  = \'utilisateur\';', $this->getFileContent($file));
     }
 
     public function testGenerateModelWithOptionDBGroup(): void
@@ -72,7 +72,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
-        $this->assertStringContainsString('protected $DBGroup          = \'testing\';', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $DBGroup                = \'testing\';', $this->getFileContent($file));
     }
 
     public function testGenerateModelWithOptionReturnArray(): void
@@ -81,7 +81,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
-        $this->assertStringContainsString('protected $returnType       = \'array\';', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $returnType             = \'array\';', $this->getFileContent($file));
     }
 
     public function testGenerateModelWithOptionReturnObject(): void
@@ -90,7 +90,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
-        $this->assertStringContainsString('protected $returnType       = \'object\';', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $returnType             = \'object\';', $this->getFileContent($file));
     }
 
     public function testGenerateModelWithOptionReturnEntity(): void
@@ -100,7 +100,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
 
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
-        $this->assertStringContainsString('protected $returnType       = \App\Entities\User::class;', $this->getFileContent($file));
+        $this->assertStringContainsString('protected $returnType             = \App\Entities\User::class;', $this->getFileContent($file));
 
         if (is_file($file)) {
             unlink($file);

--- a/tests/system/Models/InsertOnlyFieldsModelTest.php
+++ b/tests/system/Models/InsertOnlyFieldsModelTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Models;
+
+use CodeIgniter\Database\Exceptions\DataException;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Entity\User;
+use Tests\Support\Models\UserModel;
+use Tests\Support\Models\ValidModel;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class InsertOnlyFieldsModelTest extends LiveModelTestCase
+{
+    public function testInsertAllowsInsertOnlyFields(): void
+    {
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->insert([
+            'name'    => 'Insert Only',
+            'email'   => 'insert-only@example.com',
+            'country' => 'US',
+        ]);
+
+        $this->seeInDatabase('user', [
+            'email' => 'insert-only@example.com',
+        ]);
+    }
+
+    public function testInsertBatchAllowsInsertOnlyFields(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->insertBatch([
+            [
+                'name'    => 'Insert Only Batch',
+                'email'   => 'insert-only-batch@example.com',
+                'country' => 'US',
+            ],
+        ]);
+
+        $this->assertSame(1, $result);
+        $this->seeInDatabase('user', [
+            'email' => 'insert-only-batch@example.com',
+        ]);
+    }
+
+    public function testUpdateThrowsOnInsertOnlyFields(): void
+    {
+        $this->expectException(DataException::class);
+        $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
+
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->update(1, [
+            'name'  => 'Insert Only Update',
+            'email' => 'insert-only-update@example.com',
+        ]);
+    }
+
+    public function testSaveUpdateThrowsOnInsertOnlyFields(): void
+    {
+        $this->expectException(DataException::class);
+        $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
+
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->save([
+            'id'    => 1,
+            'name'  => 'Insert Only Save',
+            'email' => 'insert-only-save@example.com',
+        ]);
+    }
+
+    public function testSetUpdateThrowsOnInsertOnlyFields(): void
+    {
+        $this->expectException(DataException::class);
+        $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
+
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])
+            ->where('id', 1)
+            ->set('email', 'insert-only-set@example.com')
+            ->update(null, ['name' => 'Insert Only Set']);
+    }
+
+    public function testUpdateBatchThrowsOnInsertOnlyFields(): void
+    {
+        $this->expectException(DataException::class);
+        $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
+
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->updateBatch([
+            [
+                'id'    => 1,
+                'name'  => 'Insert Only Batch',
+                'email' => 'insert-only-update-batch@example.com',
+            ],
+        ], 'id');
+    }
+
+    public function testUpdateBatchAllowsInsertOnlyFieldAsIndex(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->updateBatch([
+            [
+                'email' => 'derek@world.com',
+                'name'  => 'Insert Only Batch Index',
+            ],
+        ], 'email');
+
+        $this->assertSame(1, $result);
+        $this->seeInDatabase('user', [
+            'email' => 'derek@world.com',
+            'name'  => 'Insert Only Batch Index',
+        ]);
+    }
+
+    public function testEntityUpdateThrowsOnChangedInsertOnlyFields(): void
+    {
+        $model = new class ($this->db) extends UserModel {
+            protected $returnType       = User::class;
+            protected $insertOnlyFields = ['email'];
+        };
+
+        $user = $model->find(1);
+        $this->assertInstanceOf(User::class, $user);
+
+        $user->email = 'insert-only-entity@example.com';
+
+        $this->expectException(DataException::class);
+        $this->expectExceptionMessage('Fields cannot be updated for model "' . $model::class . '": email');
+
+        $model->update($user->id, $user);
+    }
+
+    public function testEntityUpdateAllowsUnchangedInsertOnlyFields(): void
+    {
+        $model = new class ($this->db) extends UserModel {
+            protected $returnType       = User::class;
+            protected $insertOnlyFields = ['email'];
+        };
+
+        $user = $model->find(1);
+        $this->assertInstanceOf(User::class, $user);
+
+        $user->name = 'Insert Only Entity';
+
+        $this->assertTrue($model->update($user->id, $user));
+        $this->seeInDatabase('user', [
+            'id'   => 1,
+            'name' => 'Insert Only Entity',
+        ]);
+    }
+
+    public function testProtectFalseBypassesInsertOnlyFields(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->protect(false)->update(1, [
+            'email' => 'insert-only-disabled@example.com',
+        ]);
+
+        $this->assertTrue($result);
+        $this->seeInDatabase('user', [
+            'id'    => 1,
+            'email' => 'insert-only-disabled@example.com',
+        ]);
+    }
+
+    public function testValidationRunsBeforeInsertOnlyFields(): void
+    {
+        $model = $this->createModel(ValidModel::class)->setInsertOnlyFields(['description']);
+        $this->setPrivateProperty($model, 'cleanValidationRules', false);
+
+        $this->assertFalse($model->update(1, [
+            'description' => 'Insert only description',
+        ]));
+        $this->assertArrayHasKey('name', $model->errors());
+    }
+}

--- a/tests/system/Models/InsertOnlyFieldsModelTest.php
+++ b/tests/system/Models/InsertOnlyFieldsModelTest.php
@@ -54,46 +54,110 @@ final class InsertOnlyFieldsModelTest extends LiveModelTestCase
         ]);
     }
 
-    public function testUpdateThrowsOnInsertOnlyFields(): void
+    public function testUpdateDiscardsInsertOnlyFieldsByDefault(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->update(1, [
+            'name'  => 'Insert Only Update',
+            'email' => 'insert-only-update@example.com',
+        ]);
+
+        $this->assertTrue($result);
+        $this->seeInDatabase('user', [
+            'id'    => 1,
+            'name'  => 'Insert Only Update',
+            'email' => 'derek@world.com',
+        ]);
+    }
+
+    public function testThrowOnDisallowedFieldsThrowsOnInsertOnlyFields(): void
     {
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
 
-        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->update(1, [
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->throwOnDisallowedFields()->update(1, [
             'name'  => 'Insert Only Update',
             'email' => 'insert-only-update@example.com',
         ]);
     }
 
-    public function testSaveUpdateThrowsOnInsertOnlyFields(): void
+    public function testSaveUpdateDiscardsInsertOnlyFieldsByDefault(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->save([
+            'id'    => 1,
+            'name'  => 'Insert Only Save',
+            'email' => 'insert-only-save@example.com',
+        ]);
+
+        $this->assertTrue($result);
+        $this->seeInDatabase('user', [
+            'id'    => 1,
+            'name'  => 'Insert Only Save',
+            'email' => 'derek@world.com',
+        ]);
+    }
+
+    public function testSaveUpdateThrowsOnInsertOnlyFieldsWhenThrowingOnDisallowedFields(): void
     {
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
 
-        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->save([
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->throwOnDisallowedFields()->save([
             'id'    => 1,
             'name'  => 'Insert Only Save',
             'email' => 'insert-only-save@example.com',
         ]);
     }
 
-    public function testSetUpdateThrowsOnInsertOnlyFields(): void
+    public function testSetUpdateDiscardsInsertOnlyFieldsByDefault(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])
+            ->where('id', 1)
+            ->set('email', 'insert-only-set@example.com')
+            ->update(null, ['name' => 'Insert Only Set']);
+
+        $this->assertTrue($result);
+        $this->seeInDatabase('user', [
+            'id'    => 1,
+            'name'  => 'Insert Only Set',
+            'email' => 'derek@world.com',
+        ]);
+    }
+
+    public function testSetUpdateThrowsOnInsertOnlyFieldsWhenThrowingOnDisallowedFields(): void
     {
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
 
-        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->throwOnDisallowedFields()
             ->where('id', 1)
             ->set('email', 'insert-only-set@example.com')
             ->update(null, ['name' => 'Insert Only Set']);
     }
 
-    public function testUpdateBatchThrowsOnInsertOnlyFields(): void
+    public function testUpdateBatchDiscardsInsertOnlyFieldsByDefault(): void
+    {
+        $result = $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->updateBatch([
+            [
+                'id'    => 1,
+                'name'  => 'Insert Only Batch',
+                'email' => 'insert-only-update-batch@example.com',
+            ],
+        ], 'id');
+
+        $this->assertSame(1, $result);
+        $this->seeInDatabase('user', [
+            'id'    => 1,
+            'name'  => 'Insert Only Batch',
+            'email' => 'derek@world.com',
+        ]);
+    }
+
+    public function testUpdateBatchThrowsOnInsertOnlyFieldsWhenThrowingOnDisallowedFields(): void
     {
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('Fields cannot be updated for model "Tests\Support\Models\UserModel": email');
 
-        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->updateBatch([
+        $this->createModel(UserModel::class)->setInsertOnlyFields(['email'])->throwOnDisallowedFields()->updateBatch([
             [
                 'id'    => 1,
                 'name'  => 'Insert Only Batch',
@@ -118,29 +182,32 @@ final class InsertOnlyFieldsModelTest extends LiveModelTestCase
         ]);
     }
 
-    public function testEntityUpdateThrowsOnChangedInsertOnlyFields(): void
+    public function testEntityUpdateDiscardsChangedInsertOnlyFieldsByDefault(): void
     {
         $model = new class ($this->db) extends UserModel {
-            protected $returnType       = User::class;
-            protected $insertOnlyFields = ['email'];
+            protected $returnType             = User::class;
+            protected array $insertOnlyFields = ['email'];
         };
 
         $user = $model->find(1);
         $this->assertInstanceOf(User::class, $user);
 
         $user->email = 'insert-only-entity@example.com';
+        $user->name  = 'Insert Only Entity';
 
-        $this->expectException(DataException::class);
-        $this->expectExceptionMessage('Fields cannot be updated for model "' . $model::class . '": email');
-
-        $model->update($user->id, $user);
+        $this->assertTrue($model->update($user->id, $user));
+        $this->seeInDatabase('user', [
+            'id'    => 1,
+            'name'  => 'Insert Only Entity',
+            'email' => 'derek@world.com',
+        ]);
     }
 
     public function testEntityUpdateAllowsUnchangedInsertOnlyFields(): void
     {
         $model = new class ($this->db) extends UserModel {
-            protected $returnType       = User::class;
-            protected $insertOnlyFields = ['email'];
+            protected $returnType             = User::class;
+            protected array $insertOnlyFields = ['email'];
         };
 
         $user = $model->find(1);

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -274,7 +274,7 @@ Model
 
 - Added new ``chunkRows()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks.
 - Added new ``firstOrInsert()`` method to ``CodeIgniter\Model`` that finds the first row matching the given attributes or inserts a new one. See :ref:`model-first-or-insert`.
-- Added ``$insertOnlyFields`` and ``setInsertOnlyFields()`` to ``CodeIgniter\Model`` to prevent configured fields from being submitted during Model update operations. See :ref:`model-insert-only-fields`.
+- Added ``$insertOnlyFields`` and ``setInsertOnlyFields()`` to ``CodeIgniter\Model`` to remove configured fields from Model update operations while allowing them during inserts. See :ref:`model-insert-only-fields`.
 - Added ``$throwOnDisallowedFields`` and ``throwOnDisallowedFields()`` to ``CodeIgniter\Model`` to throw a ``DataException`` when write data contains fields that would otherwise be discarded by ``$allowedFields``. See :ref:`model-throw-on-disallowed-fields`.
 
 Libraries

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -274,6 +274,7 @@ Model
 
 - Added new ``chunkRows()`` method to ``CodeIgniter\Model`` for processing large datasets in smaller chunks.
 - Added new ``firstOrInsert()`` method to ``CodeIgniter\Model`` that finds the first row matching the given attributes or inserts a new one. See :ref:`model-first-or-insert`.
+- Added ``$insertOnlyFields`` and ``setInsertOnlyFields()`` to ``CodeIgniter\Model`` to prevent configured fields from being submitted during Model update operations. See :ref:`model-insert-only-fields`.
 - Added ``$throwOnDisallowedFields`` and ``throwOnDisallowedFields()`` to ``CodeIgniter\Model`` to throw a ``DataException`` when write data contains fields that would otherwise be discarded by ``$allowedFields``. See :ref:`model-throw-on-disallowed-fields`.
 
 Libraries

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -163,6 +163,31 @@ potential mass assignment vulnerabilities.
 
 .. note:: The `$primaryKey`_ field should never be an allowed field.
 
+.. _model-insert-only-fields:
+
+$insertOnlyFields
+-----------------
+
+.. versionadded:: 4.8.0
+
+This array may contain fields that can be set during ``insert()`` and
+``insertBatch()`` calls, but cannot be submitted during ``update()``,
+``updateBatch()``, or update-side ``save()`` calls.
+
+This is useful for values that should be created once and then left unchanged
+through normal Model writes, such as public IDs, external references, or
+generated slugs.
+
+.. literalinclude:: model/069.php
+
+Fields listed here must also be listed in `$allowedFields`_ when field
+protection is enabled. This is Model-level protection only. It does not create a
+database constraint, does not inspect previous database values, and does not
+intercept direct Query Builder writes. Calling ``protect(false)`` disables this
+protection.
+
+You may also change this setting with the ``setInsertOnlyFields()`` method.
+
 .. _model-throw-on-disallowed-fields:
 
 $throwOnDisallowedFields
@@ -943,6 +968,11 @@ removed, enable throwing on disallowed fields:
 When throwing on disallowed fields is enabled, operation fields such as the
 primary key passed to ``update()`` or the index passed to ``updateBatch()`` may
 still be used to locate rows.
+
+If some allowed fields should only be set during insert operations, list them
+in `$insertOnlyFields`_:
+
+.. literalinclude:: model/069.php
 
 Occasionally, you will find times where you need to be able to change these elements. This is often during
 testing, migrations, or seeds. In these cases, you can turn the protection on or off:

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -171,8 +171,8 @@ $insertOnlyFields
 .. versionadded:: 4.8.0
 
 This array may contain fields that can be set during ``insert()`` and
-``insertBatch()`` calls, but cannot be submitted during ``update()``,
-``updateBatch()``, or update-side ``save()`` calls.
+``insertBatch()`` calls, but should be removed from ``update()``,
+``updateBatch()``, and update-side ``save()`` calls.
 
 This is useful for values that should be created once and then left unchanged
 through normal Model writes, such as public IDs, external references, or
@@ -183,8 +183,13 @@ generated slugs.
 Fields listed here must also be listed in `$allowedFields`_ when field
 protection is enabled. This is Model-level protection only. It does not create a
 database constraint, does not inspect previous database values, and does not
-intercept direct Query Builder writes. Calling ``protect(false)`` disables this
-protection.
+intercept ``replace()`` or direct Query Builder writes. Calling
+``protect(false)`` disables this protection.
+
+By default, insert-only fields are discarded from update data, the same way
+fields outside `$allowedFields`_ are discarded. When `$throwOnDisallowedFields`_
+is enabled, submitting an insert-only field during an update operation throws a
+``DataException``.
 
 You may also change this setting with the ``setInsertOnlyFields()`` method.
 

--- a/user_guide_src/source/models/model/005.php
+++ b/user_guide_src/source/models/model/005.php
@@ -14,8 +14,8 @@ class UserModel extends Model
     protected $returnType     = 'array';
     protected $useSoftDeletes = true;
 
-    protected $allowedFields    = ['name', 'email'];
-    protected $insertOnlyFields = [];
+    protected $allowedFields          = ['name', 'email'];
+    protected array $insertOnlyFields = [];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;

--- a/user_guide_src/source/models/model/005.php
+++ b/user_guide_src/source/models/model/005.php
@@ -14,7 +14,8 @@ class UserModel extends Model
     protected $returnType     = 'array';
     protected $useSoftDeletes = true;
 
-    protected $allowedFields = ['name', 'email'];
+    protected $allowedFields    = ['name', 'email'];
+    protected $insertOnlyFields = [];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;

--- a/user_guide_src/source/models/model/069.php
+++ b/user_guide_src/source/models/model/069.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class UserModel extends Model
+{
+    protected $allowedFields = ['public_id', 'name', 'email'];
+
+    protected $insertOnlyFields = ['public_id'];
+}

--- a/user_guide_src/source/models/model/069.php
+++ b/user_guide_src/source/models/model/069.php
@@ -8,5 +8,5 @@ class UserModel extends Model
 {
     protected $allowedFields = ['public_id', 'name', 'email'];
 
-    protected $insertOnlyFields = ['public_id'];
+    protected array $insertOnlyFields = ['public_id'];
 }


### PR DESCRIPTION
**Description**

This adds `$insertOnlyFields` to Model.

The goal is to allow fields that can be set when a row is created, but should not be submitted later through Model update operations. This can be useful for values like public IDs, external references, generated slugs, or similar fields that should normally stay unchanged after insert.

Example:

```php
class UserModel extends Model
{
    protected $allowedFields = ['public_id', 'name', 'email'];

    protected $insertOnlyFields = ['public_id'];
}
```

With this configuration, `public_id` is allowed during `insert()` and `insertBatch()`, but `update()`, `updateBatch()`, and update-side `save()` will throw a `DataException` if the field is submitted.

This is only Model-level protection. It does not create a database constraint, does not inspect previous database values, and does not affect direct Query Builder writes. Calling `protect(false)` disables this protection, the same as other field protection.

I also added `setInsertOnlyFields()` for cases where the list needs to be changed at runtime.

Tests cover insert, insertBatch, update, save, set/update, updateBatch, entity updates, validation order, and `protect(false)`.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide