### PR TITLE
fix: convert DateTimeInterface objects to strings in Entity::toRawArray

### DIFF
--- a/system/DataCaster/Cast/DatetimeCast.php
+++ b/system/DataCaster/Cast/DatetimeCast.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\DataCaster\Cast;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\I18n\Time;
+use DateTimeInterface;
+use Exception;
 
 /**
  * Class DatetimeCast
@@ -51,7 +53,15 @@ class DatetimeCast extends BaseCast
         array $params = [],
         ?object $helper = null,
     ): string {
-        if (! $value instanceof Time) {
+        if (is_string($value)) {
+            try {
+                $value = Time::parse($value);
+            } catch (Exception) {
+                self::invalidTypeValueError($value);
+            }
+        }
+
+        if (! $value instanceof DateTimeInterface) {
             self::invalidTypeValueError($value);
         }
 

--- a/system/DataCaster/Cast/TimestampCast.php
+++ b/system/DataCaster/Cast/TimestampCast.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace CodeIgniter\DataCaster\Cast;
 
 use CodeIgniter\I18n\Time;
+use DateTimeInterface;
+use Exception;
 
 /**
  * Class TimestampCast
@@ -40,7 +42,15 @@ class TimestampCast extends BaseCast
         array $params = [],
         ?object $helper = null,
     ): int {
-        if (! $value instanceof Time) {
+        if (is_string($value)) {
+            try {
+                $value = Time::parse($value);
+            } catch (Exception) {
+                self::invalidTypeValueError($value);
+            }
+        }
+
+        if (! $value instanceof DateTimeInterface) {
             self::invalidTypeValueError($value);
         }
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -261,84 +261,93 @@ class Entity implements JsonSerializable
 
         // When returning everything
         if (! $onlyChanged) {
-            return $recursive
-                ? array_map($convert, $this->attributes)
-                : $this->attributes;
-        }
+            $result = array_map($convert, $this->attributes);
+        } else {
+            // When filtering by changed values only
+            $result = [];
 
-        // When filtering by changed values only
-        $return = [];
+            foreach ($this->attributes as $key => $value) {
+                // Special handling for arrays of entities in recursive mode
+                // Skip hasChanged() and do per-entity comparison directly
+                if ($recursive && is_array($value) && $this->containsOnlyEntities($value)) {
+                    $originalValue = $this->original[$key] ?? null;
 
-        foreach ($this->attributes as $key => $value) {
-            // Special handling for arrays of entities in recursive mode
-            // Skip hasChanged() and do per-entity comparison directly
-            if ($recursive && is_array($value) && $this->containsOnlyEntities($value)) {
-                $originalValue = $this->original[$key] ?? null;
+                    if (! is_string($originalValue)) {
+                        // No original or invalid format, export all entities
+                        $converted = [];
 
-                if (! is_string($originalValue)) {
-                    // No original or invalid format, export all entities
-                    $converted = [];
+                        foreach ($value as $idx => $item) {
+                            $converted[$idx] = $item->toRawArray(false, true);
+                        }
+                        $result[$key] = $converted;
+
+                        continue;
+                    }
+
+                    // Decode original array structure for per-entity comparison
+                    $originalArray = json_decode($originalValue, true);
+                    $converted     = [];
 
                     foreach ($value as $idx => $item) {
-                        $converted[$idx] = $item->toRawArray(false, true);
+                        // Compare current entity against its original state
+                        $currentNormalized  = $this->normalizeValue($item);
+                        $originalNormalized = $originalArray[$idx] ?? null;
+
+                        // Only include if changed, new, or can't determine
+                        if ($originalNormalized === null || $currentNormalized !== $originalNormalized) {
+                            $converted[$idx] = $item->toRawArray(false, true);
+                        }
                     }
-                    $return[$key] = $converted;
+
+                    // Only include this property if at least one entity changed
+                    if ($converted !== []) {
+                        $result[$key] = $converted;
+                    }
 
                     continue;
                 }
 
-                // Decode original array structure for per-entity comparison
-                $originalArray = json_decode($originalValue, true);
-                $converted     = [];
-
-                foreach ($value as $idx => $item) {
-                    // Compare current entity against its original state
-                    $currentNormalized  = $this->normalizeValue($item);
-                    $originalNormalized = $originalArray[$idx] ?? null;
-
-                    // Only include if changed, new, or can't determine
-                    if ($originalNormalized === null || $currentNormalized !== $originalNormalized) {
-                        $converted[$idx] = $item->toRawArray(false, true);
-                    }
+                // For all other cases, use hasChanged()
+                if (! $this->hasChanged($key)) {
+                    continue;
                 }
 
-                // Only include this property if at least one entity changed
-                if ($converted !== []) {
-                    $return[$key] = $converted;
-                }
+                if ($recursive) {
+                    // Special handling for arrays (mixed or not all entities)
+                    if (is_array($value)) {
+                        $converted = [];
 
-                continue;
-            }
+                        foreach ($value as $idx => $item) {
+                            $converted[$idx] = $item instanceof self ? $item->toRawArray(false, true) : $convert($item);
+                        }
+                        $result[$key] = $converted;
 
-            // For all other cases, use hasChanged()
-            if (! $this->hasChanged($key)) {
-                continue;
-            }
-
-            if ($recursive) {
-                // Special handling for arrays (mixed or not all entities)
-                if (is_array($value)) {
-                    $converted = [];
-
-                    foreach ($value as $idx => $item) {
-                        $converted[$idx] = $item instanceof self ? $item->toRawArray(false, true) : $convert($item);
+                        continue;
                     }
-                    $return[$key] = $converted;
+
+                    // default recursive conversion
+                    $result[$key] = $convert($value);
 
                     continue;
                 }
 
-                // default recursive conversion
-                $return[$key] = $convert($value);
-
-                continue;
+                // non-recursive changed value
+                $result[$key] = $convert($value);
             }
-
-            // non-recursive changed value
-            $return[$key] = $value;
         }
 
-        return $return;
+        // Convert DateTime objects to string for user-facing calls
+        if (! $recursive) {
+            $result = array_map(static function ($value) {
+                if ($value instanceof DateTimeInterface) {
+                    return method_exists($value, '__toString') ? (string) $value : $value->format('Y-m-d H:i:s');
+                }
+
+                return $value;
+            }, $result);
+        }
+
+        return $result;
     }
 
     /**

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -336,15 +336,27 @@ class Entity implements JsonSerializable
             }
         }
 
-        // Convert DateTime objects to string for user-facing calls
+        // Convert DateTime objects to string for user-facing calls (only for dates/datetime cast fields)
         if (! $recursive) {
-            $result = array_map(static function ($value) {
+            foreach ($result as $key => $value) {
                 if ($value instanceof DateTimeInterface) {
-                    return method_exists($value, '__toString') ? (string) $value : $value->format('Y-m-d H:i:s');
-                }
+                    $isDate = in_array($key, $this->dates, true);
+                    if (! $isDate && isset($this->casts[$key])) {
+                        $cast = $this->casts[$key];
+                        if (str_contains($cast, 'datetime')) {
+                            $isDate = true;
+                        }
+                    }
 
-                return $value;
-            }, $result);
+                    if ($isDate) {
+                        if ((int) $value->format('u') > 0) {
+                            $result[$key] = $value->format('Y-m-d H:i:s.u');
+                        } else {
+                            $result[$key] = method_exists($value, '__toString') ? (string) $value : $value->format('Y-m-d H:i:s');
+                        }
+                    }
+                }
+            }
         }
 
         return $result;

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\DataConverter;
 
 use Closure;
 use CodeIgniter\DataCaster\Exceptions\CastException;
+use CodeIgniter\Entity\Entity;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -875,6 +876,44 @@ final class DataConverterTest extends CIUnitTestCase
             'name'       => 'John Smith',
             'created_at' => '2023-12-02 07:35:57',
         ], $array);
+    }
+
+    public function testExtractEntityWithTimestampCast(): void
+    {
+        $converter = $this->createDataConverter([
+            'updated_at' => 'timestamp',
+        ]);
+
+        $entity = new class () extends Entity {
+            protected $dates = [];
+        };
+        $entity->injectRawData([
+            'updated_at' => Time::createFromTimestamp(1_784_092_299),
+        ]);
+
+        $data = $converter->extract($entity);
+
+        $this->assertSame(1_784_092_299, $data['updated_at']);
+    }
+
+    public function testExtractEntityPreservesMicrosecondsWithDatetimeCast(): void
+    {
+        $converter = $this->createDataConverter(
+            ['updated_at' => 'datetime[us]'],
+            [],
+            db_connect(),
+        );
+
+        $entity = new class () extends Entity {
+            protected $dates = [];
+        };
+        $entity->injectRawData([
+            'updated_at' => Time::createFromFormat('Y-m-d H:i:s.u', '2026-07-15 00:00:01.123456'),
+        ]);
+
+        $data = $converter->extract($entity);
+
+        $this->assertSame('2026-07-15 00:00:01.123456', $data['updated_at']);
     }
 
     /**

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -367,6 +367,41 @@ final class EntityTest extends CIUnitTestCase
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
 
+    public function testToRawArrayConvertsDateTimeToString(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'created_at' => null,
+                'updated_at' => null,
+            ];
+            protected $original = [
+                'created_at' => null,
+                'updated_at' => null,
+            ];
+        };
+
+        $entity->created_at = '2023-12-12 12:12:12';
+        $entity->updated_at = '2023-12-13 13:13:13';
+
+        $raw = $entity->toRawArray();
+
+        // toRawArray() should return primitive types, not objects
+        $this->assertIsString($raw['created_at']);
+        $this->assertSame('2023-12-12 12:12:12', $raw['created_at']);
+        $this->assertIsString($raw['updated_at']);
+        $this->assertSame('2023-12-13 13:13:13', $raw['updated_at']);
+
+        // Attributes themselves should still contain Time objects
+        $attrs = $this->getPrivateProperty($entity, 'attributes');
+        $this->assertInstanceOf(Time::class, $attrs['created_at']);
+        $this->assertInstanceOf(Time::class, $attrs['updated_at']);
+
+        // toArray() should still return Time objects (no regression)
+        $array = $entity->toArray();
+        $this->assertInstanceOf(Time::class, $array['created_at']);
+        $this->assertInstanceOf(Time::class, $array['updated_at']);
+    }
+
     public function testCastInteger(): void
     {
         $entity = $this->getCastEntity();
@@ -1419,6 +1454,93 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame([
             'bar' => 'bar:foo',
         ], $result);
+    }
+
+    public function testToRawArrayConvertsDateTimeToStringOnlyWhenNonRecursive(): void
+    {
+        $entity = $this->getEntity();
+
+        // Non-recursive: DateTime becomes string
+        $entity->created_at = '2024-03-15 10:30:00';
+        $raw                = $entity->toRawArray();
+        $this->assertIsString($raw['created_at']);
+
+        // Recursive: DateTime stays Time
+        $recursive = $entity->toRawArray(false, true);
+        $this->assertInstanceOf(Time::class, $recursive['created_at']);
+
+        // Non-recursive onlyChanged: also converts to string
+        $entity->syncOriginal();
+        $entity->created_at = '2024-06-15 14:30:00';
+        $changed            = $entity->toRawArray(true);
+        $this->assertIsString($changed['created_at']);
+
+        // Recursive onlyChanged: preserves Time
+        $changedRecursive = $entity->toRawArray(true, true);
+        $this->assertInstanceOf(Time::class, $changedRecursive['created_at']);
+
+        // Null values stay null regardless of mode
+        $entity2 = $this->getEntity();
+        $this->assertNull($entity2->toRawArray()['created_at']);
+        $this->assertNull($entity2->toRawArray(false, true)['created_at']);
+
+        // toArray() should not be affected (still returns Time)
+        $arr = $entity->toArray();
+        $this->assertInstanceOf(Time::class, $arr['createdAt']);
+    }
+
+    public function testToRawArrayRecursivePreservesTimeObjectsInNestedEntities(): void
+    {
+        $child             = $this->getEntity();
+        $child->created_at = '2024-03-10 08:00:00';
+
+        $parent             = $this->getEntity();
+        $parent->created_at = '2024-03-15 10:30:00';
+        $parent->entity     = $child;
+
+        $result = $parent->toRawArray(false, true);
+
+        $this->assertInstanceOf(Time::class, $result['created_at']);
+        $this->assertIsArray($result['entity']);
+        $this->assertInstanceOf(Time::class, $result['entity']['created_at']);
+
+        // Non-recursive: converts to string
+        $nonRecursive = $parent->toRawArray();
+        $this->assertIsString($nonRecursive['created_at']);
+
+        // toArray() uses datamapped keys
+        $arr = $parent->toArray();
+        $this->assertInstanceOf(Time::class, $arr['createdAt']);
+    }
+
+    public function testToRawArrayRecursiveWithMixedAttributes(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'name'       => null,
+                'created_at' => null,
+                'count'      => null,
+            ];
+            protected $original = [
+                'name'       => null,
+                'created_at' => null,
+                'count'      => null,
+            ];
+        };
+
+        $entity->name       = 'test';
+        $entity->count      = 42;
+        $entity->created_at = '2024-08-20 16:45:00';
+
+        // Recursive: scalars unchanged, DateTime preserved as Time
+        $result = $entity->toRawArray(false, true);
+        $this->assertSame('test', $result['name']);
+        $this->assertSame(42, $result['count']);
+        $this->assertInstanceOf(Time::class, $result['created_at']);
+
+        // Non-recursive: DateTime converted to string
+        $result2 = $entity->toRawArray();
+        $this->assertIsString($result2['created_at']);
     }
 
     public function testFilledConstruction(): void

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -1543,6 +1543,62 @@ final class EntityTest extends CIUnitTestCase
         $this->assertIsString($result2['created_at']);
     }
 
+    public function testToRawArrayDoesNotConvertDateTimeWhenNotDeclaredInDatesOrCasts(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'custom_date' => null,
+            ];
+            protected $dates = [];
+            protected $casts = [];
+        };
+
+        $entity->custom_date = Time::parse('2024-08-20 16:45:00');
+
+        $result = $entity->toRawArray();
+        $this->assertInstanceOf(Time::class, $result['custom_date']);
+    }
+
+    public function testToRawArrayRespectsCustomDateTimeStringConversion(): void
+    {
+        $customDateTime = new class ('2024-08-20 16:45:00') extends DateTime {
+            public function __toString(): string
+            {
+                return 'custom-formatted-date';
+            }
+        };
+
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'created_at' => null,
+            ];
+            protected $dates = [];
+            protected $casts = [
+                'created_at' => 'datetime',
+            ];
+        };
+
+        $entity->created_at = $customDateTime;
+
+        $result = $entity->toRawArray();
+        $this->assertSame('custom-formatted-date', $result['created_at']);
+    }
+
+    public function testToRawArrayConvertsNativeDateTimeToString(): void
+    {
+        $entity = new class () extends Entity {
+            protected $attributes = [
+                'created_at' => null,
+            ];
+            protected $dates = ['created_at'];
+        };
+
+        $entity->created_at = new DateTime('2024-08-20 16:45:00');
+
+        $result = $entity->toRawArray();
+        $this->assertSame('2024-08-20 16:45:00', $result['created_at']);
+    }
+
     public function testFilledConstruction(): void
     {
         $data = [

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -30,7 +30,7 @@ Deprecations
 Bugs Fixed
 **********
 
-- **Entity:** Fixed a bug where ``toRawArray()`` returned ``Time`` objects instead of ISO-8601 strings for date fields.
+- **Entity:** Fixed a bug where ``toRawArray()`` returned ``Time`` objects instead of strings for date fields.
 
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
 

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Entity:** Fixed a bug where ``toRawArray()`` returned ``Time`` objects instead of ISO-8601 strings for date fields.
+
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
 
 See the repo's

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 212 errors
+# total 205 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1819 errors
+# total 1812 errors
 
 includes:
     - argument.type.neon


### PR DESCRIPTION
**Description**
Supersedes #10207. Fixes #8302.

`Entity::toRawArray()` was returning `Time` objects instead of primitive strings for date fields. This PR fixes it by converting all `DateTimeInterface` objects to strings in non-recursive mode.

Unlike the original PR (#10207), this version safely handles native PHP `DateTime` objects to prevent Fatal Errors (*Object of class DateTime could not be converted to string*), by falling back to `$value->format('Y-m-d H:i:s')` if `__toString()` is not implemented.

The conversion only applies to non-recursive calls (`$recursive = false`). The recursive mode preserves `Time` objects, which are then handled by `BaseModel::timeToString()` in the non-cast path and by `DataConverter::toDataSource()` in the cast path — so model saving/casting is unaffected.

**Changes:**
- Safely stringify `DateTimeInterface` objects in `Entity::toRawArray()` (non-recursive only)
- Updated `DatetimeCast::set()` to accept strings and any `DateTimeInterface` for round-trip compatibility
- Added test cases: basic conversion, non-recursive vs recursive, nested entities, mixed attributes


**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [] Conforms to style guide