### PR TITLE
fix: resolve race conditions in Redis TTL and prevent cache test state leakage

### DIFF
--- a/.github/scripts/random-tests-config.txt
+++ b/.github/scripts/random-tests-config.txt
@@ -11,7 +11,7 @@
 API
 AutoReview
 Autoloader
-# Cache
+Cache
 CLI
 Commands
 Config

--- a/tests/system/Cache/Handlers/ApcuHandlerTest.php
+++ b/tests/system/Cache/Handlers/ApcuHandlerTest.php
@@ -27,30 +27,24 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 #[RequiresPhpExtension('apcu')]
 final class ApcuHandlerTest extends AbstractHandlerTestCase
 {
-    /**
-     * @return list<string>
-     */
-    private static function getKeyArray(): array
-    {
-        return [
-            self::$key1,
-            self::$key2,
-            self::$key3,
-        ];
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
+
+        if (! function_exists('apcu_enabled') || ! apcu_enabled()) {
+            $this->markTestSkipped('APCu extension is not loaded or not enabled in CLI.');
+        }
 
         $this->handler = CacheFactory::getHandler(new Cache(), 'apcu');
     }
 
     protected function tearDown(): void
     {
-        foreach (self::getKeyArray() as $key) {
-            $this->handler->delete($key);
+        if (isset($this->handler)) {
+            $this->handler->clean();
         }
+
+        parent::tearDown();
     }
 
     public function testNew(): void

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -31,18 +31,6 @@ final class FileHandlerTest extends AbstractHandlerTestCase
     private static string $directory = 'FileHandler';
     private Cache $config;
 
-    /**
-     * @return list<string>
-     */
-    private static function getKeyArray(): array
-    {
-        return [
-            self::$key1,
-            self::$key2,
-            self::$key3,
-        ];
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -69,15 +57,8 @@ final class FileHandlerTest extends AbstractHandlerTestCase
         if (is_dir($this->config->file['storePath'])) {
             chmod($this->config->file['storePath'], 0777);
 
-            foreach (self::getKeyArray() as $key) {
-                if (is_file($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $key)) {
-                    chmod($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $key, 0777);
-                    unlink($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $key);
-                }
-                if (is_file($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . $key)) {
-                    chmod($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . $key, 0777);
-                    unlink($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . $key);
-                }
+            if (isset($this->handler)) {
+                $this->handler->clean();
             }
 
             rmdir($this->config->file['storePath']);
@@ -118,7 +99,7 @@ final class FileHandlerTest extends AbstractHandlerTestCase
      */
     public function testGet(): void
     {
-        $this->handler->save(self::$key1, 'value', 2);
+        $this->assertTrue($this->handler->save(self::$key1, 'value', 2));
 
         $this->assertSame('value', $this->handler->get(self::$key1));
         $this->assertNull($this->handler->get(self::$dummy));

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -26,18 +26,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('CacheLive')]
 final class MemcachedHandlerTest extends AbstractHandlerTestCase
 {
-    /**
-     * @return list<string>
-     */
-    private static function getKeyArray(): array
-    {
-        return [
-            self::$key1,
-            self::$key2,
-            self::$key3,
-        ];
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -51,9 +39,11 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
-        foreach (self::getKeyArray() as $key) {
-            $this->handler->delete($key);
+        if (isset($this->handler)) {
+            $this->handler->clean();
         }
+
+        parent::tearDown();
     }
 
     public function testNew(): void

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -27,18 +27,6 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 {
     private Cache $config;
 
-    /**
-     * @return list<string>
-     */
-    private static function getKeyArray(): array
-    {
-        return [
-            self::$key1,
-            self::$key2,
-            self::$key3,
-        ];
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -49,9 +37,11 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
-        foreach (self::getKeyArray() as $key) {
-            $this->handler->delete($key);
+        if (isset($this->handler)) {
+            $this->handler->clean();
         }
+
+        parent::tearDown();
     }
 
     public function testNew(): void

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -28,18 +28,6 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 {
     private Cache $config;
 
-    /**
-     * @return list<string>
-     */
-    private static function getKeyArray(): array
-    {
-        return [
-            self::$key1,
-            self::$key2,
-            self::$key3,
-        ];
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -54,9 +42,11 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
-        foreach (self::getKeyArray() as $key) {
-            $this->handler->delete($key);
+        if (isset($this->handler)) {
+            $this->handler->clean();
         }
+
+        parent::tearDown();
     }
 
     public function testNew(): void


### PR DESCRIPTION
**Description**
This PR fixes persistent and random failures when running the cache test suite (`tests/system/Cache`) repeatedly or in a random order (`--order-by=random`). 

Ref: #9968

Changes included:
1. **Fix TTL Race Condition in Redis/Predis Handlers**: Changed the `PredisHandler` and `RedisHandler` to use the `expire()` command directly with a relative TTL (in seconds) instead of calculating an absolute timestamp for `expireAt()` via PHP's `Time::now()`. Using a PHP-generated timestamp makes the cache vulnerable to clock drifts between the PHP server and the Redis server. This drift resulted in random test failures (e.g. `testGet` and `testRemember` failing to assert `null` after waiting for 3 seconds).
2. **Prevent State Leakage in Tests**: Several test classes (`FileHandlerTest`, `RedisHandlerTest`, `PredisHandlerTest`, `ApcuHandlerTest`, `MemcachedHandlerTest`) inherited `testDeleteMatching` which temporarily created 50-100 cache entries. The `tearDown()` methods previously only deleted three predefined default keys (`key1`, `key2`, `key3`), leaving dozens of dummy keys behind. This leaked state caused random `Directory not empty` system errors for `FileHandler` and false-positive assertion failures in tests like `testDeleteMatchingNothing`. `tearDown()` now properly calls `$this->handler->clean()` to guarantee a perfectly clean state for the next random test.
3. **Proper ApcuHandlerTest Skip Logic**: Added an explicit check in `ApcuHandlerTest`'s `setUp()` to verify `apcu_enabled()`. This correctly skips the test when APCu CLI mode is disabled instead of falling back to the `DummyHandler` and producing cascaded test failures.

**Checklist:**
- [x] Securely signed commits (if configured in your environment)
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
