### PR TITLE
chore: adapt output buffer handling to PHPStan 2.2.3

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -119,7 +119,7 @@ if (! function_exists('command')) {
      *
      *  > command('migrate:create SomeMigration');
      *
-     * @return string
+     * @return false|string
      */
     function command(string $command)
     {
@@ -185,13 +185,21 @@ if (! function_exists('command')) {
             $params[$arg] = $value;
         }
 
+        $bufferLevel = ob_get_level();
+
         try {
             ob_start();
             service('commands')->run($command, $params);
 
+            if (ob_get_level() <= $bufferLevel) {
+                return false;
+            }
+
             return ob_get_contents();
         } finally {
-            ob_end_clean();
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
         }
     }
 }

--- a/system/Common.php
+++ b/system/Common.php
@@ -119,7 +119,7 @@ if (! function_exists('command')) {
      *
      *  > command('migrate:create SomeMigration');
      *
-     * @return false|string
+     * @return string
      */
     function command(string $command)
     {

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -58,9 +58,7 @@ final class CommonFunctionsSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Set-Cookie: foo=onething;');

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -377,9 +377,7 @@ final class DownloadResponseTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Content-Length: ' . filesize(__FILE__));

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -67,9 +67,7 @@ final class ResponseSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Date:');
@@ -102,9 +100,7 @@ final class ResponseSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?; test both ways
         $this->assertHeaderEmitted('Content-Security-Policy:');
@@ -140,9 +136,7 @@ final class ResponseSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Set-Cookie: foo=bar;');
@@ -213,9 +207,7 @@ final class ResponseSendTest extends CIUnitTestCase
         header('Access-Control-Expose-Headers: Content-Encoding');
         header('Allow: GET, POST');
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // single header
         $this->assertHeaderEmitted('Vary: Accept-Encoding');

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -100,7 +100,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
         return $fileContents . 'echo FCPATH;' . PHP_EOL;
     }
 
-    private function readOutput(string $file): false|string
+    private function readOutput(string $file): string
     {
         ob_start();
         system('php -f ' . $file);

--- a/tests/system/Test/TestCaseEmissionsTest.php
+++ b/tests/system/Test/TestCaseEmissionsTest.php
@@ -62,9 +62,7 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?; test both ways
         $this->assertHeaderEmitted('Set-Cookie: foo=bar;');
@@ -90,9 +88,7 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send(); // what really was sent
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         $this->assertHeaderNotEmitted('Set-Cookie: pop=corn', true);
     }


### PR DESCRIPTION
**Description**

This PR fixes PHPStan failures after `phpstan/phpstan` started resolving to `2.2.3`.

PHPStan now narrows `ob_get_contents()` / `ob_get_clean()` / `ob_get_flush()` / `ob_get_length()` to non-`false` while output buffering is active: https://github.com/phpstan/phpstan-src/pull/5909

Because of that, a few existing output-buffering tests now report redundant `ob_get_level() > 0` checks, and helper return types can be narrowed from `false|string` to `string`.

There is no behavior change.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide