### PR TITLE
test: cover GDHandler save failures and unsupported image types

### DIFF
--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -489,10 +489,6 @@ final class GDHandlerTest extends CIUnitTestCase
     public function testImageCopyTargetWithMaxQuality(): void
     {
         foreach (['gif', 'jpeg', 'png', 'webp'] as $type) {
-            if ($type === 'webp' && ! function_exists('imagecreatefromwebp')) {
-                $this->markTestSkipped('webp is not supported.');
-            }
-
             $this->handler->withFile($this->origin . 'ci-logo.' . $type);
             $this->assertTrue($this->handler->save($this->start . 'work/ci-logo.' . $type, 100));
             $this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
@@ -505,21 +501,6 @@ final class GDHandlerTest extends CIUnitTestCase
                 $child->getContent(),
             );
         }
-    }
-
-    public function testSaveUnsupportedImageType(): void
-    {
-        $this->handler->withFile($this->path);
-
-        // Force an invalid image type to trigger getImageResource() default case
-        $image            = $this->handler->getFile();
-        $image->imageType = 9999;
-
-        $this->expectException(ImageException::class);
-        $this->expectExceptionMessage(lang('Images.unsupportedImageCreate'));
-
-        // save() calls ensureResource() -> getImageResource(), which should throw
-        $this->handler->save($this->start . 'work/ci-logo.jpg');
     }
 
     public function testProcessUnsupportedImageType(): void

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -19,7 +19,9 @@ use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use org\bovigo\vfs\vfsStreamFile;
 use PHPUnit\Framework\Attributes\Group;
+use Throwable;
 
 /**
  * Unit testing for the GD image handler.
@@ -462,5 +464,76 @@ final class GDHandlerTest extends CIUnitTestCase
         $result = $this->handler->clearMetadata();
 
         $this->assertSame($this->handler, $result);
+    }
+
+    public function testSaveFailed(): void
+    {
+        foreach (['gif', 'jpeg', 'png', 'webp'] as $type) {
+            if ($type === 'webp' && ! function_exists('imagecreatefromwebp')) {
+                $this->markTestSkipped('webp is not supported.');
+            }
+
+            $this->handler->withFile($this->origin . 'ci-logo.' . $type);
+            $this->handler->getResource(); // make sure resource is loaded
+
+            try {
+                $this->handler->save($this->start . 'wontwork/ci-logo.' . $type);
+                $this->fail('Exception should have been thrown for ' . $type);
+            } catch (Throwable $e) {
+                $this->assertInstanceOf(ImageException::class, $e);
+                $this->assertSame(lang('Images.saveFailed'), $e->getMessage());
+            }
+        }
+    }
+
+    public function testImageCopyTargetWithMaxQuality(): void
+    {
+        foreach (['gif', 'jpeg', 'png', 'webp'] as $type) {
+            if ($type === 'webp' && ! function_exists('imagecreatefromwebp')) {
+                $this->markTestSkipped('webp is not supported.');
+            }
+
+            $this->handler->withFile($this->origin . 'ci-logo.' . $type);
+            $this->assertTrue($this->handler->save($this->start . 'work/ci-logo.' . $type, 100));
+            $this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
+
+            /** @var vfsStreamFile $child */
+            $child = $this->root->getChild('work/ci-logo.' . $type);
+
+            $this->assertSame(
+                file_get_contents($this->origin . 'ci-logo.' . $type),
+                $child->getContent(),
+            );
+        }
+    }
+
+    public function testSaveUnsupportedImageType(): void
+    {
+        $this->handler->withFile($this->path);
+
+        // Force an invalid image type to ensure proper exception handling
+        $image            = $this->handler->getFile();
+        $image->imageType = 9999;
+
+        $this->expectException(ImageException::class);
+        $this->expectExceptionMessage(lang('Images.unsupportedImageCreate'));
+
+        // save() should throw an exception instead of fatal error in GD
+        $this->handler->save($this->start . 'work/ci-logo.jpg');
+    }
+
+    public function testProcessUnsupportedImageType(): void
+    {
+        $this->handler->withFile($this->path);
+
+        // Force an invalid image type to trigger getImageResource default case
+        $image            = $this->handler->getFile();
+        $image->imageType = 9999;
+
+        $this->expectException(ImageException::class);
+        $this->expectExceptionMessage('Ima');
+
+        // Calling any process function that triggers ensureResource/createImage
+        $this->handler->resize(10, 10);
     }
 }

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -511,14 +511,14 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
 
-        // Force an invalid image type to ensure proper exception handling
+        // Force an invalid image type to trigger getImageResource() default case
         $image            = $this->handler->getFile();
         $image->imageType = 9999;
 
         $this->expectException(ImageException::class);
         $this->expectExceptionMessage(lang('Images.unsupportedImageCreate'));
 
-        // save() should throw an exception instead of fatal error in GD
+        // save() calls ensureResource() -> getImageResource(), which should throw
         $this->handler->save($this->start . 'work/ci-logo.jpg');
     }
 
@@ -526,14 +526,14 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
 
-        // Force an invalid image type to trigger getImageResource default case
+        // Force an invalid image type to trigger getImageResource() default case
         $image            = $this->handler->getFile();
         $image->imageType = 9999;
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Ima');
+        $this->expectExceptionMessage(lang('Images.unsupportedImageCreate'));
 
-        // Calling any process function that triggers ensureResource/createImage
+        // resize() calls ensureResource() -> getImageResource(), which should throw
         $this->handler->resize(10, 10);
     }
 }


### PR DESCRIPTION
**Description**
Adds missing unit tests for `GDHandler::save()` and unsupported image types exceptions to improve code coverage.

Changes:
- Added tests for file save failures using `vfsStream`.
- Added a test for the `save($target, 100)` unmodified copy logic.
- Added tests simulating an unsupported `imageType` to ensure `ImageException` is thrown instead of a fatal GD error.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
