### PR TITLE
test: resolve service registry pollution in CSRFTest

### DIFF
--- a/.github/scripts/random-tests-config.txt
+++ b/.github/scripts/random-tests-config.txt
@@ -25,7 +25,7 @@ Cookie
 # Entity
 Events
 Files
-# Filters
+Filters
 Format
 HTTP
 # Helpers

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -40,6 +40,9 @@ final class CSRFTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->resetServices();
+
         $this->config = new \Config\Filters();
     }
 


### PR DESCRIPTION
**Description**
This PR resolves a test pollution issue in the Filters test suite causing `CSRFTest` execution failures under random order (`--order-by=random`).
Ref: #9968
**Key Changes:**
- **`tests/system/Filters/CSRFTest.php`**: Added `$this->resetServices()` to `setUp()`. When `CSRFTest` runs after tests that mock/clear the shared `superglobals` instance (like `IncomingRequestTest`), the empty state persists in the shared registry, causing `testDoNotCheckCliRequest` to fail with a `TypeError` due to missing `argv` in `CLIRequest`, and `testPassGetRequest` to fail with a `SecurityException` due to a mutated `REQUEST_METHOD`.
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide