### PR TITLE
refactor(tests): remove redundant ob_get_level() checks after ob_start()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -119,7 +119,7 @@ if (! function_exists('command')) {
      *
      *  > command('migrate:create SomeMigration');
      *
-     * @return false|string
+     * @return string
      */
     function command(string $command)
     {

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -58,9 +58,7 @@ final class CommonFunctionsSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Set-Cookie: foo=onething;');

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -377,9 +377,7 @@ final class DownloadResponseTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Content-Length: ' . filesize(__FILE__));

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -67,9 +67,7 @@ final class ResponseSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Date:');
@@ -102,9 +100,7 @@ final class ResponseSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?; test both ways
         $this->assertHeaderEmitted('Content-Security-Policy:');
@@ -140,9 +136,7 @@ final class ResponseSendTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?
         $this->assertHeaderEmitted('Set-Cookie: foo=bar;');
@@ -213,9 +207,7 @@ final class ResponseSendTest extends CIUnitTestCase
         header('Access-Control-Expose-Headers: Content-Encoding');
         header('Allow: GET, POST');
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // single header
         $this->assertHeaderEmitted('Vary: Accept-Encoding');

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -100,7 +100,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
         return $fileContents . 'echo FCPATH;' . PHP_EOL;
     }
 
-    private function readOutput(string $file): false|string
+    private function readOutput(string $file): string
     {
         ob_start();
         system('php -f ' . $file);

--- a/tests/system/Test/TestCaseEmissionsTest.php
+++ b/tests/system/Test/TestCaseEmissionsTest.php
@@ -62,9 +62,7 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send();
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         // and what actually got sent?; test both ways
         $this->assertHeaderEmitted('Set-Cookie: foo=bar;');
@@ -90,9 +88,7 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
         // send it
         ob_start();
         $response->send(); // what really was sent
-        if (ob_get_level() > 0) {
-            ob_end_clean();
-        }
+        ob_end_clean();
 
         $this->assertHeaderNotEmitted('Set-Cookie: pop=corn', true);
     }


### PR DESCRIPTION
**Description**
This PR resolves two types of static analysis warnings introduced by PHPStan 2.x:

1. **`greater.alwaysTrue`**: `"Comparison operation '>' between int<1, max> and 0 is always true"` is reported when `ob_get_level() > 0` is checked immediately after `ob_start()`. Since output buffering is guaranteed to be active, checking if `ob_get_level() > 0` before cleaning the buffer is redundant. The condition was removed, and direct `ob_end_clean()` calls are used instead.
   * *Affected files:* 
     * `tests/system/Test/TestCaseEmissionsTest.php`
     * `tests/system/HTTP/ResponseSendTest.php`
     * `tests/system/HTTP/DownloadResponseTest.php`
     * `tests/system/CommonFunctionsSendTest.php`

2. **`return.unusedType`**: `"Function/Method never returns false so it can be removed from the return type"` is reported when a function signature includes `false` in its return type but never actually returns it. Since `ob_get_contents()` and `ob_get_clean()` are guaranteed to return strings when output buffering is active, the `false` return type was removed.
   * *Affected files:*
     * `system/Common.php` (for the helper function `command()`)
     * `tests/system/Test/BootstrapFCPATHTest.php` (for the private method `readOutput()`)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
