### PR TITLE
feat: add HTTP `QUERY` method support

### DIFF
--- a/system/Filters/PageCache.php
+++ b/system/Filters/PageCache.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Filters;
 use CodeIgniter\Cache\ResponseCache;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\NonBufferedResponseInterface;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
@@ -53,6 +54,10 @@ class PageCache implements FilterInterface
     {
         assert($request instanceof CLIRequest || $request instanceof IncomingRequest);
 
+        if ($request instanceof IncomingRequest && $request->getMethod() === Method::QUERY) {
+            return null;
+        }
+
         $response = service('response');
 
         return $this->pageCache->get($request, $response);
@@ -66,6 +71,10 @@ class PageCache implements FilterInterface
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
         assert($request instanceof CLIRequest || $request instanceof IncomingRequest);
+
+        if ($request instanceof IncomingRequest && $request->getMethod() === Method::QUERY) {
+            return null;
+        }
 
         if (
             ! $response instanceof NonBufferedResponseInterface

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -293,6 +293,16 @@ class CURLRequest extends OutgoingRequest
     }
 
     /**
+     * Convenience method for sending a QUERY request.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function query(string $url, array $options = []): ResponseInterface
+    {
+        return $this->request(Method::QUERY, $url, $options);
+    }
+
+    /**
      * Set the HTTP Authentication.
      *
      * @param string $type basic or digest

--- a/system/HTTP/FormRequest.php
+++ b/system/HTTP/FormRequest.php
@@ -223,10 +223,10 @@ abstract class FormRequest
      * multiple sources. By default, data is sourced from the appropriate
      * part of the request based on HTTP method and Content-Type:
      *
-     * - JSON (any method)      - decoded JSON body
-     * - PUT / PATCH / DELETE   - raw body (unless multipart/form-data)
-     * - GET / HEAD             - query-string parameters
-     * - Everything else (POST) - POST body
+     * - JSON (any method)              - decoded JSON body
+     * - PUT / PATCH / DELETE / QUERY   - raw body (unless multipart/form-data)
+     * - GET / HEAD                     - query-string parameters
+     * - Everything else (POST)         - POST body
      *
      * @return array<string, mixed>
      */
@@ -239,7 +239,7 @@ abstract class FormRequest
         }
 
         if (
-            in_array($this->request->getMethod(), [Method::PUT, Method::PATCH, Method::DELETE], true)
+            in_array($this->request->getMethod(), [Method::PUT, Method::PATCH, Method::DELETE, Method::QUERY], true)
             && ! str_contains($contentType, 'multipart/form-data')
         ) {
             return $this->request->getRawInput() ?? [];

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -503,7 +503,7 @@ class IncomingRequest extends Request
     }
 
     /**
-     * A convenience method that grabs the raw input stream(send method in PUT, PATCH, DELETE) and decodes
+     * A convenience method that grabs the raw input stream (send method in PUT, PATCH, DELETE, QUERY) and decodes
      * the String into an array.
      *
      * @return array
@@ -516,7 +516,7 @@ class IncomingRequest extends Request
     }
 
     /**
-     * Gets a specific variable from raw input stream (send method in PUT, PATCH, DELETE).
+     * Gets a specific variable from raw input stream (send method in PUT, PATCH, DELETE, QUERY).
      *
      * @param array|string|null $index  The variable that you want which can use dot syntax for getting specific values.
      * @param int|null          $filter Filter Constant

--- a/system/HTTP/Method.php
+++ b/system/HTTP/Method.php
@@ -93,6 +93,15 @@ class Method
     /**
      * Safe: Yes
      * Idempotent: Yes
+     * Cacheable: Yes
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc10008.html
+     */
+    public const QUERY = 'QUERY';
+
+    /**
+     * Safe: Yes
+     * Idempotent: Yes
      * Cacheable: No
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/TRACE
@@ -115,6 +124,7 @@ class Method
             self::PATCH,
             self::POST,
             self::PUT,
+            self::QUERY,
             self::TRACE,
         ];
     }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -143,6 +143,7 @@ class RouteCollection implements RouteCollectionInterface
         Method::OPTIONS => [],
         Method::GET     => [],
         Method::HEAD    => [],
+        Method::QUERY   => [],
         Method::POST    => [],
         Method::PATCH   => [],
         Method::PUT     => [],
@@ -168,6 +169,7 @@ class RouteCollection implements RouteCollectionInterface
         Method::OPTIONS => [],
         Method::GET     => [],
         Method::HEAD    => [],
+        Method::QUERY   => [],
         Method::POST    => [],
         Method::PATCH   => [],
         Method::PUT     => [],
@@ -1098,6 +1100,19 @@ class RouteCollection implements RouteCollectionInterface
     public function head(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
         $this->create(Method::HEAD, $from, $to, $options);
+
+        return $this;
+    }
+
+    /**
+     * Specifies a route that is only available to QUERY requests.
+     *
+     * @param array<string, mixed>|(Closure(mixed...): (ResponseInterface|string|void))|string $to
+     * @param array<string, mixed>|null                                                        $options
+     */
+    public function query(string $from, $to, ?array $options = null): RouteCollectionInterface
+    {
+        $this->create(Method::QUERY, $from, $to, $options);
 
         return $this;
     }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -43,6 +43,7 @@ class Router implements RouterInterface
     public const HTTP_METHODS = [
         Method::GET,
         Method::HEAD,
+        Method::QUERY,
         Method::POST,
         Method::PATCH,
         Method::PUT,

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -297,6 +297,21 @@ trait FeatureTestTrait
     }
 
     /**
+     * Performs a QUERY request.
+     *
+     * @param array<string, mixed>|null $params
+     *
+     * @return TestResponse
+     *
+     * @throws RedirectException
+     * @throws Exception
+     */
+    public function query(string $path, ?array $params = null)
+    {
+        return $this->call(Method::QUERY, $path, $params);
+    }
+
+    /**
      * Setup a Request object to use so that CodeIgniter
      * won't try to auto-populate some of the items.
      *

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -535,7 +535,7 @@ class Validation implements ValidationInterface
             return $this;
         }
 
-        if (in_array($request->getMethod(), [Method::PUT, Method::PATCH, Method::DELETE], true)
+        if (in_array($request->getMethod(), [Method::PUT, Method::PATCH, Method::DELETE, Method::QUERY], true)
             && ! str_contains($request->getHeaderLine('Content-Type'), 'multipart/form-data')
         ) {
             $this->data = $request->getRawInput();

--- a/tests/system/Commands/Utilities/RoutesTest.php
+++ b/tests/system/Commands/Utilities/RoutesTest.php
@@ -32,6 +32,10 @@ final class RoutesTest extends CIUnitTestCase
     {
         $this->resetServices();
         parent::setUp();
+
+        service('superglobals')
+            ->setServer('HTTP_HOST', 'example.com')
+            ->setServer('SERVER_NAME', 'example.com');
     }
 
     protected function tearDown(): void
@@ -68,6 +72,7 @@ final class RoutesTest extends CIUnitTestCase
             | GET     | closure | »             | (Closure)                              |                |               |
             | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | QUERY   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PATCH   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
@@ -104,6 +109,7 @@ final class RoutesTest extends CIUnitTestCase
             | GET     | /       | »             | \App\Controllers\Home::index           |                |               |
             | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | QUERY   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PATCH   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
@@ -133,6 +139,7 @@ final class RoutesTest extends CIUnitTestCase
             | GET     | all     | »             | \App\Controllers\AllDomain::index      |                |               |
             | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | QUERY   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PATCH   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
@@ -162,6 +169,7 @@ final class RoutesTest extends CIUnitTestCase
             | GET     | all     | »             | \App\Controllers\AllDomain::index      |                |               |
             | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | QUERY   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PATCH   | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
@@ -193,6 +201,7 @@ final class RoutesTest extends CIUnitTestCase
             | GET        | closure                        | »             | (Closure)                                           |                |               |
             | GET        | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
             | HEAD       | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | QUERY      | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
             | POST       | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
             | PATCH      | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
             | PUT        | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
@@ -228,6 +237,7 @@ final class RoutesTest extends CIUnitTestCase
             | GET     | closure          | »             | (Closure)                              |                |               |
             | GET     | testing          | testing-index | \App\Controllers\TestController::index |                |               |
             | HEAD    | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | QUERY   | testing          | testing-index | \App\Controllers\TestController::index |                |               |
             | POST    | testing          | testing-index | \App\Controllers\TestController::index |                |               |
             | PATCH   | testing          | testing-index | \App\Controllers\TestController::index |                |               |
             | PUT     | testing          | testing-index | \App\Controllers\TestController::index |                |               |

--- a/tests/system/Filters/PageCacheTest.php
+++ b/tests/system/Filters/PageCacheTest.php
@@ -171,7 +171,7 @@ final class PageCacheTest extends CIUnitTestCase
         ]), 60);
 
         $result = $filter->before($request);
-        $this->assertNull($result);
+        $this->assertNotInstanceOf(ResponseInterface::class, $result);
 
         service('cache')->delete($key);
     }

--- a/tests/system/Filters/PageCacheTest.php
+++ b/tests/system/Filters/PageCacheTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -31,14 +32,15 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class PageCacheTest extends CIUnitTestCase
 {
-    private function createRequest(): IncomingRequest
+    private function createRequest(string $method = Method::GET): IncomingRequest
     {
         $superglobals = service('superglobals');
         $superglobals->setServer('REQUEST_URI', '/');
 
         $siteUri = new SiteURI(new App());
 
-        return new IncomingRequest(new App(), $siteUri, null, new UserAgent());
+        return (new IncomingRequest(new App(), $siteUri, null, new UserAgent()))
+            ->withMethod($method);
     }
 
     public function testDefaultConfigCachesAllStatusCodes(): void
@@ -139,6 +141,39 @@ final class PageCacheTest extends CIUnitTestCase
 
         $result = $filter->after($request, $response500);
         $this->assertNotInstanceOf(ResponseInterface::class, $result);
+    }
+
+    public function testQueryRequestIsNotCached(): void
+    {
+        $config = new Cache();
+        $filter = new PageCache($config);
+
+        $request  = $this->createRequest(Method::QUERY);
+        $response = new Response();
+        $response->setStatusCode(200);
+        $response->setBody('Success');
+
+        $result = $filter->after($request, $response);
+        $this->assertNotInstanceOf(ResponseInterface::class, $result);
+    }
+
+    public function testQueryRequestDoesNotReturnCachedResponse(): void
+    {
+        $filter  = new PageCache(new Cache());
+        $request = $this->createRequest(Method::QUERY);
+        $key     = service('responsecache')->generateCacheKey($request);
+
+        service('cache')->save($key, serialize([
+            'headers' => [],
+            'output'  => 'Cached',
+            'status'  => 200,
+            'reason'  => 'OK',
+        ]), 60);
+
+        $result = $filter->before($request);
+        $this->assertNull($result);
+
+        service('cache')->delete($key);
     }
 
     public function testDownloadResponseNotCached(): void

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -175,6 +175,35 @@ class CURLRequestTest extends CIUnitTestCase
         $this->assertSame('OPTIONS', $options[CURLOPT_CUSTOMREQUEST]);
     }
 
+    public function testQuerySetsCorrectMethod(): void
+    {
+        $this->request->query('http://example.com');
+
+        $this->assertSame('QUERY', $this->request->getMethod());
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
+        $this->assertSame('QUERY', $options[CURLOPT_CUSTOMREQUEST]);
+    }
+
+    public function testQueryWithJsonSetsBodyAndContentType(): void
+    {
+        $params = [
+            'foo' => 'bar',
+        ];
+        $this->request->query('http://example.com', [
+            'json' => $params,
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertSame('QUERY', $this->request->getMethod());
+        $this->assertSame('QUERY', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame(json_encode($params), $options[CURLOPT_POSTFIELDS]);
+        $this->assertContains('Content-Type: application/json', $options[CURLOPT_HTTPHEADER]);
+    }
+
     public function testOptionsBaseURIOption(): void
     {
         $options = ['baseURI' => 'http://www.foo.com/api/v1/'];

--- a/tests/system/HTTP/FormRequestTest.php
+++ b/tests/system/HTTP/FormRequestTest.php
@@ -40,7 +40,7 @@ final class FormRequestTest extends CIUnitTestCase
         parent::setUp();
 
         $this->resetServices();
-        Services::injectMock('superglobals', new Superglobals());
+        Services::injectMock('superglobals', new Superglobals(get: [], post: []));
         service('superglobals')->setServer('REQUEST_METHOD', 'POST');
         service('superglobals')->setServer('SERVER_PROTOCOL', 'HTTP/1.1');
         service('superglobals')->setServer('SERVER_NAME', 'example.com');
@@ -344,6 +344,23 @@ final class FormRequestTest extends CIUnitTestCase
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testResolveRequestUsesQueryRawBody(): void
+    {
+        service('superglobals')
+            ->setServer('REQUEST_METHOD', Method::QUERY)
+            ->setServer('CONTENT_TYPE', 'application/x-www-form-urlencoded');
+
+        $formRequest = $this->makeFormRequest($this->makeRequest('title=Hello&body=World'));
+
+        $response = $formRequest->resolveRequest();
+
+        $this->assertNotInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame([
+            'title' => 'Hello',
+            'body'  => 'World',
+        ], $formRequest->getValidated());
     }
 
     public function testResolveRequestReturns422WhenJsonIsPreferred(): void

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -700,6 +700,7 @@ final class IncomingRequestTest extends CIUnitTestCase
             ['HEAD'],
             ['PATCH'],
             ['OPTIONS'],
+            ['QUERY'],
         ];
     }
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -839,12 +839,17 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expected = ['here' => '\there'];
 
-        $routes->match(['GET', 'POST'], 'here', 'there');
+        $routes->match(['GET', 'POST', 'QUERY'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
 
         service('request')->setMethod(Method::POST);
         $routes = $this->getCollector();
-        $routes->match(['GET', 'POST'], 'here', 'there');
+        $routes->match(['GET', 'POST', 'QUERY'], 'here', 'there');
+        $this->assertSame($expected, $routes->getRoutes());
+
+        service('request')->setMethod(Method::QUERY);
+        $routes = $this->getCollector();
+        $routes->match(['GET', 'POST', 'QUERY'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
     }
 
@@ -912,6 +917,17 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->head('here', 'there');
+        $this->assertSame($expected, $routes->getRoutes());
+    }
+
+    public function testQuery(): void
+    {
+        $routes = $this->getCollector();
+        $routes->setHTTPVerb(Method::QUERY);
+
+        $expected = ['here' => '\there'];
+
+        $routes->query('here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
     }
 

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Security;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
@@ -102,6 +103,16 @@ final class SecurityTest extends CIUnitTestCase
         $security->verify($this->createIncomingRequest());
 
         $this->assertSame(self::CORRECT_CSRF_HASH, $security->getHash());
+    }
+
+    public function testCsrfVerifyQueryReturnsSelf(): void
+    {
+        service('superglobals')->setServer('REQUEST_METHOD', Method::QUERY);
+
+        $security = $this->createMockSecurity();
+        $request  = $this->createIncomingRequest();
+
+        $this->assertSame($security, $security->verify($request));
     }
 
     public function testCsrfVerifyPostThrowsExceptionOnNoMatch(): void

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -538,6 +538,30 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $response->assertJSONExact($data);
     }
 
+    public function testCallQueryWithJsonRequest(): void
+    {
+        $this->withRoutes([
+            [
+                'QUERY',
+                'home',
+                '\Tests\Support\Controllers\Popcorn::echoJson',
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->withBodyFormat('json')
+            ->query('home', $data);
+
+        $response->assertOK();
+        $response->assertJSONExact($data);
+    }
+
     public function testCallPutWithJsonRequestAndREQUEST(): void
     {
         $this->withRoutes([

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -974,7 +974,8 @@ class ValidationTest extends CIUnitTestCase
         $this->validation->run($data);
     }
 
-    public function testRawInput(): void
+    #[DataProvider('provideRawInput')]
+    public function testRawInput(string $method): void
     {
         $rawstring       = 'username=admin001&role=administrator&usepass=0';
         $config          = new App();
@@ -984,11 +985,21 @@ class ValidationTest extends CIUnitTestCase
         $rules = [
             'role' => 'required|min_length[5]',
         ];
-        $result = $this->validation->withRequest($request->withMethod('PATCH'))->setRules($rules)->run();
+        $result = $this->validation->withRequest($request->withMethod($method))->setRules($rules)->run();
 
         $this->assertTrue($result);
         $this->assertSame([], $this->validation->getErrors());
         $this->assertSame(['role' => 'administrator'], $this->validation->getValidated());
+    }
+
+    /**
+     * @return iterable<string, list<string>>
+     */
+    public static function provideRawInput(): iterable
+    {
+        yield 'PATCH' => ['PATCH'];
+
+        yield 'QUERY' => ['QUERY'];
     }
 
     public function testJsonInput(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -306,6 +306,7 @@ Helpers and Functions
 HTTP
 ====
 
+- Added support for the HTTP ``QUERY`` method in routing, feature tests, ``CURLRequest``, and ``FormRequest`` input source selection.
 - Added the ``retry`` option to ``CURLRequest`` for retrying failed responses with configurable delays, retryable status codes, optional transient cURL error retries, and ``Retry-After`` support. See :ref:`curlrequest-request-options-retry`.
 - Added :ref:`Form Requests <form-requests>` - a new ``FormRequest`` base class that encapsulates validation rules, custom error messages, and authorization logic for a single HTTP request.
 - Added ``IncomingRequest::input()`` to read GET, POST, JSON, and raw request data through ``InputData``.

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -40,6 +40,7 @@ Behavior Changes
 - **Database:** The Postgre driver's ``$db->error()['code']`` previously always returned ``''``. It now returns the 5-character SQLSTATE string for query and transaction failures (e.g., ``'42P01'``), or ``'08006'`` for connection-level failures. Code that relied on ``$db->error()['code'] === ''`` will need updating.
 - **Filters:** HTTP method matching for method-based filters is now case-sensitive. The keys in ``Config\Filters::$methods`` must exactly match the request method
   (e.g., ``GET``, ``POST``). Lowercase method names (e.g., ``post``) will no longer match.
+- **HTTP:** Routes defined with ``$routes->add()`` now also match HTTP ``QUERY`` requests. If the route has CSRF protection, remember that CSRF verification does not protect safe methods such as ``GET`` and ``QUERY``.
 - **Testing:** Tests using the ``FeatureTestTrait`` must now use uppercase HTTP method names when performing a request when using the ``call()`` method directly
   (e.g., ``$this->call('GET', '/path')`` instead of ``$this->call('get', '/path')``). Additionally, setting method-based routes using ``withRoutes()`` must
   also use uppercase method names (e.g., ``$this->withRoutes([['GET', 'home', 'Home::index']])``).

--- a/user_guide_src/source/general/caching.rst
+++ b/user_guide_src/source/general/caching.rst
@@ -90,8 +90,8 @@ Valid options are:
     caching errors that should be temporary. For example, a cached 404 page would
     remain cached even after the resource is created, until the cache expires.
 
-.. note:: Regardless of this setting, ``DownloadResponse`` and ``RedirectResponse``
-    instances are never cached by the ``PageCache`` filter.
+.. note:: Regardless of this setting, ``DownloadResponse``, ``RedirectResponse``,
+    and HTTP ``QUERY`` responses are never cached by the ``PageCache`` filter.
 
 Enabling Caching
 ================

--- a/user_guide_src/source/incoming/form_requests.rst
+++ b/user_guide_src/source/incoming/form_requests.rst
@@ -185,7 +185,7 @@ By default ``validationData()`` selects the appropriate data source
 automatically based on the HTTP method and ``Content-Type`` header:
 
 * **JSON request** (``Content-Type: application/json``) -> decoded JSON body
-* **PUT / PATCH / DELETE** (non-multipart) -> raw body via ``getRawInput()``
+* **PUT / PATCH / DELETE / QUERY** (non-multipart) -> raw body via ``getRawInput()``
 * **GET / HEAD** -> query-string parameters via ``getGet()``
 * **Everything else** (POST, multipart) -> POST body via ``getPost()``
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -231,8 +231,8 @@ pass true in the second parameter:
 
 .. _incomingrequest-retrieving-raw-data:
 
-Retrieving Raw Data (PUT, PATCH, DELETE)
-========================================
+Retrieving Raw Data (PUT, PATCH, DELETE, QUERY)
+===============================================
 
 Finally, you can grab the contents of ``php://input`` as a raw stream with ``getRawInput()``:
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -79,14 +79,17 @@ You can use any standard HTTP verb (GET, POST, PUT, DELETE, OPTIONS, etc):
 .. literalinclude:: routing/003.php
 
 ``QUERY`` routes are for the HTTP QUERY method defined by RFC 10008.
-QUERY requests are safe and idempotent like GET, but send query content in the
+``QUERY`` requests are safe and idempotent like GET, but send query content in the
 request body. Read that body explicitly with request input methods such as
 ``$this->request->input()->json()`` or ``$this->request->input()->raw()``. Your
 controller should reject missing or unsupported ``Content-Type`` values for the
-query content it expects.
+query content it expects. Do not use ``QUERY`` for operations that create,
+update, delete, or otherwise change server state.
 
 .. note:: Your web server, proxy, or CORS configuration may need to allow the
-    ``QUERY`` method before these requests can reach CodeIgniter.
+    ``QUERY`` method before these requests can reach CodeIgniter. For
+    browser-based cross-origin requests, ensure ``QUERY`` is included in your
+    allowed CORS methods so preflight requests can succeed.
 
 You can supply multiple verbs that a route should match by passing them in as an array to the ``match()`` method:
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -367,9 +367,9 @@ Routes with any HTTP verbs
     another, more appropriate method.
 
 .. warning:: While the ``add()`` method seems to be convenient, it is recommended to always use the HTTP-verb-based
-    routes, described above, as it is more secure. If you use the :doc:`CSRF protection </libraries/security>`, it does not protect **GET**
-    requests. If the URI specified in the ``add()`` method is accessible by the GET method, the CSRF protection
-    will not work.
+    routes, described above, as it is more secure. If you use the :doc:`CSRF protection </libraries/security>`, it does not protect
+    **GET** or **QUERY** requests. If the URI specified in the ``add()`` method is accessible by the GET or QUERY method,
+    the CSRF protection will not work.
 
 It is possible to define a route with any HTTP verbs.
 You can use the ``add()`` method:

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -78,6 +78,16 @@ You can use any standard HTTP verb (GET, POST, PUT, DELETE, OPTIONS, etc):
 
 .. literalinclude:: routing/003.php
 
+``QUERY`` routes are for the HTTP QUERY method defined by RFC 10008.
+QUERY requests are safe and idempotent like GET, but send query content in the
+request body. Read that body explicitly with request input methods such as
+``$this->request->input()->json()`` or ``$this->request->input()->raw()``. Your
+controller should reject missing or unsupported ``Content-Type`` values for the
+query content it expects.
+
+.. note:: Your web server, proxy, or CORS configuration may need to allow the
+    ``QUERY`` method before these requests can reach CodeIgniter.
+
 You can supply multiple verbs that a route should match by passing them in as an array to the ``match()`` method:
 
 .. literalinclude:: routing/004.php

--- a/user_guide_src/source/incoming/routing/003.php
+++ b/user_guide_src/source/incoming/routing/003.php
@@ -3,3 +3,4 @@
 $routes->post('products', 'Product::feature');
 $routes->put('products/1', 'Product::feature');
 $routes->delete('products/1', 'Product::feature');
+$routes->query('products/search', 'Product::search');

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -116,6 +116,10 @@ each take the URL as the first parameter and an array of options as the second:
 
 .. literalinclude:: curlrequest/007.php
 
+The ``query()`` shortcut sends an HTTP QUERY request. QUERY requests usually
+include query content, so use options such as ``json``, ``form_params``, or
+``body`` to send the expected body.
+
 Base URI
 --------
 

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -118,7 +118,8 @@ each take the URL as the first parameter and an array of options as the second:
 
 The ``query()`` shortcut sends an HTTP QUERY request. QUERY requests usually
 include query content, so use options such as ``json``, ``form_params``, or
-``body`` to send the expected body.
+``body`` to send the expected body. This is different from the ``query`` request
+option, which adds URL query variables to the request URI.
 
 Base URI
 --------

--- a/user_guide_src/source/libraries/curlrequest/007.php
+++ b/user_guide_src/source/libraries/curlrequest/007.php
@@ -7,3 +7,4 @@ $client->options('http://example.com');
 $client->patch('http://example.com');
 $client->put('http://example.com');
 $client->post('http://example.com');
+$client->query('http://example.com');

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -399,7 +399,7 @@ data to be validated:
     when the request is a JSON request (``Content-Type: application/json``),
     or gets Raw data from
     :ref:`$request->getRawInput() <incomingrequest-retrieving-raw-data>`
-    when the request is a PUT, PATCH, DELETE request and
+    when the request is a PUT, PATCH, DELETE, or QUERY request and
     is not HTML form post (``Content-Type: multipart/form-data``),
     or gets data from :ref:`$request->getVar() <incomingrequest-getting-data>`,
     and an attacker could change what data is validated.

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -105,6 +105,9 @@ This is useful when testing JSON or XML APIs so that you can set the request in 
 This will take the parameters passed into ``call()``, ``post()``, ``get()``... and assign them to the
 body of the request in the given format.
 
+For example, use ``withBodyFormat('json')->query()`` to test a QUERY request
+with a JSON body.
+
 This will also set the `Content-Type` header for your request accordingly.
 
 .. literalinclude:: feature/008.php

--- a/user_guide_src/source/testing/feature/003.php
+++ b/user_guide_src/source/testing/feature/003.php
@@ -6,3 +6,4 @@ $this->put($path, $params);
 $this->patch($path, $params);
 $this->delete($path, $params);
 $this->options($path, $params);
+$this->query($path, $params);


### PR DESCRIPTION
**Description**

This PR proposes adding support for the HTTP `QUERY` method defined by [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html).

`QUERY` fills a long-standing gap between `GET` and `POST`.

`GET` is the right semantic fit for read-only requests, but it pushes all query data into the URL. That works for simple filters, but it becomes awkward for advanced search screens, report previews, analytics queries, GraphQL-style reads, JSON-RPC queries, or audit-log filters with nested conditions.

`POST` can carry that data in the body, but it no longer clearly communicates that the request is safe and read-only.

`QUERY` gives applications a better option: a safe and idempotent request with query content in the request body. In CodeIgniter this can be expressed naturally with a route like:

```php
$routes->query('products/search', 'Products::search');
```

This is not just a CodeIgniter-specific idea. The web ecosystem has already started moving in this direction, with support merged or being discussed in nginx, Symfony, Laravel, Rails, Spring Framework, Node.js, and other projects.

This PR wires `QUERY` into the framework areas where CodeIgniter already exposes HTTP methods:

- `CodeIgniter\HTTP\Method`
- route definitions via `$routes->query(...)`
- route matching via `match(['QUERY'], ...)`
- route command output
- Feature tests via `$this->query(...)`
- `CURLRequest::query(...)`
- validation and Form Request input source selection

For input handling, `QUERY` follows the same raw-body path as `PUT`, `PATCH`, and `DELETE`. JSON requests continue to use the existing JSON handling based on `Content-Type`.

This PR is intentionally conservative. It teaches CodeIgniter how to recognize, route, test, and send `QUERY` requests, but it does not add special cache handling, `Accept-Query` support, or global `Content-Type` enforcement. Applications should still decide which query content types they accept and validate that in the controller or request layer.

Tests cover routing, route command output, feature testing, `CURLRequest`, validation, Form Requests, raw input handling, and CSRF behavior.

**References**

- RFC 10008: https://www.rfc-editor.org/rfc/rfc10008.html
- IANA HTTP Method Registry: https://www.iana.org/assignments/http-methods/http-methods.xhtml

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide