### PR TITLE
fix: handle null results in get_dir_file_info()

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -281,8 +281,11 @@ if (! function_exists('get_dir_file_info')) {
                 if (is_dir($sourceDir . $file) && $file[0] !== '.' && $topLevelOnly === false) {
                     get_dir_file_info($sourceDir . $file . DIRECTORY_SEPARATOR, $topLevelOnly, true);
                 } elseif ($file[0] !== '.') {
-                    $fileData[$file]                  = get_file_info($sourceDir . $file);
-                    $fileData[$file]['relative_path'] = $relativePath;
+                    $info = get_file_info($sourceDir . $file);
+                    if ($info !== null) {
+                        $fileData[$file]                  = $info;
+                        $fileData[$file]['relative_path'] = $relativePath;
+                    }
                 }
             }
 

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -477,6 +477,22 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $this->assertSame($expected, get_dir_file_info(SUPPORTPATH . 'Files#baker'));
     }
 
+    public function testGetDirFileInfoIgnoresDirectoriesWhenTopLevelOnlyIsTrue(): void
+    {
+        $dir = WRITEPATH . 'test_get_dir_file_info';
+        mkdir($dir . '/subdir', 0777, true);
+        file_put_contents($dir . '/file.txt', 'test');
+
+        $result = get_dir_file_info($dir, true);
+
+        unlink($dir . '/file.txt');
+        rmdir($dir . '/subdir');
+        rmdir($dir);
+
+        $this->assertArrayHasKey('file.txt', $result);
+        $this->assertArrayNotHasKey('subdir', $result);
+    }
+
     public function testGetFileInfo(): void
     {
         $file = SUPPORTPATH . 'Files/baker/banana.php';

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -32,7 +32,7 @@ Bugs Fixed
 
 - **CLIRequest:** Fixed a bug where ``parseCommand()`` could throw a TypeError when ``argv`` is missing.
 - **Content Security Policy:** Fixed a bug where empty ``Content-Security-Policy``, ``Content-Security-Policy-Report-Only``, and ``Reporting-Endpoints`` response headers were generated when no corresponding values existed.
-- **Helpers:** Fixed a bug where ``get_dir_file_info()`` could cause a null pointer error when ``get_file_info()`` returns null.
+- **Helpers:** Fixed a bug where ``get_dir_file_info()`` returned incomplete entries for subdirectories and missing files instead of omitting them.
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
 
 See the repo's

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -32,6 +32,7 @@ Bugs Fixed
 
 - **CLIRequest:** Fixed a bug where ``parseCommand()`` could throw a TypeError when ``argv`` is missing.
 - **Content Security Policy:** Fixed a bug where empty ``Content-Security-Policy``, ``Content-Security-Policy-Report-Only``, and ``Reporting-Endpoints`` response headers were generated when no corresponding values existed.
+- **Helpers:** Fixed a bug where ``get_dir_file_info()`` could cause a null pointer error when ``get_file_info()`` returns null.
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
 
 See the repo's


### PR DESCRIPTION
**Description**
Add null check in `get_dir_file_info()` for when `get_file_info()` returns `null` (race condition: file deleted after `readdir()` but before `get_file_info()`). This prevents broken entries and fixes random test failures in `Commands`. Includes unit test.

Ref: #9968

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
