### PR TITLE
feat: Add `post_response` event that gets triggered after response is sent to the client

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -297,6 +297,8 @@ class CodeIgniter
 
         $this->sendResponse();
 
+        Events::trigger('post_response');
+
         return null;
     }
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -405,10 +405,10 @@ trait ResponseTrait
     private function closeOutputBuffers(): void
     {
         $status = ob_get_status(true);
-        $level = count($status);
-        $flags = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
+        $level  = count($status);
+        $flags  = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
 
-        while ($level-- > 0 && ($s = $status[$level]) && (!isset($s['del']) ? !isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
+        while ($level-- > 0 && ($s = $status[$level]) && (! isset($s['del']) ? ! isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
             ob_end_flush();
         }
     }

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -385,7 +385,32 @@ trait ResponseTrait
         $this->sendCookies();
         $this->sendBody();
 
+        $this->finishResponse();
+
         return $this;
+    }
+
+    private function finishResponse(): void
+    {
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        } elseif (function_exists('litespeed_finish_request')) {
+            litespeed_finish_request();
+        } elseif (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+            $this->closeOutputBuffers();
+            flush();
+        }
+    }
+
+    private function closeOutputBuffers(): void
+    {
+        $status = ob_get_status(true);
+        $level = count($status);
+        $flags = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
+
+        while ($level-- > 0 && ($s = $status[$level]) && (!isset($s['del']) ? !isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
+            ob_end_flush();
+        }
     }
 
     /**

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -405,10 +405,10 @@ trait ResponseTrait
     private function closeOutputBuffers(): void
     {
         $status = ob_get_status(true);
-        $level  = count($status);
-        $flags  = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
+        $level = count($status);
+        $flags = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
 
-        while ($level-- > 0 && ($s = $status[$level]) && (! isset($s['del']) ? ! isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
+        while ($level-- > 0 && ($s = $status[$level]) && (!isset($s['del']) ? !isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
             ob_end_flush();
         }
     }

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -408,7 +408,7 @@ trait ResponseTrait
         $level  = count($status);
         $flags  = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
 
-        while ($level-- > 0 && ($s = $status[$level]) && (! isset($s['del']) ? ! isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
+        while ($level-- > 0 && ($s = $status[$level]) && ($s['del'] ?? (! isset($s['flags']) || ($s['flags'] & $flags) === $flags))) {
             ob_end_flush();
         }
     }

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -396,7 +396,7 @@ trait ResponseTrait
             fastcgi_finish_request();
         } elseif (function_exists('litespeed_finish_request')) {
             litespeed_finish_request();
-        } elseif (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+        } elseif (! in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
             $this->closeOutputBuffers();
             flush();
         }
@@ -405,10 +405,10 @@ trait ResponseTrait
     private function closeOutputBuffers(): void
     {
         $status = ob_get_status(true);
-        $level = count($status);
-        $flags = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
+        $level  = count($status);
+        $flags  = PHP_OUTPUT_HANDLER_REMOVABLE | PHP_OUTPUT_HANDLER_FLUSHABLE;
 
-        while ($level-- > 0 && ($s = $status[$level]) && (!isset($s['del']) ? !isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
+        while ($level-- > 0 && ($s = $status[$level]) && (! isset($s['del']) ? ! isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
             ob_end_flush();
         }
     }

--- a/tests/_support/HTTP/Responses/ResponseWithPostSendFlag.php
+++ b/tests/_support/HTTP/Responses/ResponseWithPostSendFlag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Support\HTTP\Responses;
+
+use CodeIgniter\HTTP\Response;
+
+class ResponseWithPostSendFlag extends Response
+{
+    public $responseSent = false;
+
+    /**
+     * Sends the output to the browser.
+     *
+     * @return $this
+     */
+    public function send()
+    {
+        parent::send();
+
+        $this->responseSent = true;
+
+        return $this;
+    }
+}

--- a/tests/_support/HTTP/Responses/ResponseWithPostSendFlag.php
+++ b/tests/_support/HTTP/Responses/ResponseWithPostSendFlag.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
 namespace Tests\Support\HTTP\Responses;
 
 use CodeIgniter\HTTP\Response;

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -39,8 +39,8 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use Tests\Support\Filters\Customfilter;
 use Tests\Support\Filters\RedirectFilter;
-use Tests\Support\Router\Filters\TestAttributeFilter;
 use Tests\Support\HTTP\Responses\ResponseWithPostSendFlag;
+use Tests\Support\Router\Filters\TestAttributeFilter;
 
 /**
  * @internal
@@ -1340,7 +1340,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $postResponseTriggeredAfterResponseSent = false;
 
-        Events::on('post_response', static function () use (&$postResponseTriggeredAfterResponseSent, &$response) {
+        Events::on('post_response', static function () use (&$postResponseTriggeredAfterResponseSent, &$response): void {
             $postResponseTriggeredAfterResponseSent = $response->responseSent;
         });
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -17,6 +17,7 @@ use App\Controllers\Home;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Debug\Timer;
+use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Response;
@@ -39,6 +40,7 @@ use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use Tests\Support\Filters\Customfilter;
 use Tests\Support\Filters\RedirectFilter;
 use Tests\Support\Router\Filters\TestAttributeFilter;
+use Tests\Support\HTTP\Responses\ResponseWithPostSendFlag;
 
 /**
  * @internal
@@ -1327,5 +1329,25 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertNull(RichRenderer::$js_nonce);
         $this->assertNull(RichRenderer::$css_nonce);
         $this->assertTrue(RichRenderer::$needs_pre_render);
+    }
+
+    public function testPostResponseTriggeredAfterSend(): void
+    {
+        $this->resetServices();
+
+        $response = new ResponseWithPostSendFlag();
+        Services::injectMock('response', $response);
+
+        $postResponseTriggeredAfterResponseSent = false;
+
+        Events::on('post_response', static function () use (&$postResponseTriggeredAfterResponseSent, &$response) {
+            $postResponseTriggeredAfterResponseSent = $response->responseSent;
+        });
+
+        ob_start();
+        $this->codeigniter->run();
+        ob_get_clean();
+
+        $this->assertTrue($postResponseTriggeredAfterResponseSent);
     }
 }

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -350,6 +350,7 @@ Others
 - **Filters:** Added ``RequestId`` filter for request tracing and correlation logging. The filter stores the request ID in the request context and automatically adds the ``X-Request-ID`` response header. Incoming ``X-Request-ID`` headers are used when valid. See :ref:`requestid` for details.
 - **Environment:** Added ``CodeIgniter\EnvironmentDetector`` class and corresponding ``environment`` service as a mockable wrapper around the ``ENVIRONMENT`` constant.
   Framework internals that previously compared ``ENVIRONMENT`` directly now go through this service, making environment-specific branches reachable in tests via ``Services::injectMock()``. See :ref:`environment-detector-service`.
+- **Events**: Added ``post_response`` event to run after the response is sent to the client.
 - **Time:** Added ``Time::between()``, ``Time::min()``, and ``Time::max()`` comparison helpers. See :ref:`between <time-comparing-two-times-between>`, :ref:`min <time-comparing-two-times-min>`, and :ref:`max <time-comparing-two-times-max>`.
 
 ***************

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -99,6 +99,10 @@ invoked by **public/index.php**:
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
 * **post_system** Called right before the final rendered page is sent to the browser,
   at the end of system execution, after the execution of "after" controller filters.
+* **post_response** Called after the response is sent to the client. This event is useful
+  for performing tasks that do not need to be completed before the response is sent, such as logging or cleanup tasks.
+
+.. note:: The ``post_response`` event was added in v4.8.0.
 
 .. _event-points-for-cli-apps:
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This PR adds a new `post_response` event that is triggered from the `run()` method of the CodeIgniter class after the response has been sent to the client.

The `ResponseTrait::send()` method now manually finalizes the request lifecycle after sending the response. The implementation of `ResponseTrait::finishResponse()` and `ResponseTrait::closeOutputBuffers()` is adapted from Symfony's implementation, which can be viewed here:
- https://github.com/symfony/symfony/blob/8.2/src/Symfony/Component/HttpFoundation/Response.php#L398-L424
- https://github.com/symfony/symfony/blob/8.2/src/Symfony/Component/HttpFoundation/Response.php#L1269-L1289

This allows developers to register post-response tasks, such as cleanup operations or analytics processing, without delaying the response sent to the client.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
