### PR TITLE
refactor(database): optimize `_processForeignKeys()` string allocations and loop invariants

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1072,7 +1072,8 @@ class Forge
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
     {
-        if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
+        if (
+            ! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
             && str_contains(strtolower($field['type']), 'int')
         ) {
             $field['auto_increment'] = ' AUTO_INCREMENT';
@@ -1105,7 +1106,7 @@ class Forge
             $sql .= 'CONSTRAINT ' . $this->db->escapeIdentifiers(($this->primaryKeys['keyName'] === '' ?
                 'pk_' . $table :
                 $this->primaryKeys['keyName']))
-                    . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';
+                . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';
         }
 
         return $sql;
@@ -1225,40 +1226,44 @@ class Forge
             throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
         }
 
-        $sqls = [''];
+        $sqls     = [''];
+        $isOci8   = $this->db->DBDriver === 'OCI8';
+        $dbPrefix = $this->db->DBPrefix;
+        $fkSuffix = $isOci8 ? '_fk' : '_foreign';
+
+        // Niezmienne fragmenty SQL przygotowane przed pętlą
+        $prefixSql = $asQuery
+            ? 'ALTER TABLE ' . $this->db->escapeIdentifiers($dbPrefix . $table) . ' ADD '
+            : ",\n\t";
 
         foreach ($this->foreignKeys as $index => $fkey) {
-            if ($asQuery === false) {
-                $index = 0;
-            } else {
-                $sqls[$index] = '';
-            }
-
-            $nameIndex = $fkey['fkName'] !== '' ?
-            $fkey['fkName'] :
-            $table . '_' . implode('_', $fkey['field']) . ($this->db->DBDriver === 'OCI8' ? '_fk' : '_foreign');
-
-            $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
-            $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
-            $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
+            $idx = $asQuery ? $index : 0;
 
             if ($asQuery) {
-                $sqls[$index] .= 'ALTER TABLE ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $table) . ' ADD ';
-            } else {
-                $sqls[$index] .= ",\n\t";
+                $sqls[$idx] = '';
             }
 
-            $formatSql = 'CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s)';
-            $sqls[$index] .= sprintf($formatSql, $nameIndexFilled, $foreignKeyFilled, $referenceTableFilled, $referenceFieldFilled);
+            $nameIndex = $fkey['fkName'] !== ''
+                ? $fkey['fkName']
+                : $table . '_' . implode('_', $fkey['field']) . $fkSuffix;
+
+            $sql = $prefixSql . sprintf(
+                'CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s)',
+                $this->db->escapeIdentifiers($nameIndex),
+                implode(', ', $this->db->escapeIdentifiers($fkey['field'])),
+                $this->db->escapeIdentifiers($dbPrefix . $fkey['referenceTable']),
+                implode(', ', $this->db->escapeIdentifiers($fkey['referenceField'])),
+            );
 
             if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $this->fkAllowActions, true)) {
-                $sqls[$index] .= ' ON DELETE ' . $fkey['onDelete'];
+                $sql .= ' ON DELETE ' . $fkey['onDelete'];
             }
 
-            if ($this->db->DBDriver !== 'OCI8' && $fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $this->fkAllowActions, true)) {
-                $sqls[$index] .= ' ON UPDATE ' . $fkey['onUpdate'];
+            if (! $isOci8 && $fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $this->fkAllowActions, true)) {
+                $sql .= ' ON UPDATE ' . $fkey['onUpdate'];
             }
+
+            $sqls[$idx] .= $sql;
         }
 
         return $sqls;

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1072,8 +1072,7 @@ class Forge
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
     {
-        if (
-            ! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
+        if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
             && str_contains(strtolower($field['type']), 'int')
         ) {
             $field['auto_increment'] = ' AUTO_INCREMENT';
@@ -1106,7 +1105,7 @@ class Forge
             $sql .= 'CONSTRAINT ' . $this->db->escapeIdentifiers(($this->primaryKeys['keyName'] === '' ?
                 'pk_' . $table :
                 $this->primaryKeys['keyName']))
-                . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';
+                    . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';
         }
 
         return $sql;
@@ -1210,6 +1209,10 @@ class Forge
      */
     protected function _processForeignKeys(string $table, bool $asQuery = false): array
     {
+        if ($this->foreignKeys === []) {
+            return [''];
+        }
+
         $errorNames = [];
 
         foreach ($this->foreignKeys as $fkeyInfo) {
@@ -1231,7 +1234,6 @@ class Forge
         $dbPrefix = $this->db->DBPrefix;
         $fkSuffix = $isOci8 ? '_fk' : '_foreign';
 
-        // Niezmienne fragmenty SQL przygotowane przed pętlą
         $prefixSql = $asQuery
             ? 'ALTER TABLE ' . $this->db->escapeIdentifiers($dbPrefix . $table) . ' ADD '
             : ",\n\t";


### PR DESCRIPTION
**Description**
Refactors `_processForeignKeys()` in `Forge.php` to optimize performance and reduce memory allocations:
- Calculates invariant SQL fragments (e.g., driver checks, `fkSuffix`, `prefixSql`) once outside the main loop.
- Caches the escaped table identifier, significantly reducing repeated calls to `$this->db->escapeIdentifiers()`.
- Builds the SQL constraint string locally in memory using a single `sprintf()` and string appending before performing a single concatenation to the `$sqls` array. This saves multiple intermediate array lookup and string allocations per foreign key.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
