### PR TITLE
chore: enable RemoveDuplicatedReturnSelfDocblockRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -23,7 +23,6 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
@@ -178,7 +177,6 @@ return RectorConfig::configure()
 
         // to be applied in separate PRs to ease review
         NegatedAndsToPositiveOrsRector::class,
-        RemoveDuplicatedReturnSelfDocblockRector::class,
     ])
     // auto import fully qualified class names
     ->withImportNames()

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -105,8 +105,6 @@ final class DataCaster
      *
      * @param array<string, string> $types [field => type]
      *
-     * @return $this
-     *
      * @internal
      */
     public function setTypes(array $types): static

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -577,8 +577,6 @@ class BaseBuilder
      * Generates the FROM portion of the query
      *
      * @param array|string $from
-     *
-     * @return $this
      */
     public function from($from, bool $overwrite = false): self
     {
@@ -608,8 +606,6 @@ class BaseBuilder
     /**
      * @param BaseBuilder $from  Expected subquery
      * @param string      $alias Subquery alias
-     *
-     * @return $this
      */
     public function fromSubquery(BaseBuilder $from, string $alias): self
     {

--- a/system/HTTP/MessageTrait.php
+++ b/system/HTTP/MessageTrait.php
@@ -48,13 +48,10 @@ trait MessageTrait
     // --------------------------------------------------------------------
     // Body
     // --------------------------------------------------------------------
-
     /**
      * Sets the body of the current message.
      *
      * @param string $data
-     *
-     * @return $this
      */
     public function setBody($data): self
     {
@@ -67,8 +64,6 @@ trait MessageTrait
      * Appends data to the body of the current message.
      *
      * @param string $data
-     *
-     * @return $this
      */
     public function appendBody($data): self
     {
@@ -144,8 +139,6 @@ trait MessageTrait
      * Sets a header and it's value.
      *
      * @param array|string|null $value
-     *
-     * @return $this
      */
     public function setHeader(string $name, $value): self
     {
@@ -191,8 +184,6 @@ trait MessageTrait
 
     /**
      * Removes a header from the list of headers we track.
-     *
-     * @return $this
      */
     public function removeHeader(string $name): self
     {
@@ -205,8 +196,6 @@ trait MessageTrait
     /**
      * Adds an additional header value to any headers that accept
      * multiple values (i.e. are an array or implement ArrayAccess)
-     *
-     * @return $this
      */
     public function appendHeader(string $name, ?string $value): self
     {
@@ -225,8 +214,6 @@ trait MessageTrait
      * Adds a header (not a header value) with the same name.
      * Use this only when you set multiple headers with the same name,
      * typically, for `Set-Cookie`.
-     *
-     * @return $this
      */
     public function addHeader(string $name, string $value): static
     {
@@ -251,8 +238,6 @@ trait MessageTrait
     /**
      * Adds an additional header value to any headers that accept
      * multiple values (i.e. are an array or implement ArrayAccess)
-     *
-     * @return $this
      */
     public function prependHeader(string $name, string $value): self
     {
@@ -276,8 +261,6 @@ trait MessageTrait
 
     /**
      * Sets the HTTP protocol version.
-     *
-     * @return $this
      *
      * @throws HTTPException For invalid protocols
      */

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -108,8 +108,6 @@ class RedirectResponse extends Response
      * If the validation has any errors, transmit those back
      * so they can be displayed when the validation is handled
      * within a method different than displaying the form.
-     *
-     * @return $this
      */
     private function withErrors(): self
     {

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -537,8 +537,6 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Clears metadata from the image.
      *
-     * @return $this
-     *
      * @throws ImagickException
      */
     public function clearMetadata(): static

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -152,8 +152,6 @@ interface ImageHandlerInterface
 
     /**
      * Clear metadata before saving image as a new file.
-     *
-     * @return $this
      */
     public function clearMetadata(): static;
 }

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -23,8 +23,6 @@ trait ConditionalTrait
      * @param TWhen                        $condition
      * @param callable(self, TWhen): mixed $callback
      * @param (callable(self): mixed)|null $defaultCallback
-     *
-     * @return $this
      */
     public function when($condition, callable $callback, ?callable $defaultCallback = null): self
     {
@@ -45,8 +43,6 @@ trait ConditionalTrait
      * @param TWhenNot                        $condition
      * @param callable(self, TWhenNot): mixed $callback
      * @param (callable(self): mixed)|null    $defaultCallback
-     *
-     * @return $this
      */
     public function whenNot($condition, callable $callback, ?callable $defaultCallback = null): self
     {

--- a/system/Traits/PropertiesTrait.php
+++ b/system/Traits/PropertiesTrait.php
@@ -27,8 +27,6 @@ trait PropertiesTrait
 {
     /**
      * Attempts to set the values of public class properties.
-     *
-     * @return $this
      */
     final public function fill(array $params): self
     {
@@ -43,10 +41,15 @@ trait PropertiesTrait
 
     /**
      * Get the public properties of the class and return as an array.
+     *
+     * @return array<string, mixed>
      */
     final public function getPublicProperties(): array
     {
         $worker = new class () {
+            /**
+             * @return array<string, mixed>
+             */
             public function getProperties(object $obj): array
             {
                 return get_object_vars($obj);

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 213 errors
+# total 212 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1827 errors
+# total 1825 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1141 errors
+# total 1140 errors
 
 parameters:
     ignoreErrors:
@@ -4129,11 +4129,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\View\\Cells\\Cell\:\:getNonPublicProperties\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/View/Cells/Cell.php
-
-        -
-            message: '#^Method CodeIgniter\\View\\Cells\\Cell\:\:getPublicProperties\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/View/Cells/Cell.php
 

--- a/utils/phpstan-baseline/return.type.neon
+++ b/utils/phpstan-baseline/return.type.neon
@@ -3,7 +3,7 @@
 parameters:
     ignoreErrors:
         -
-            message: '#^Method CodeIgniter\\Database\\BaseBuilder\:\:cleanClone\(\) should return \$this\(CodeIgniter\\Database\\BaseBuilder\) but returns static\(CodeIgniter\\Database\\BaseBuilder\)\.$#'
+            message: '#^Method CodeIgniter\\Database\\BaseBuilder\:\:cleanClone\(\) should return \$this\(CodeIgniter\\Database\\BaseBuilder\) but returns CodeIgniter\\Database\\BaseBuilder\.$#'
             count: 1
             path: ../../system/Database/BaseBuilder.php
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

Enable `RemoveDuplicatedReturnSelfDocblockRector` to remove `@return` docblock that duplicates the native self/static return type of the current object.

This PR also clean up phpstan ignore config.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
