### PR TITLE
feat: Add support to enable/disable CSP at runtime

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -403,6 +403,22 @@ class ContentSecurityPolicy
     }
 
     /**
+     * Enable Content Security Policy enforcement.
+     */
+    public function enable(): void
+    {
+        $this->CSPEnabled = true;
+    }
+
+    /**
+     * Disable Content Security Policy enforcement.
+     */
+    public function disable(): void
+    {
+        $this->CSPEnabled = false;
+    }
+
+    /**
      * Whether adding nonce in style-* directives is enabled or not.
      */
     public function styleNonceEnabled(): bool

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -93,6 +93,26 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function testDisable(): void
+    {
+        $this->prepare(true);
+        $this->csp->disable();
+        $this->assertTrue($this->work());
+        $this->assertHeaderNotEmitted('Content-Security-Policy:');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testEnable(): void
+    {
+        $this->prepare(false);
+        $this->csp->enable();
+        $this->assertTrue($this->work());
+        $this->assertHeaderEmitted('Content-Security-Policy:');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testReportOnly(): void
     {
         $this->csp->reportOnly(false);

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -321,6 +321,7 @@ HTTP
   For example: ``php index.php command -- --myarg`` will pass ``--myarg`` as an argument instead of an option.
 - ``CLIRequest`` now supports options with values specified using an equals sign (e.g., ``--option=value``) in addition to the existing space-separated syntax (e.g., ``--option value``).
   This provides more flexibility in how you can pass options to CLI requests.
+- Added ``enable()`` and ``disable()`` methods to ``ContentSecurityPolicy`` to enable or disable the CSP header for the current request. See :ref:`csp-enable-disable`.
 - Added ``$enableStyleNonce`` and ``$enableScriptNonce`` options to ``Config\App`` to automatically add nonces to control whether to add nonces to style-* and script-* directives in the Content Security Policy (CSP) header when CSP is enabled. See :ref:`csp-control-nonce-generation` for details.
 - Added ``URI::withQuery()``, ``URI::withQueryArray()``, ``URI::withoutQueryVars()``, and ``URI::withOnlyQueryVars()`` to return cloned URIs with replaced or filtered query variables.
 - Added ``URI::withQueryVar()`` and ``URI::withQueryVars()`` to return a cloned URI with query variables added or replaced.

--- a/user_guide_src/source/outgoing/csp.rst
+++ b/user_guide_src/source/outgoing/csp.rst
@@ -93,14 +93,14 @@ For example, to enable/disable CSP for a specific response:
 .. literalinclude:: csp/017.php
 
 The runtime value takes precedence over the ``CSPEnabled`` configuration value
-for the current response.
+for the current request.
 
-These methods only affect the current response. After the response has been sent,
-the CSP instance is recreated and the value of ``CSPEnabled`` in
-**app/Config/App.php** is used as the default for subsequent requests.
+These methods only affect the current request. They do not modify the
+application configuration. On subsequent requests, the ``CSPEnabled`` value in
+**app/Config/App.php** is used again.
 
-This allows applications to keep CSP enabled globally while temporarily disabling
-it for specific responses, or enable it only where required.
+This allows applications to keep CSP enabled globally while temporarily
+disabling it for specific requests, or enable it only where required.
 
 Report Only
 ===========

--- a/user_guide_src/source/outgoing/csp.rst
+++ b/user_guide_src/source/outgoing/csp.rst
@@ -78,6 +78,30 @@ name or an array of them:
 The first parameter to each of the "add" methods is an appropriate string value,
 or an array of them.
 
+.. _csp-enable-disable:
+
+Enable or Disable CSP at Runtime
+================================
+
+.. versionadded:: 4.8.0
+
+You can enable or disable CSP for the current request by using the
+``enable()`` and ``disable()`` methods on the CSP instance.
+
+For example, to enable/disable CSP for a specific response:
+
+.. literalinclude:: csp/017.php
+
+The runtime value takes precedence over the ``CSPEnabled`` configuration value
+for the current response.
+
+These methods only affect the current response. After the response has been sent,
+the CSP instance is recreated and the value of ``CSPEnabled`` in
+**app/Config/App.php** is used as the default for subsequent requests.
+
+This allows applications to keep CSP enabled globally while temporarily disabling
+it for specific responses, or enable it only where required.
+
 Report Only
 ===========
 

--- a/user_guide_src/source/outgoing/csp/017.php
+++ b/user_guide_src/source/outgoing/csp/017.php
@@ -1,0 +1,10 @@
+<?php
+
+// get the CSP instance
+$csp = $this->response->getCSP();
+
+// Disable CSP for the request
+$csp->disable();
+
+// Re-enable CSP for the request
+$csp->enable();


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This PR adds support to let users enable/disable CSP for current request without modifying config variables in runtime.

This lets them exclude specific routes (especially routes handling serving files) from `Content-Security-Policy` header.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
