### PR TITLE
refactor: add int type hint to gc() in all session handlers

### DIFF
--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -80,7 +80,7 @@ class ArrayHandler extends BaseHandler
      * @param int $max_lifetime Sessions that have not updated
      *                          for the last max_lifetime seconds will be removed.
      */
-    public function gc($max_lifetime): int
+    public function gc(int $max_lifetime): int
     {
         return 1;
     }

--- a/system/Session/Handlers/Database/PostgreHandler.php
+++ b/system/Session/Handlers/Database/PostgreHandler.php
@@ -59,7 +59,7 @@ class PostgreHandler extends DatabaseHandler
      * @param int $max_lifetime Sessions that have not updated
      *                          for the last max_lifetime seconds will be removed.
      */
-    public function gc($max_lifetime): false|int
+    public function gc(int $max_lifetime): false|int
     {
         $separator = '\'';
         $interval  = implode($separator, ['', "{$max_lifetime} second", '']);

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -276,7 +276,7 @@ class DatabaseHandler extends BaseHandler
      *
      * @return false|int Returns the number of deleted sessions on success, or false on failure.
      */
-    public function gc($max_lifetime): false|int
+    public function gc(int $max_lifetime): false|int
     {
         return $this->db->table($this->table)->where(
             'timestamp <',

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -263,7 +263,7 @@ class FileHandler extends BaseHandler
      * @param int $max_lifetime Sessions that have not updated
      *                          for the last max_lifetime seconds will be removed.
      */
-    public function gc($max_lifetime): false|int
+    public function gc(int $max_lifetime): false|int
     {
         if (! is_dir($this->savePath) || ($directory = opendir($this->savePath)) === false) {
             $this->logger->debug("Session: Garbage collector couldn't list files under directory '" . $this->savePath . "'.");

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -255,7 +255,7 @@ class MemcachedHandler extends BaseHandler
      * @param int $max_lifetime Sessions that have not updated
      *                          for the last max_lifetime seconds will be removed.
      */
-    public function gc($max_lifetime): int
+    public function gc(int $max_lifetime): int
     {
         return 1;
     }

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -341,7 +341,7 @@ class RedisHandler extends BaseHandler
      * @param int $max_lifetime Sessions that have not updated
      *                          for the last max_lifetime seconds will be removed.
      */
-    public function gc($max_lifetime): int
+    public function gc(int $max_lifetime): int
     {
         return 1;
     }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -73,6 +73,7 @@ Method Signature Changes
 - **Database:** The following methods have had their signatures updated to remove deprecated parameters:
     - ``CodeIgniter\Database\Forge::_createTable()`` no longer accepts the deprecated ``$ifNotExists`` parameter. The method signature is now ``_createTable(string $table, array $attributes)``.
 - **Model:** ``CodeIgniter\BaseModel`` now requires the ``chunkRows()``, ``chunkById()``, and ``chunkRowsById()`` methods. Custom classes extending ``BaseModel`` directly must implement them.
+- **Session:** The ``$max_lifetime`` parameter of the following ``gc()`` methods now has the native ``int`` type, matching ``SessionHandlerInterface``: ``ArrayHandler::gc()``, ``DatabaseHandler::gc()``, ``FileHandler::gc()``, ``MemcachedHandler::gc()``, ``PostgreHandler::gc()``, ``RedisHandler::gc()``.
 
 Property Scope Changes
 ======================


### PR DESCRIPTION
**Description**
Added int type hint to $max_lifetime in all 6 session handlers' gc() to match SessionHandlerInterface. This prevents SQL injection from non-integer input by rejecting it with a `TypeError`.

Affected handlers: ArrayHandler, DatabaseHandler, FileHandler, MemcachedHandler, PostgreHandler, RedisHandler.

**Checklist:**
- [x] Securely signed commits
- [x] PHPDoc blocks updated
- [ ] User guide updated
- [x] Conforms to style guide