### PR TITLE
fix: remove destructive setServerArray([]) in FiltersTest::setUp to prevent random-order test failures

### DIFF
--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -68,7 +68,6 @@ final class FiltersTest extends CIUnitTestCase
         ];
         service('autoloader')->addNamespace($defaults);
 
-        service('superglobals')->setServerArray([]);
         Services::injectMock('superglobals', new Superglobals());
 
         $this->response = service('response');


### PR DESCRIPTION
**Description**

`FiltersTest::setUp()` called `service('superglobals')->setServerArray([])` which sets `$_SERVER = []` for the entire process. Immediately after, `Services::injectMock('superglobals', new Superglobals())` creates a new `Superglobals` instance from the now-empty `$_SERVER`, resulting in a mock with no `argv` key.

When tests run in random order, this mock persists from `FiltersTest` to other test classes that lack their own `setUp()` service reset (e.g. `CorsTest`). When `CorsTest::testBeforeDoesNothingWhenCliRequest` creates `new CLIRequest()`, the constructor calls `parseCommand()` → `getServer('argv')` which returns `null` from the empty mock, causing `array_shift(null)` to throw a `TypeError`.

The `setServerArray([])` call is redundant — `new Superglobals()` without arguments already captures a clean snapshot of the current `$_SERVER`. Removing it restores the normal CLI `argv` values for all subsequent tests.

Verified with multiple random seeds, including the originally failing seed `1784667021`.
https://github.com/codeigniter4/CodeIgniter4/actions/runs/29867283088/job/88758550319?pr=10417