### PR TITLE
fix: enhance Logger PSR-3 compliance and interpolation reliability

### DIFF
--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -291,9 +291,13 @@ class Logger implements LoggerInterface
      */
     protected function interpolate($message, array $context = [])
     {
-        if (! is_string($message)) {
+
+        if (! is_string($message) && ! ($message instanceof Stringable)) {
             return print_r($message, true);
         }
+
+        // Cast to string in case $message is a Stringable object
+        $message = (string) $message;
 
         $replace = [];
 
@@ -305,6 +309,10 @@ class Logger implements LoggerInterface
             }
 
             // todo - sanitize input before writing to file?
+            if (is_array($val) || (is_object($val) && ! method_exists($val, '__toString'))) {
+                $val = print_r($val, true);
+            }
+
             $replace['{' . $key . '}'] = $val;
         }
 
@@ -322,9 +330,9 @@ class Logger implements LoggerInterface
 
         // Match up environment variables in {env:foo} tags.
         if (str_contains($message, 'env:')) {
-            preg_match('/env:[^}]+/', $message, $matches);
+            preg_match_all('/env:[^}]+/', $message, $matches);
 
-            foreach ($matches as $str) {
+            foreach ($matches[0] as $str) {
                 $key                 = str_replace('env:', '', $str);
                 $replace["{{$str}}"] = $_ENV[$key] ?? 'n/a';
             }

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -307,6 +307,10 @@ class Logger implements LoggerInterface
                 $val = $val->getMessage() . ' ' . clean_path($val->getFile()) . ':' . $val->getLine();
             }
 
+            if (is_bool($val)) {
+                $val = $val ? 'true' : 'false';
+            }
+
             // todo - sanitize input before writing to file?
             if (is_array($val) || (is_object($val) && ! method_exists($val, '__toString'))) {
                 $val = print_r($val, true);

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -291,7 +291,6 @@ class Logger implements LoggerInterface
      */
     protected function interpolate($message, array $context = [])
     {
-
         if (! is_string($message) && ! ($message instanceof Stringable)) {
             return print_r($message, true);
         }

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -529,7 +529,7 @@ final class LoggerTest extends CIUnitTestCase
 
         Time::setTestNow('2023-11-25 12:00:00');
 
-        $user = new stdClass();
+        $user       = new stdClass();
         $user->name = 'John';
         $user->role = 'admin';
 
@@ -560,4 +560,3 @@ final class LoggerTest extends CIUnitTestCase
         $this->assertSame($expected, $logs[0]);
     }
 }
-

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -22,6 +22,8 @@ use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use PHPUnit\Framework\Attributes\Group;
 use ReflectionMethod;
 use ReflectionNamedType;
+use stdClass;
+use Stringable;
 use Tests\Support\Log\Handlers\TestHandler;
 
 /**
@@ -437,5 +439,86 @@ final class LoggerTest extends CIUnitTestCase
         ];
 
         $this->assertSame($expected, $logger->determineFile());
+    }
+
+    public function testLogInterpolatesArrayContext(): void
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        Time::setTestNow('2023-11-25 12:00:00');
+
+        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Test message ' . print_r(['foo' => 'bar'], true);
+
+        $logger->log('debug', 'Test message {foo}', ['foo' => ['foo' => 'bar']]);
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
+    }
+
+    public function testLogInterpolatesObjectContext(): void
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        Time::setTestNow('2023-11-25 12:00:00');
+
+        $obj      = new stdClass();
+        $obj->foo = 'bar';
+
+        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Test message ' . print_r($obj, true);
+
+        $logger->log('debug', 'Test message {foo}', ['foo' => $obj]);
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
+    }
+
+    public function testLogInterpolatesMultipleEnvironmentVars(): void
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        Time::setTestNow('2023-11-25 12:00:00');
+
+        $_ENV['foo'] = 'bar';
+        $_ENV['baz'] = 'qux';
+
+        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Test message bar and qux';
+
+        $logger->log('debug', 'Test message {env:foo} and {env:baz}');
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
+    }
+
+    public function testLogAcceptsStringableMessage(): void
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        Time::setTestNow('2023-11-25 12:00:00');
+
+        $message = new class () implements Stringable {
+            public function __toString(): string
+            {
+                return 'Stringable message {foo}';
+            }
+        };
+
+        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Stringable message bar';
+
+        $logger->log('debug', $message, ['foo' => 'bar']);
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
     }
 }

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -521,4 +521,43 @@ final class LoggerTest extends CIUnitTestCase
         $this->assertCount(1, $logs);
         $this->assertSame($expected, $logs[0]);
     }
+
+    public function testLogObjectContextLosesProperties(): void
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        Time::setTestNow('2023-11-25 12:00:00');
+
+        $user = new stdClass();
+        $user->name = 'John';
+        $user->role = 'admin';
+
+        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> User: ' . print_r($user, true);
+
+        $logger->log('debug', 'User: {user}', ['user' => $user]);
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
+    }
+
+    public function testLogBooleanFalseIsLoggedAsEmptyString(): void
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        Time::setTestNow('2023-11-25 12:00:00');
+
+        $expected = 'DEBUG - ' . Time::now()->format('Y-m-d') . ' --> Active: false';
+
+        $logger->log('debug', 'Active: {status}', ['status' => false]);
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
+    }
 }
+


### PR DESCRIPTION
**Description**
This PR addresses several issues in the `Logger::interpolate()` method regarding PSR-3 compliance and interpolation robustness. Based on the community discussion [here](https://forum.codeigniter.com/showthread.php?tid=94242), passing an array or an unstringable object inside the `$context` array previously caused PHP `E_WARNING`s (`Array to string conversion` or `Object ... could not be converted to string`) when parsed through `strtr()`. PSR-3 specifies that the context array can contain *anything*, so the logger should handle these types gracefully.
Key Changes:
1. **Array and Object Context Handling:** Checks if a context value `is_array()` or is an unstringable object (`is_object()` without `__toString()`). If so, gracefully formats it using `print_r($val, true)` before interpolating, preventing runtime warnings.
2. **`\Stringable` Interface Support:** The `$message` argument now correctly supports PHP 8.0 `\Stringable` objects, safely casting them to strings. 
3. **Multiple Environment Variables:** Replaced `preg_match` with `preg_match_all` when evaluating `{env:foo}` tags. Previously, only the very first environment variable tag in a log message was parsed. Now, multiple tags within the same message (e.g. `{env:foo} and {env:baz}`) are accurately matched and interpolated.
Related issue/discussion: https://forum.codeigniter.com/showthread.php?tid=94242
**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide