### PR TITLE
refactor: use `array-key` as the benevolent union of `int|string` in array shapes

### DIFF
--- a/system/API/TransformerInterface.php
+++ b/system/API/TransformerInterface.php
@@ -43,7 +43,7 @@ interface TransformerInterface
     /**
      * Transforms a collection of resources using $this->transform() on each item.
      *
-     * @param array<int|string, mixed> $resources
+     * @param array<array-key, mixed> $resources
      *
      * @return array<int, array<string, mixed>>
      */

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1855,7 +1855,7 @@ abstract class BaseModel
      *
      * @param object|row_array|null $row
      *
-     * @return array<int|string, mixed>
+     * @return array<array-key, mixed>
      *
      * @throws DataException
      * @throws InvalidArgumentException
@@ -1947,7 +1947,7 @@ abstract class BaseModel
     /**
      * Provides direct access to method in the database connection.
      *
-     * @param array<int|string, mixed> $params
+     * @param array<array-key, mixed> $params
      *
      * @return mixed
      */

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -99,7 +99,7 @@ abstract class BaseCommand
     /**
      * Actually execute a command.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      *
      * @return int|void
      */
@@ -108,7 +108,7 @@ abstract class BaseCommand
     /**
      * Can be used by a command to run other commands.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      *
      * @return int|void
      *

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -273,10 +273,10 @@ class CLI
     /**
      * prompt(), but based on the option's key
      *
-     * @param list<string>|string       $text       Output "field" text or an one or two value array where the first value is the text before listing the options
-     *                                              and the second value the text before asking to select one option. Provide empty string to omit
-     * @param array<int|string, string> $options    A list of options (array(key => description)), the first option will be the default value
-     * @param list<string>|string|null  $validation Validation rules
+     * @param list<string>|string      $text       Output "field" text or an one or two value array where the first value is the text before listing the options
+     *                                             and the second value the text before asking to select one option. Provide empty string to omit
+     * @param array<array-key, string> $options    A list of options (array(key => description)), the first option will be the default value
+     * @param list<string>|string|null $validation Validation rules
      *
      * @return string The selected key of $options
      */
@@ -302,11 +302,11 @@ class CLI
     /**
      * This method is the same as promptByKey(), but this method supports multiple keys, separated by commas.
      *
-     * @param string                    $text    Output "field" text or an one or two value array where the first value is the text before listing the options
-     *                                           and the second value the text before asking to select one option. Provide empty string to omit
-     * @param array<int|string, string> $options A list of options (array(key => description)), the first option will be the default value
+     * @param string                   $text    Output "field" text or an one or two value array where the first value is the text before listing the options
+     *                                          and the second value the text before asking to select one option. Provide empty string to omit
+     * @param array<array-key, string> $options A list of options (array(key => description)), the first option will be the default value
      *
-     * @return array<int|string, string> The selected key(s) and value(s) of $options
+     * @return array<array-key, string> The selected key(s) and value(s) of $options
      */
     public static function promptByMultipleKeys(string $text, array $options): array
     {
@@ -376,7 +376,7 @@ class CLI
     /**
      * Validation for $options in promptByKey() and promptByMultipleKeys(). Return an error if $options is an empty array.
      *
-     * @param array<int|string, string> $options
+     * @param array<array-key, string> $options
      */
     private static function isZeroOptions(array $options): void
     {
@@ -388,7 +388,7 @@ class CLI
     /**
      * Print each key and value one by one
      *
-     * @param array<int|string, string> $options
+     * @param array<array-key, string> $options
      */
     private static function printKeysAndValues(array $options): void
     {
@@ -1029,8 +1029,8 @@ class CLI
     /**
      * Returns a well formatted table
      *
-     * @param list<array<int|string, mixed>> $tbody List of rows
-     * @param list<string>                   $thead List of columns
+     * @param list<array<array-key, mixed>> $tbody List of rows
+     * @param list<string>                  $thead List of columns
      *
      * @return void
      */

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -54,7 +54,7 @@ class Commands
     /**
      * Runs a command given
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      *
      * @return int Exit code
      */

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -74,9 +74,9 @@ class Console
      * We'll remove that as an option from `$params` and
      * unshift it as argument instead.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      *
-     * @return array<int|string, string|null>
+     * @return array<array-key, string|null>
      */
     private function parseParamsForHelpOption(array $params): array
     {

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -96,14 +96,14 @@ trait GeneratorTrait
      *
      * @internal
      *
-     * @var array<int|string, string|null>
+     * @var array<array-key, string|null>
      */
     private $params = [];
 
     /**
      * Execute the command.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      *
      * @deprecated use generateClass() instead
      */
@@ -115,7 +115,7 @@ trait GeneratorTrait
     /**
      * Generates a class file from an existing template.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      */
     protected function generateClass(array $params): void
     {
@@ -138,8 +138,8 @@ trait GeneratorTrait
     /**
      * Generate a view file from an existing template.
      *
-     * @param string                         $view   namespaced view name that is generated
-     * @param array<int|string, string|null> $params
+     * @param string                        $view   namespaced view name that is generated
+     * @param array<array-key, string|null> $params
      */
     protected function generateView(string $view, array $params): void
     {

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -72,7 +72,7 @@ class MigrateRefresh extends BaseCommand
      */
     public function run(array $params)
     {
-        $params['b'] = 0;
+        $params['b'] = '0';
 
         if (ENVIRONMENT === 'production') {
             // @codeCoverageIgnoreStart

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -77,8 +77,6 @@ class MigrateStatus extends BaseCommand
 
     /**
      * Displays a list of all migrations and whether they've been run or not.
-     *
-     * @param array<string, mixed> $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -127,7 +127,7 @@ class GenerateKey extends BaseCommand
     /**
      * Sets the new encryption key in your .env file.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      */
     protected function setNewEncryptionKey(string $key, array $params): bool
     {
@@ -144,7 +144,7 @@ class GenerateKey extends BaseCommand
     /**
      * Checks whether to overwrite existing encryption key.
      *
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      */
     protected function confirmOverwrite(array $params): bool
     {

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -108,7 +108,7 @@ class FilterCheck extends BaseCommand
     }
 
     /**
-     * @param array<int|string, string|null> $params
+     * @param array<array-key, string|null> $params
      */
     private function checkParams(array $params): bool
     {

--- a/system/Common.php
+++ b/system/Common.php
@@ -154,7 +154,7 @@ if (! function_exists('command')) {
             $cursor += strlen($match[0]);
         }
 
-        /** @var array<int|string, string|null> */
+        /** @var array<array-key, string|null> */
         $params      = [];
         $command     = array_shift($args);
         $optionValue = false;
@@ -450,13 +450,13 @@ if (! function_exists('esc')) {
      * If $data is an array, then it loops over it, escaping each
      * 'value' of the key/value pairs.
      *
-     * @param array<int|string, array<int|string, mixed>|string>|string $data
-     * @param 'attr'|'css'|'html'|'js'|'raw'|'url'                      $context
-     * @param string|null                                               $encoding Current encoding for escaping.
-     *                                                                            If not UTF-8, we convert strings from this encoding
-     *                                                                            pre-escaping and back to this encoding post-escaping.
+     * @param array<array-key, array<array-key, mixed>|string>|string $data
+     * @param 'attr'|'css'|'html'|'js'|'raw'|'url'                    $context
+     * @param string|null                                             $encoding Current encoding for escaping.
+     *                                                                          If not UTF-8, we convert strings from this encoding
+     *                                                                          pre-escaping and back to this encoding post-escaping.
      *
-     * @return ($data is string ? string : array<int|string, array<int|string, mixed>|string>)
+     * @return ($data is string ? string : array<array-key, array<array-key, mixed>|string>)
      *
      * @throws InvalidArgumentException
      */

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -166,7 +166,7 @@ class BaseConfig
     /**
      * Initialization an environment-specific configuration setting
      *
-     * @param array<int|string, mixed>|bool|float|int|string|null $property
+     * @param array<array-key, mixed>|bool|float|int|string|null $property
      *
      * @return void
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2813,7 +2813,7 @@ class BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param array<int|string, mixed>|RawSql|string $where
+     * @param array<array-key, mixed>|RawSql|string $where
      *
      * @return bool|string Returns a SQL string if in test mode.
      *

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -781,7 +781,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param array<int|string, mixed>|string|null $binds
+     * @param array<array-key, mixed>|string|null $binds
      *
      * @return BaseResult<TConnection, TResult>|bool|Query
      *

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -100,7 +100,7 @@ interface ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param array<int|string, mixed>|string|null $binds
+     * @param array<array-key, mixed>|string|null $binds
      *
      * @return BaseResult<TConnection, TResult>|bool|Query
      */

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -150,7 +150,7 @@ class Builder extends BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param array<int|string, mixed>|RawSql|string $where
+     * @param array<array-key, mixed>|RawSql|string $where
      *
      * @return bool|string
      *

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -225,7 +225,7 @@ class Builder extends BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param array<int|string, mixed>|RawSql|string $where
+     * @param array<array-key, mixed>|RawSql|string $where
      *
      * @return bool|string
      *

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -538,7 +538,7 @@ class Builder extends BaseBuilder
     /**
      * Compiles a delete string and runs the query
      *
-     * @param array<int|string, mixed>|RawSql|string $where
+     * @param array<array-key, mixed>|RawSql|string $where
      *
      * @return bool|string
      *

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -55,7 +55,7 @@ abstract class BaseHandler implements EncrypterInterface
      *
      * @param string $key Property name
      *
-     * @return array<int|string, mixed>|bool|int|string|null
+     * @return array<array-key, mixed>|bool|int|string|null
      */
     public function __get($key)
     {

--- a/system/Encryption/KeyRotationDecorator.php
+++ b/system/Encryption/KeyRotationDecorator.php
@@ -86,7 +86,7 @@ class KeyRotationDecorator implements EncrypterInterface
     /**
      * Delegate property access to the inner handler.
      *
-     * @return array<int|string, mixed>|bool|int|string|null
+     * @return array<array-key, mixed>|bool|int|string|null
      */
     public function __get(string $key)
     {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -421,7 +421,7 @@ class Entity implements JsonSerializable
      * Checks if an array contains only Entity instances.
      * This allows optimization for per-entity change tracking.
      *
-     * @param array<int|string, mixed> $data
+     * @param array<array-key, mixed> $data
      */
     private function containsOnlyEntities(array $data): bool
     {

--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -44,14 +44,14 @@ class Header implements Stringable
      *       'baz' => 'buzz',
      *   ]
      *
-     * @var array<int|string, array<string, string>|string>|string
+     * @var array<array-key, array<string, string>|string>|string
      */
     protected $value;
 
     /**
      * Header constructor. name is mandatory, if a value is provided, it will be set.
      *
-     * @param array<int|string, array<string, string>|string>|string|null $value
+     * @param array<array-key, array<string, string>|string>|int|string|null $value
      */
     public function __construct(string $name, $value = null)
     {
@@ -71,7 +71,7 @@ class Header implements Stringable
      * Gets the raw value of the header. This may return either a string
      * or an array, depending on whether the header has multiple values or not.
      *
-     * @return array<int|string, array<string, string>|string>|string
+     * @return array<array-key, array<string, string>|string>|string
      */
     public function getValue()
     {
@@ -96,7 +96,7 @@ class Header implements Stringable
     /**
      * Sets the value of the header, overwriting any previous value(s).
      *
-     * @param array<int|string, array<string, string>|string>|string|null $value
+     * @param array<array-key, array<string, string>|int|string>|int|string|null $value
      *
      * @return $this
      *
@@ -235,7 +235,7 @@ class Header implements Stringable
      *
      * @see https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
      *
-     * @param array<int|string, array<string, string>|string>|int|string $value
+     * @param array<array-key, array<string, string>|int|string>|int|string $value
      *
      * @throws InvalidArgumentException
      */

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -367,7 +367,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter Filter constant
      * @param array|int|null    $flags
      *
-     * @return array<int|string, mixed>|bool|float|int|stdClass|string|null
+     * @return array<array-key, mixed>|bool|float|int|stdClass|string|null
      */
     public function getVar($index = null, $filter = null, $flags = null)
     {
@@ -394,7 +394,7 @@ class IncomingRequest extends Request
      *
      * @see http://php.net/manual/en/function.json-decode.php
      *
-     * @return array<int|string, mixed>|bool|float|int|stdClass|null
+     * @return array<array-key, mixed>|bool|float|int|stdClass|null
      *
      * @throws HTTPException When the body is invalid as JSON.
      */
@@ -421,7 +421,7 @@ class IncomingRequest extends Request
      * @param int|null          $filter Filter Constant
      * @param array|int|null    $flags  Option
      *
-     * @return array<int|string, mixed>|bool|float|int|stdClass|string|null
+     * @return array<array-key, mixed>|bool|float|int|stdClass|string|null
      */
     public function getJsonVar($index = null, bool $assoc = false, ?int $filter = null, $flags = null)
     {

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -1211,7 +1211,7 @@ trait TimeTrait
      *
      * @param string $name
      *
-     * @return array<int|string, mixed>|bool|DateTimeInterface|DateTimeZone|int|IntlCalendar|self|string|null
+     * @return array<array-key, mixed>|bool|DateTimeInterface|DateTimeZone|int|IntlCalendar|self|string|null
      */
     public function __get($name)
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -123,7 +123,7 @@ class Model extends BaseModel
      * so that we can capture it (not the builder)
      * and ensure it gets validated first.
      *
-     * @var array{escape: array<int|string, bool|null>, data: row_array}|array{}
+     * @var array{escape: array<array-key, bool|null>, data: row_array}|array{}
      */
     protected $tempData = [];
 
@@ -131,7 +131,7 @@ class Model extends BaseModel
      * Escape array that maps usage of escape
      * flag for every parameter.
      *
-     * @var array<int|string, bool|null>
+     * @var array<array-key, bool|null>
      */
     protected $escape = [];
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -169,7 +169,7 @@ abstract class CIUnitTestCase extends TestCase
      * Stores information needed to remove any
      * rows inserted via $this->hasInDatabase().
      *
-     * @var list<array<int|string, mixed>>
+     * @var list<array<array-key, mixed>>
      */
     protected $insertCache = [];
 
@@ -189,7 +189,7 @@ abstract class CIUnitTestCase extends TestCase
      * Values to be set in the SESSION global
      * before running the test.
      *
-     * @var array<int|string, mixed>
+     * @var array<array-key, mixed>
      */
     protected $session = [];
 

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -29,11 +29,11 @@ use PHPUnit\Framework\Attributes\AfterClass;
  * Provides functionality for refreshing/seeding
  * the database during testing.
  *
- * @property BaseConnection                 $db
- * @property list<array<int|string, mixed>> $insertCache
- * @property Seeder|null                    $seeder
- * @property MigrationRunner|null           $migrations
- * @property list<string>|string|null       $namespace
+ * @property BaseConnection                $db
+ * @property list<array<array-key, mixed>> $insertCache
+ * @property Seeder|null                   $seeder
+ * @property MigrationRunner|null          $migrations
+ * @property list<string>|string|null      $namespace
  *
  * @mixin CIUnitTestCase
  */

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -35,7 +35,7 @@ use ReflectionException;
  * Provides additional utilities for doing full HTTP testing
  * against your application in trait format.
  *
- * @property array<int|string, mixed>           $session
+ * @property array<array-key, mixed>            $session
  * @property array<string, list<string>|string> $headers
  * @property RouteCollection|null               $routes
  *
@@ -104,7 +104,7 @@ trait FeatureTestTrait
     /**
      * Sets any values that should exist during this session.
      *
-     * @param array<int|string, mixed>|null $values Array of values, or null to use the current $_SESSION
+     * @param array<array-key, mixed>|null $values Array of values, or null to use the current $_SESSION
      *
      * @return $this
      */

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -70,7 +70,7 @@ class MockConnection extends BaseConnection
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param array<int|string, mixed>|string|null $binds
+     * @param array<array-key, mixed>|string|null $binds
      *
      * @return BaseResult<object|resource, object|resource>|bool|Query
      *

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -721,7 +721,7 @@ class Parser extends View
     /**
      * Makes a new plugin available during the parsing of the template.
      *
-     * @param (callable(array<int|string, string>): string)|(callable(string, array<int|string, string>): string) $callback
+     * @param (callable(array<array-key, string>): string)|(callable(string, array<array-key, string>): string) $callback
      *
      * @return $this
      */

--- a/system/View/Plugins.php
+++ b/system/View/Plugins.php
@@ -71,7 +71,7 @@ class Plugins
     /**
      * Wrap helper function to use as view plugin.
      *
-     * @param array<int|string, string>|list<string> $params
+     * @param array<array-key, string>|list<string> $params
      */
     public static function lang(array $params = []): string
     {

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -67,7 +67,7 @@ final class HeaderTest extends CIUnitTestCase
         $name  = 'foo';
         $value = new stdClass();
 
-        new Header($name, $value);
+        new Header($name, $value); // @phpstan-ignore argument.type
     }
 
     public function testHeaderStoresArrayValues(): void
@@ -275,7 +275,7 @@ final class HeaderTest extends CIUnitTestCase
     }
 
     /**
-     * @param array<int|string, array<string, string>|string>|string|null $value
+     * @param array<array-key, array<string, string>|string>|string|null $value
      */
     #[DataProvider('provideInvalidHeaderValues')]
     public function testInvalidHeaderValues($value): void
@@ -286,7 +286,7 @@ final class HeaderTest extends CIUnitTestCase
     }
 
     /**
-     * @return list<list<array<(int|string), string>|string>>
+     * @return list<list<array<array-key, string>|string>>
      */
     public static function provideInvalidHeaderValues(): iterable
     {

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -26,7 +26,7 @@ final class CreditCardRulesTest extends StrictCreditCardRulesTest
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -26,7 +26,7 @@ final class FileRulesTest extends StrictFileRulesTest
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -33,7 +33,7 @@ class FormatRulesTest extends CIUnitTestCase
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -31,7 +31,7 @@ class RulesTest extends CIUnitTestCase
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -30,7 +30,7 @@ class CreditCardRulesTest extends CIUnitTestCase
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -30,7 +30,7 @@ class FileRulesTest extends CIUnitTestCase
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -24,7 +24,7 @@ use Tests\Support\Validation\TestRules;
 final class FormatRulesTest extends TraditionalFormatRulesTest
 {
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -28,7 +28,7 @@ final class RulesTest extends TraditionalRulesTest
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, string>|string>>
+     * @var array<string, array<array-key, array<string, string>|string>>
      */
     protected array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -24,7 +24,7 @@ use Tests\Support\Validation\TestRules;
 final class ValidationTest extends TraditionalValidationTest
 {
     /**
-     * @var array<string, array<int|string, array<string, array<string, string>|string>|string>|string>
+     * @var array<string, array<array-key, array<string, array<string, string>|string>|string>|string>
      */
     protected static array $config = [
         'ruleSets' => [

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -40,7 +40,7 @@ class ValidationTest extends CIUnitTestCase
     protected Validation $validation;
 
     /**
-     * @var array<string, array<int|string, array<string, array<string, string>|string>|string>|string>
+     * @var array<string, array<array-key, array<string, array<string, string>|string>|string>|string>
      */
     protected static array $config = [
         'ruleSets' => [

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,12 +1,7 @@
-# total 73 errors
+# total 68 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^Parameter \#2 \$params of method CodeIgniter\\CLI\\BaseCommand\:\:call\(\) expects array\<int\|string, string\|null\>, array\<int\|string, int\|string\|null\> given\.$#'
-            count: 2
-            path: ../../system/Commands/Database/MigrateRefresh.php
-
         -
             message: '#^Parameter \#3 \.\.\.\$arrays of function array_map expects array, int\|string given\.$#'
             count: 1
@@ -101,21 +96,6 @@ parameters:
             message: '#^Parameter \#2 \$callable of method CodeIgniter\\Debug\\Timer\:\:record\(\) expects callable\(\)\: mixed, ''strlen'' given\.$#'
             count: 1
             path: ../../tests/system/Debug/TimerTest.php
-
-        -
-            message: '#^Parameter \#1 \$value of method CodeIgniter\\HTTP\\Header\:\:setValue\(\) expects array\<int\|string, array\<string, string\>\|string\>\|string\|null, array\<int, int\|string\> given\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/HeaderTest.php
-
-        -
-            message: '#^Parameter \#2 \$value of class CodeIgniter\\HTTP\\Header constructor expects array\<int\|string, array\<string, string\>\|string\>\|string\|null, int given\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/HeaderTest.php
-
-        -
-            message: '#^Parameter \#2 \$value of class CodeIgniter\\HTTP\\Header constructor expects array\<int\|string, array\<string, string\>\|string\>\|string\|null, stdClass given\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/HeaderTest.php
 
         -
             message: '#^Parameter \#1 \$array of method CodeIgniter\\Superglobals\:\:setServerArray\(\) expects array\<string, array\<mixed\>\|float\|int\|string\>, array\<string, string\|null\> given\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1825 errors
+# total 1819 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/method.childParameterType.neon
+++ b/utils/phpstan-baseline/method.childParameterType.neon
@@ -1,12 +1,7 @@
-# total 11 errors
+# total 10 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^Parameter \#1 \$params \(array\<string, mixed\>\) of method CodeIgniter\\Commands\\Database\\MigrateStatus\:\:run\(\) should be contravariant with parameter \$params \(array\<int\|string, string\|null\>\) of method CodeIgniter\\CLI\\BaseCommand\:\:run\(\)$#'
-            count: 1
-            path: ../../system/Commands/Database/MigrateStatus.php
-
         -
             message: '#^Parameter \#1 \$offset \(string\) of method CodeIgniter\\Cookie\\Cookie\:\:offsetSet\(\) should be contravariant with parameter \$offset \(string\|null\) of method ArrayAccess\<string,bool\|int\|string\>\:\:offsetSet\(\)$#'
             count: 1


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Plain `array<int|string, ...>` is actually different from the nature of PHP array keys, that's why PHPStan uses `array-key` or `(int|string)` to mean these kind of unioned types: benevolent unions.

Ref: https://phpstan.org/config-reference#checkbenevolentuniontypes

This PR normalizes to use `array-key` instead of plain union.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
