### PR TITLE
fix: support array indexes in `getPostGet()` and `getGetPost()`

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -602,6 +602,16 @@ class IncomingRequest extends Request
             return array_merge($this->getGet($index, $filter, $flags), $this->getPost($index, $filter, $flags));
         }
 
+        if (is_array($index)) {
+            $output = [];
+
+            foreach ($index as $key) {
+                $output[$key] = $this->getPostGet($key, $filter, $flags);
+            }
+
+            return $output;
+        }
+
         // Use $_POST directly here, since filter_has_var only
         // checks the initial POST data, not anything that might
         // have been added since.
@@ -623,6 +633,16 @@ class IncomingRequest extends Request
     {
         if ($index === null) {
             return array_merge($this->getPost($index, $filter, $flags), $this->getGet($index, $filter, $flags));
+        }
+
+        if (is_array($index)) {
+            $output = [];
+
+            foreach ($index as $key) {
+                $output[$key] = $this->getGetPost($key, $filter, $flags);
+            }
+
+            return $output;
         }
 
         // Use $_GET directly here, since filter_has_var only

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -101,6 +101,34 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame('3', $this->request->getGetPost('TEST'));
     }
 
+    public function testCanGrabMultiplePostAndGetVars(): void
+    {
+        service('superglobals')
+            ->setPostArray([
+                'post'   => 'post value',
+                'shared' => 'post shared value',
+            ])
+            ->setGetArray([
+                'get'    => 'get value',
+                'shared' => 'get shared value',
+            ]);
+
+        $index = ['post', 'get', 'shared', 'missing'];
+
+        $this->assertSame([
+            'post'    => 'post value',
+            'get'     => 'get value',
+            'shared'  => 'post shared value',
+            'missing' => null,
+        ], $this->request->getPostGet($index));
+        $this->assertSame([
+            'post'    => 'post value',
+            'get'     => 'get value',
+            'shared'  => 'get shared value',
+            'missing' => null,
+        ], $this->request->getGetPost($index));
+    }
+
     public function testNoOldInput(): void
     {
         $this->assertNull($this->request->getOldInput('name'));

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -84,6 +84,7 @@ Bugs Fixed
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
 - **Encryption:** Fixed bugs in ``SodiumHandler`` where runtime ``blockSize`` overrides without ``key`` were handled incorrectly, invalid key lengths could leak native Sodium errors, and mismatched decrypt ``blockSize`` values could throw ``SodiumException`` instead of ``EncryptionException``.
 - **Filters:** Fixed a bug in ``InvalidChars`` filter where invalid UTF-8 or control characters in array keys were not checked.
+- **HTTP:** Fixed a bug where ``IncomingRequest::getPostGet()`` and ``IncomingRequest::getGetPost()`` threw a ``TypeError`` when passed an array of indexes.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.
 - **Model:** Fixed a bug in ``Model::objectToRawArray()`` where the ``$recursive`` parameter was ignored.
 - **Security:** Fixed a bug where ``CheckPhpIni`` could raise a type error when ``ini_get_all()`` returned ``null`` for a configured directive value.

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -384,7 +384,7 @@ The methods provided by the parent classes that are available are:
 
     .. php:method:: getGet([$index = null[, $filter = null[, $flags = null]]])
 
-        :param  string  $index: The name of the variable/key to look for.
+        :param  array|string  $index: The name of the variable/key to look for, or an array of names.
         :param  int     $filter: The type of filter to apply. A list of filters can be found in
                         `Types of filters <https://www.php.net/manual/en/filters.php>`__.
         :param  int     $flags: Flags to apply. A list of flags can be found in
@@ -423,7 +423,7 @@ The methods provided by the parent classes that are available are:
 
     .. php:method:: getPost([$index = null[, $filter = null[, $flags = null]]])
 
-        :param  string  $index: The name of the variable/key to look for.
+        :param  array|string  $index: The name of the variable/key to look for, or an array of names.
         :param  int     $filter: The type of filter to apply. A list of filters can be
                         found `here <https://www.php.net/manual/en/filters.php>`__.
         :param  int     $flags: Flags to apply. A list of flags can be found
@@ -435,7 +435,7 @@ The methods provided by the parent classes that are available are:
 
     .. php:method:: getPostGet([$index = null[, $filter = null[, $flags = null]]])
 
-        :param  string  $index: The name of the variable/key to look for.
+        :param  array|string  $index: The name of the variable/key to look for, or an array of names.
         :param  int     $filter: The type of filter to apply. A list of filters can be found in
                         `Types of filters <https://www.php.net/manual/en/filters.php>`__.
         :param  int     $flags: Flags to apply. A list of flags can be found in
@@ -450,12 +450,15 @@ The methods provided by the parent classes that are available are:
 
         .. literalinclude:: incomingrequest/032.php
 
+        If an array of indexes is specified, the method returns an associative array and applies
+        the POST-then-GET lookup order to each index.
+
         If no index is specified, it will return both POST and GET streams combined.
         Although POST data will be preferred in case of name conflict.
 
     .. php:method:: getGetPost([$index = null[, $filter = null[, $flags = null]]])
 
-        :param  string  $index: The name of the variable/key to look for.
+        :param  array|string  $index: The name of the variable/key to look for, or an array of names.
         :param  int     $filter: The type of filter to apply. A list of filters can be found in
                         `Types of filters <https://www.php.net/manual/en/filters.php>`__.
         :param  int     $flags: Flags to apply. A list of flags can be found in
@@ -469,6 +472,9 @@ The methods provided by the parent classes that are available are:
         then in POST:
 
         .. literalinclude:: incomingrequest/033.php
+
+        If an array of indexes is specified, the method returns an associative array and applies
+        the GET-then-POST lookup order to each index.
 
         If no index is specified, it will return both GET and POST streams combined.
         Although GET data will be preferred in case of name conflict.
@@ -534,4 +540,3 @@ The methods provided by the parent classes that are available are:
         .. note:: Prior to v4.4.0, this was the safest method to determine the
             "current URI", since ``IncomingRequest::$uri`` might not be aware of
             the complete App configuration for base URLs.
-

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1825 errors
+# total 1827 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/method.notFound.neon
+++ b/utils/phpstan-baseline/method.notFound.neon
@@ -1,4 +1,4 @@
-# total 78 errors
+# total 80 errors
 
 parameters:
     ignoreErrors:
@@ -69,7 +69,7 @@ parameters:
 
         -
             message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getGetPost\(\)\.$#'
-            count: 5
+            count: 6
             path: ../../tests/system/HTTP/IncomingRequestTest.php
 
         -
@@ -89,7 +89,7 @@ parameters:
 
         -
             message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getPostGet\(\)\.$#'
-            count: 5
+            count: 6
             path: ../../tests/system/HTTP/IncomingRequestTest.php
 
         -


### PR DESCRIPTION
**Description**
This PR fixes `IncomingRequest::getPostGet()` and `getGetPost()` throwing a `TypeError` when passed an array of indexes. Each index now respects the expected GET/POST precedence, with tests and documentation updates.

Closes #10361

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
