### PR TITLE
fix: resolve TypeError in CLIRequest::parseCommand when argv is missing

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -185,7 +185,7 @@ class CLIRequest extends Request
      */
     protected function parseCommand()
     {
-        $args = $this->getServer('argv');
+        $args = $this->getServer('argv') ?? [];
         array_shift($args); // Scrap index.php
 
         $optionValue = false;

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -574,4 +574,15 @@ final class CLIRequestTest extends CIUnitTestCase
     {
         $this->assertFalse($this->request->is('get'));
     }
+
+    public function testParseCommandWithMissingArgv(): void
+    {
+        Services::injectMock('superglobals', new Superglobals([], [], [], [], []));
+
+        $request = new CLIRequest(new App());
+
+        $this->assertSame('', $request->getPath());
+        $this->assertSame([], $request->getSegments());
+        $this->assertSame('', $request->getOptionString());
+    }
 }

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -30,6 +30,7 @@ Deprecations
 Bugs Fixed
 **********
 
+- **CLIRequest:** Fixed a bug where ``parseCommand()`` could throw a TypeError when ``argv`` is missing.
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
 
 See the repo's


### PR DESCRIPTION
**Description**
In environments where `$_SERVER['argv']` is not populated or explicitly set to `null` (e.g., during testing or non-standard executions), instantiating `CLIRequest` throws a `TypeError: array_shift(): Argument #1 ($array) must be of type array, null given` on modern PHP versions. 

This PR resolves the issue by defaulting `$args` to an empty array before calling `array_shift()`. A corresponding unit test `testParseCommandWithMissingArgv` has been added to `CLIRequestTest` to ensure the class initializes properly under these conditions without throwing an error.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
