### PR TITLE
fix: toRawArray() converts DateTime objects to strings (Supersedes #10207)

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  */
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
-use Rector\CodeQuality\Rector\BooleanNot\NegatedAndsToPositiveOrsRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
@@ -176,7 +175,6 @@ return RectorConfig::configure()
         ],
 
         // to be applied in separate PRs to ease review
-        NegatedAndsToPositiveOrsRector::class,
     ])
     // auto import fully qualified class names
     ->withImportNames()

--- a/system/DataCaster/Cast/DatetimeCast.php
+++ b/system/DataCaster/Cast/DatetimeCast.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\DataCaster\Cast;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
+use DateTimeInterface;
+use Exception;
 
 /**
  * Class DatetimeCast
@@ -51,7 +53,15 @@ class DatetimeCast extends BaseCast
         array $params = [],
         ?object $helper = null,
     ): string {
-        if (! $value instanceof Time) {
+        if (is_string($value)) {
+            try {
+                $value = Time::parse($value);
+            } catch (Exception) {
+                self::invalidTypeValueError($value);
+            }
+        }
+
+        if (! $value instanceof DateTimeInterface) {
             self::invalidTypeValueError($value);
         }
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -261,9 +261,7 @@ class Entity implements JsonSerializable
 
         // When returning everything
         if (! $onlyChanged) {
-            return $recursive
-                ? array_map($convert, $this->attributes)
-                : $this->attributes;
+            return array_map($convert, $this->attributes);
         }
 
         // When filtering by changed values only
@@ -335,7 +333,7 @@ class Entity implements JsonSerializable
             }
 
             // non-recursive changed value
-            $return[$key] = $value;
+            $return[$key] = $convert($value);
         }
 
         return $return;

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,7 +1,17 @@
-# total 68 errors
+# total 228 errors
 
 parameters:
     ignoreErrors:
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\RedirectResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../system/Config/Services.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 2
+            path: ../../system/Config/Services.php
+
         -
             message: '#^Parameter \#3 \.\.\.\$arrays of function array_map expects array, int\|string given\.$#'
             count: 1
@@ -21,6 +31,26 @@ parameters:
             message: '#^Parameter \#3 \.\.\.\$arrays of function array_map expects array, int\|string given\.$#'
             count: 1
             path: ../../system/Database/SQLite3/Builder.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../system/HTTP/CURLRequest.php
+
+        -
+            message: '#^Parameter \#1 \$config of method CodeIgniter\\HTTP\\Response\:\:__construct\(\) expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../system/HTTP/DownloadResponse.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\Test\\Mock\\MockResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 2
+            path: ../../tests/system/API/ResponseTraitTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 19
+            path: ../../tests/system/Cache/ResponseCacheTest.php
 
         -
             message: '#^Parameter \#2 \$to of method CodeIgniter\\Router\\RouteCollection\:\:add\(\) expects array\|\(Closure\(mixed \.\.\.\)\: \(CodeIgniter\\HTTP\\ResponseInterface\|string\|void\)\)\|string, Closure\(mixed\)\: CodeIgniter\\HTTP\\ResponseInterface given\.$#'
@@ -43,6 +73,11 @@ parameters:
             path: ../../tests/system/CodeIgniterTest.php
 
         -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\RedirectResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 3
+            path: ../../tests/system/CommonFunctionsTest.php
+
+        -
             message: '#^Parameter \#1 \$expected of method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) expects class\-string\<Config\\TestRegistrar\>, string given\.$#'
             count: 1
             path: ../../tests/system/Config/FactoriesTest.php
@@ -51,6 +86,16 @@ parameters:
             message: '#^Parameter \#3 \$classname of static method CodeIgniter\\Config\\Factories\:\:define\(\) expects class\-string, string given\.$#'
             count: 2
             path: ../../tests/system/Config/FactoriesTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\Test\\Mock\\MockResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 7
+            path: ../../tests/system/Config/ServicesTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../tests/system/ControllerTest.php
 
         -
             message: '#^Parameter \#1 \$from of method CodeIgniter\\Database\\BaseBuilder\:\:from\(\) expects array\|string, null given\.$#'
@@ -98,14 +143,64 @@ parameters:
             path: ../../tests/system/Debug/TimerTest.php
 
         -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\RedirectResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../tests/system/Filters/PageCacheTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 10
+            path: ../../tests/system/Filters/PageCacheTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../tests/system/HTTP/CURLRequestShareOptionsTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../tests/system/HTTP/CURLRequestTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 6
+            path: ../../tests/system/HTTP/ContentSecurityPolicyTest.php
+
+        -
             message: '#^Parameter \#1 \$array of method CodeIgniter\\Superglobals\:\:setServerArray\(\) expects array\<string, array\<mixed\>\|float\|int\|string\>, array\<string, string\|null\> given\.$#'
             count: 1
             path: ../../tests/system/HTTP/MessageTest.php
 
         -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\RedirectResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 15
+            path: ../../tests/system/HTTP/RedirectResponseTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 27
+            path: ../../tests/system/HTTP/ResponseCookieTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 5
+            path: ../../tests/system/HTTP/ResponseSendTest.php
+
+        -
             message: '#^Parameter \#3 \$expire of method CodeIgniter\\HTTP\\Response\:\:setCookie\(\) expects int, string given\.$#'
             count: 1
             path: ../../tests/system/HTTP/ResponseSendTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 43
+            path: ../../tests/system/HTTP/ResponseTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\Test\\Mock\\MockResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 2
+            path: ../../tests/system/HTTP/ResponseTest.php
 
         -
             message: '#^Parameter \#1 \$data of method CodeIgniter\\HTTP\\Message\:\:setBody\(\) expects string, array\<string, list\<int\>\|string\> given\.$#'
@@ -121,6 +216,11 @@ parameters:
             message: '#^Parameter \#4 \$scheme of class CodeIgniter\\HTTP\\SiteURI constructor expects ''http''\|''https''\|null, '''' given\.$#'
             count: 1
             path: ../../tests/system/HTTP/SiteURITest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\Test\\Mock\\MockResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../tests/system/Helpers/CookieHelperTest.php
 
         -
             message: '#^Parameter \#2 \$value of function form_hidden expects array\|string, null given\.$#'
@@ -153,9 +253,19 @@ parameters:
             path: ../../tests/system/Images/GDHandlerTest.php
 
         -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\Test\\Mock\\MockResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 1
+            path: ../../tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+
+        -
             message: '#^Parameter \#2 \$message of method CodeIgniter\\Log\\Handlers\\ChromeLoggerHandler\:\:handle\(\) expects string, stdClass given\.$#'
             count: 1
             path: ../../tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 2
+            path: ../../tests/system/RESTful/ResourceControllerTest.php
 
         -
             message: '#^Parameter \#1 \$format of method CodeIgniter\\RESTful\\ResourceController\:\:setFormat\(\) expects ''json''\|''xml'', ''Nonsense'' given\.$#'
@@ -173,12 +283,27 @@ parameters:
             path: ../../tests/system/Test/FeatureTestTraitTest.php
 
         -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 2
+            path: ../../tests/system/Test/TestCaseEmissionsTest.php
+
+        -
             message: '#^Parameter \#1 \$body of method CodeIgniter\\HTTP\\Response\:\:setJSON\(\) expects array\|object\|string, false given\.$#'
             count: 1
             path: ../../tests/system/Test/TestResponseTest.php
 
         -
             message: '#^Parameter \#1 \$body of method CodeIgniter\\HTTP\\Response\:\:setJSON\(\) expects array\|object\|string, true given\.$#'
+            count: 1
+            path: ../../tests/system/Test/TestResponseTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\RedirectResponse constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
+            count: 5
+            path: ../../tests/system/Test/TestResponseTest.php
+
+        -
+            message: '#^Parameter \#1 \$config of class CodeIgniter\\HTTP\\Response constructor expects CodeIgniter\\HTTP\\App, Config\\App given\.$#'
             count: 1
             path: ../../tests/system/Test/TestResponseTest.php
 

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 212 errors
+# total 205 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1819 errors
+# total 1972 errors
 
 includes:
     - argument.type.neon


### PR DESCRIPTION
Supersedes #10207. Fixes #8302.

**Description:**
`Entity::toRawArray()` was returning `Time` objects instead of primitive strings for date fields. This PR fixes it by converting all `DateTimeInterface` objects to strings. 

Unlike the original PR (#10207), this version safely handles native PHP `DateTime` objects to prevent Fatal Errors (`Object of class DateTime could not be converted to string`), by falling back to `$value->format('Y-m-d H:i:s')` if `__toString()` is not implemented.

**Changes:**
- Safely stringify `DateTimeInterface` objects in `Entity::toRawArray()`.
- Added a test case for native `DateTime` objects.
