### PR TITLE
test: skip unsupported Session DB handler tests before setup

### DIFF
--- a/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php
+++ b/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php
@@ -37,11 +37,11 @@ abstract class AbstractHandlerTestCase extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (! in_array(config(DatabaseConfig::class)->tests['DBDriver'], ['MySQLi', 'Postgre'], true)) {
             $this->markTestSkipped('Database Session Handler requires database driver to be MySQLi or Postgre');
         }
+
+        parent::setUp();
     }
 
     /**


### PR DESCRIPTION
**Description**
Ref: #9968

This PR moves the `markTestSkipped` logic earlier in the setup phase for session tests. By checking the skip conditions before the database is initialized, we avoid unnecessary setup operations and improve test execution speed.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
