### PR TITLE
test: fix cache test race conditions

### DIFF
--- a/tests/system/Commands/Cache/ClearCacheTest.php
+++ b/tests/system/Commands/Cache/ClearCacheTest.php
@@ -16,8 +16,10 @@ namespace CodeIgniter\Commands\Cache;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\Handlers\FileHandler;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use Config\Cache;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -29,6 +31,8 @@ final class ClearCacheTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
+    private Cache $config;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -36,16 +40,36 @@ final class ClearCacheTest extends CIUnitTestCase
         CLI::reset();
         $this->resetServices();
 
+        $this->config                    = new Cache();
+        $this->config->file['storePath'] = rtrim($this->config->file['storePath'], DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR . 'FileHandlerCommands';
+
+        if (! is_dir($this->config->file['storePath'])) {
+            mkdir($this->config->file['storePath'], 0777, true);
+        }
+
+        Factories::injectMock('config', Cache::class, $this->config);
+
         // Make sure we are testing with the correct handler (override injections)
-        Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
+        $handler = CacheFactory::getHandler($this->config);
+        $handler->clean();
+        Services::injectMock('cache', $handler);
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
+        $this->config->handler = 'file';
+
+        if (is_dir($this->config->file['storePath'])) {
+            CacheFactory::getHandler($this->config)->clean();
+            rmdir($this->config->file['storePath']);
+        }
 
         CLI::reset();
+        $this->resetFactories();
         $this->resetServices();
+
+        parent::tearDown();
     }
 
     public function testClearCacheInvalidHandler(): void
@@ -72,7 +96,7 @@ final class ClearCacheTest extends CIUnitTestCase
     public function testClearCacheFails(): void
     {
         $cache = $this->getMockBuilder(FileHandler::class)
-            ->setConstructorArgs([config('Cache')])
+            ->setConstructorArgs([$this->config])
             ->onlyMethods(['clean'])
             ->getMock();
         $cache->expects($this->once())->method('clean')->willReturn(false);

--- a/tests/system/Commands/Cache/InfoCacheTest.php
+++ b/tests/system/Commands/Cache/InfoCacheTest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace CodeIgniter\Commands\Cache;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use Config\Cache;
 use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -27,18 +29,41 @@ final class InfoCacheTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
+    private Cache $config;
+
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->config                    = new Cache();
+        $this->config->file['storePath'] = rtrim($this->config->file['storePath'], DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR . 'FileHandlerCommands';
+
+        if (! is_dir($this->config->file['storePath'])) {
+            mkdir($this->config->file['storePath'], 0777, true);
+        }
+
+        Factories::injectMock('config', Cache::class, $this->config);
+
         // Make sure we are testing with the correct handler (override injections)
-        Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
+        $handler = CacheFactory::getHandler($this->config);
+        $handler->clean();
+        Services::injectMock('cache', $handler);
     }
 
     protected function tearDown(): void
     {
-        // restore default cache handler
-        config('Cache')->handler = 'file';
+        $this->config->handler = 'file';
+
+        if (is_dir($this->config->file['storePath'])) {
+            CacheFactory::getHandler($this->config)->clean();
+            rmdir($this->config->file['storePath']);
+        }
+
+        $this->resetFactories();
+        $this->resetServices();
+
+        parent::tearDown();
     }
 
     protected function getBuffer(): string
@@ -48,7 +73,7 @@ final class InfoCacheTest extends CIUnitTestCase
 
     public function testInfoCacheErrorsOnInvalidHandler(): void
     {
-        config('Cache')->handler = 'redis';
+        $this->config->handler = 'redis';
         cache()->save('foo', 'bar');
         command('cache:info');
 


### PR DESCRIPTION
**Description**
This PR fixes race conditions between cache tests running concurrently by giving the cache command tests a dedicated file cache directory.

See: https://github.com/codeigniter4/CodeIgniter4/actions/runs/29436294111/job/87423746025?pr=10374

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
