### PR TITLE
chore: update PHPStan baseline and Rector config

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -25,6 +25,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
+use Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
@@ -33,6 +34,7 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
 use Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTestsRector;
@@ -100,6 +102,16 @@ return RectorConfig::configure()
 
         RemoveUnusedConstructorParamRector::class => [
             __DIR__ . '/system/HTTP/Response.php',
+        ],
+
+        // Keep property defaults for backward compatibility.
+        RemoveDefaultValueFromAssignedPropertyRector::class,
+
+        ReadOnlyPropertyRector::class => [
+            __DIR__ . '/system/Cache/ResponseCache.php',
+            __DIR__ . '/system/HotReloader/IteratorFilter.php',
+            __DIR__ . '/system/Router/RouteCollection.php',
+            __DIR__ . '/system/Security/Security.php',
         ],
 
         // Exclude test file because `is_cli()` is mocked and Rector might remove needed parameters.

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -343,7 +343,6 @@ class Services extends BaseService
         }
 
         $config ??= config(Images::class);
-        assert($config instanceof Images);
 
         $handler = in_array($handler, [null, '', '0'], true) ? $config->defaultHandler : $handler;
         $class   = $config->handlers[$handler];

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1335,7 +1335,7 @@ class RouteCollection implements RouteCollectionInterface
 
             // Ensure that the param we're inserting matches
             // the expected param type.
-            $pos  = strpos($from, $pattern);
+            $pos  = strpos($from, (string) $pattern);
             $from = substr_replace($from, $params[$index], $pos, strlen($pattern));
         }
 
@@ -1397,7 +1397,7 @@ class RouteCollection implements RouteCollectionInterface
 
             // Ensure that the param we're inserting matches
             // the expected param type.
-            $pos  = strpos($from, $placeholder);
+            $pos  = strpos($from, (string) $placeholder);
             $from = substr_replace($from, (string) $params[$index], $pos, strlen($placeholder));
         }
 

--- a/tests/system/AutoReview/FrameworkCodeTest.php
+++ b/tests/system/AutoReview/FrameworkCodeTest.php
@@ -62,7 +62,6 @@ final class FrameworkCodeTest extends TestCase
         $unrecognizedGroups = array_diff(
             array_map(static function (ReflectionAttribute $attribute): string {
                 $groupAttribute = $attribute->newInstance();
-                assert($groupAttribute instanceof Group);
 
                 return $groupAttribute->name();
             }, $attributes),

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -30,28 +30,6 @@ final class GetNumRowsTest extends CIUnitTestCase
     protected $seed    = CITestSeeder::class;
 
     /**
-     * Added as instructed at https://codeigniter4.github.io/userguide/testing/database.html#the-test-class
-     * {@inheritDoc}
-     *
-     * @see \CodeIgniter\Test\CIDatabaseTestCase::setUp()
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    /**
-     * Added as instructed at https://codeigniter4.github.io/userguide/testing/database.html#the-test-class
-     * {@inheritDoc}
-     *
-     * @see \CodeIgniter\Test\CIDatabaseTestCase::tearDown()
-     */
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
-    /**
      * tests newly added ResultInterface::getNumRows with a live db
      */
     public function testGetRowNum(): void

--- a/tests/system/Database/Migrations/MigrationTest.php
+++ b/tests/system/Database/Migrations/MigrationTest.php
@@ -26,11 +26,6 @@ final class MigrationTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testDBGroup(): void
     {
         $migration = new class () extends Migration {

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -35,11 +35,6 @@ final class GeneralModelTest extends CIUnitTestCase
      */
     private ?object $model = null;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/system/Models/LiveModelTestCase.php
+++ b/tests/system/Models/LiveModelTestCase.php
@@ -38,11 +38,6 @@ abstract class LiveModelTestCase extends CIUnitTestCase
 
     protected $seed = CITestSeeder::class;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -29,11 +29,6 @@ final class TestResponseTest extends CIUnitTestCase
     private ?TestResponse $testResponse = null;
     private Response $response;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     #[DataProvider('provideHttpStatusCodes')]
     public function testIsOK(int $code, bool $isOk): void
     {

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 212 errors
+# total 205 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1819 errors
+# total 1810 errors
 
 includes:
     - argument.type.neon
@@ -16,7 +16,6 @@ includes:
     - missingType.parameter.neon
     - missingType.property.neon
     - nullCoalesce.property.neon
-    - offsetAccess.notFound.neon
     - property.defaultValue.neon
     - property.nonObject.neon
     - property.notFound.neon

--- a/utils/phpstan-baseline/offsetAccess.notFound.neon
+++ b/utils/phpstan-baseline/offsetAccess.notFound.neon
@@ -1,8 +1,0 @@
-# total 2 errors
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Offset ''_ci_old_input'' does not exist on array\{\}\.$#'
-            count: 2
-            path: ../../tests/system/HTTP/RedirectResponseTest.php


### PR DESCRIPTION
**Description**
This PR removes obsolete PHPStan baseline entries and applies Rector cleanups while preserving property defaults for backward compatibility.

Ref:
- https://github.com/codeigniter4/CodeIgniter4/actions/runs/30374123004/job/90325269976
- https://github.com/codeigniter4/CodeIgniter4/actions/runs/30374123235/job/90325270885

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
