### PR TITLE
fix: preserve zero values in XML export

### DIFF
--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -250,7 +250,7 @@ abstract class BaseUtils
             $xml .= $tab . '<' . $element . '>' . $newline;
 
             foreach ($row as $key => $val) {
-                $val = empty($val) ? '' : xml_convert((string) $val);
+                $val = ($val === null || $val === '') ? '' : xml_convert((string) $val);
 
                 $xml .= $tab . $tab . '<' . $key . '>' . $val . '</' . $key . '>' . $newline;
             }

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -205,4 +205,24 @@ final class DbUtilsTest extends CIUnitTestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    public function testUtilsXMLFromResultWithZero(): void
+    {
+        $this->db->table('job')->insert([
+            'name'        => '0',
+            'description' => 'Testing zero value',
+        ]);
+        $data = $this->db->table('job')->where('name', '0')->get();
+
+        $util = (new Database())->loadUtils($this->db);
+
+        $data = $util->getXMLFromResult($data);
+
+        $expected = '<root><element><id>5</id><name>0</name><description>Testing zero value</description><created_at></created_at><updated_at></updated_at><deleted_at></deleted_at></element></root>';
+
+        $actual = preg_replace('#\R+#', '', $data);
+        $actual = preg_replace('/[ ]{2,}|[\t]/', '', $actual);
+
+        $this->assertSame($expected, $actual);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.7.4.rst
+++ b/user_guide_src/source/changelogs/v4.7.4.rst
@@ -82,6 +82,7 @@ Bugs Fixed
 - **Commands:** Fixed a bug where ``spark lang:find`` treated translation keys already provided by the framework or another namespace (such as ``Errors.*`` in ``system/Language``) as new, listing them under ``--show-new`` and writing untranslated placeholders into ``app/Language`` that overrode the existing translations.
 - **Config:** Fixed a bug where ``BaseService::injectMock`` did not apply ``strtolower`` consistently, causing inconsistent Service and Mock registration and resolution.
 - **Database:** Fixed a bug where ``updateBatch()`` could be called after Query Builder ``where()`` conditions, even though it's not supported. In this situation, now the ``DatabaseException`` is thrown.
+- **Database:** Fixed a bug in ``BaseUtils::getXMLFromResult()`` where database values of ``0`` or ``'0'`` were treated as empty and omitted from the generated XML export.
 - **Encryption:** Fixed bugs in ``SodiumHandler`` where runtime ``blockSize`` overrides without ``key`` were handled incorrectly, invalid key lengths could leak native Sodium errors, and mismatched decrypt ``blockSize`` values could throw ``SodiumException`` instead of ``EncryptionException``.
 - **Filters:** Fixed a bug in ``InvalidChars`` filter where invalid UTF-8 or control characters in array keys were not checked.
 - **HTTP:** Fixed a bug where the User Agent library reported Safari's WebKit version instead of the browser version from the ``Version`` token.

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -54,7 +54,7 @@ parameters:
 
         -
             message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-            count: 4
+            count: 3
             path: ../../system/Database/BaseUtils.php
 
         -


### PR DESCRIPTION
**Description**
In `BaseUtils::getXMLFromResult()`, database values of `0` or `'0'` were incorrectly treated as empty and replaced with empty strings (`''`) in the generated XML export due to the use of the `empty()` check.

This PR replaces `empty($val)` with a strict comparison `($val === null || $val === '')` to ensure that zero values are preserved in the exported XML, while still correctly replacing actual `null` and empty string values with an empty element value.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
