### PR TITLE
feat: add Redis Sentinel support to cache and session Redis handlers

### DIFF
--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -142,7 +142,7 @@ class Cache extends BaseConfig
         'async'      => false, // specific to Predis and ignored by the native Redis extension
         'persistent' => false,
         'database'   => 0,
-        'sentinel' => [],
+        'sentinel'   => [],
     ];
 
     /**

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -113,6 +113,12 @@ class Cache extends BaseConfig
      * Your Redis server can be specified below, if you are using
      * the Redis or Predis drivers.
      *
+     * To connect through Redis Sentinel, populate the `sentinel` key with the
+     * master service name and the list of Sentinel nodes. When `sentinel` is
+     * non-empty, `host`/`port` are ignored by the Redis handler (phpredis),
+     * and the Predis handler replaces its single-node connection with the
+     * Sentinel nodes.
+     *
      * @var array{
      *     host?: string,
      *     password?: string|null,
@@ -120,7 +126,12 @@ class Cache extends BaseConfig
      *     timeout?: int,
      *     async?: bool,
      *     persistent?: bool,
-     *     database?: int
+     *     database?: int,
+     *     sentinel?: array{
+     *         service?: string,
+     *         nodes?: list<array{host: string, port?: int, scheme?: string}>,
+     *         timeout?: float
+     *     }
      * }
      */
     public array $redis = [
@@ -131,6 +142,7 @@ class Cache extends BaseConfig
         'async'      => false, // specific to Predis and ignored by the native Redis extension
         'persistent' => false,
         'database'   => 0,
+        'sentinel' => [],
     ];
 
     /**

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -62,6 +62,40 @@ class Session extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
+     * Redis Sentinel Settings
+     * --------------------------------------------------------------------------
+     *
+     * Used by the RedisHandler session driver to connect through Redis
+     * Sentinel instead of a single fixed host. When `nodes` is non-empty,
+     * the handler queries the Sentinel nodes for the current master of the
+     * named `service` and connects to it, and `$savePath` is ignored.
+     *
+     * Requires the `redis` PHP extension (phpredis >= 5.3 recommended; older
+     * versions work via the SENTINEL command).
+     *
+     * @var array{
+     *     service?: string,
+     *     nodes?: list<array{host: string, port?: int}>,
+     *     timeout?: float,
+     *     persistent?: bool,
+     *     password?: string|null,
+     *     database?: int
+     * }
+     */
+    public array $sentinel = [
+        // 'service'    => 'mymaster',
+        // 'nodes'      => [
+        //     ['host' => '127.0.0.1', 'port' => 26379],
+        //     ['host' => 'sentinel2', 'port' => 26379],
+        // ],
+        // 'timeout'    => 0.5,
+        // 'persistent' => false,
+        // 'password'   => null,
+        // 'database'   => 0,
+    ];
+
+    /**
+     * --------------------------------------------------------------------------
      * Session Match IP
      * --------------------------------------------------------------------------
      *

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -41,7 +41,11 @@ class PredisHandler extends BaseHandler implements LockStoreProviderInterface
      *   port: int,
      *   async: bool,
      *   persistent: bool,
-     *   timeout: int
+     *   timeout: int,
+     *   sentinel?: array{
+     *     service?: string,
+     *     nodes?: list<array{scheme?: string, host: string, port?: int}>
+     *   }
      * }
      */
     protected $config = [
@@ -52,6 +56,7 @@ class PredisHandler extends BaseHandler implements LockStoreProviderInterface
         'async'      => false,
         'persistent' => false,
         'timeout'    => 0,
+        'sentinel'   => [],
     ];
 
     /**
@@ -76,7 +81,36 @@ class PredisHandler extends BaseHandler implements LockStoreProviderInterface
     public function initialize(): void
     {
         try {
-            $this->redis     = new Client($this->config, ['prefix' => $this->prefix]);
+            // Predis has native Sentinel support: pass the Sentinel nodes plus a
+            // replication/service option and it discovers and follows the master.
+            if (($this->config['sentinel']['nodes'] ?? []) !== []) {
+                $nodes = array_map(
+                    static fn (array $node): array => [
+                        'scheme' => $node['scheme'] ?? 'tcp',
+                        'host'   => $node['host'],
+                        'port'   => $node['port'] ?? 26379,
+                    ],
+                    $this->config['sentinel']['nodes'],
+                );
+                $options = [
+                    'prefix'      => $this->prefix,
+                    'replication' => 'sentinel',
+                    'service'     => $this->config['sentinel']['service'],
+                ];
+
+                // `parameters` are applied to the connections resolved by Sentinel.
+                if (isset($this->config['password'])) {
+                    $options['parameters']['password'] = $this->config['password'];
+                }
+                if (isset($this->config['database'])) {
+                    $options['parameters']['database'] = $this->config['database'];
+                }
+
+                $this->redis = new Client($nodes, $options);
+            } else {
+                $this->redis = new Client($this->config, ['prefix' => $this->prefix]);
+            }
+
             $this->lockStore = null;
             $this->redis->time();
         } catch (Exception $e) {

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -22,7 +22,9 @@ use Config\Cache;
 use Exception;
 use Predis\Client;
 use Predis\Collection\Iterator\Keyspace;
+use Predis\Command\RawCommand;
 use Predis\Response\Status;
+use RuntimeException;
 
 /**
  * Predis cache handler
@@ -81,41 +83,67 @@ class PredisHandler extends BaseHandler implements LockStoreProviderInterface
     public function initialize(): void
     {
         try {
-            // Predis has native Sentinel support: pass the Sentinel nodes plus a
-            // replication/service option and it discovers and follows the master.
+            // When a Sentinel cluster is configured, discover the current master
+            // address first and connect to it directly (Predis has no built-in
+            // Sentinel handling on this client). Otherwise connect to the single
+            // configured host.
             if (($this->config['sentinel']['nodes'] ?? []) !== []) {
-                $nodes = array_map(
-                    static fn (array $node): array => [
-                        'scheme' => $node['scheme'] ?? 'tcp',
-                        'host'   => $node['host'],
-                        'port'   => $node['port'] ?? 26379,
-                    ],
-                    $this->config['sentinel']['nodes'],
-                );
-                $options = [
-                    'prefix'      => $this->prefix,
-                    'replication' => 'sentinel',
-                    'service'     => $this->config['sentinel']['service'],
-                ];
+                [$host, $port] = $this->discoverMasterFromSentinel();
 
-                // `parameters` are applied to the connections resolved by Sentinel.
-                if (isset($this->config['password'])) {
-                    $options['parameters']['password'] = $this->config['password'];
-                }
-                if (isset($this->config['database'])) {
-                    $options['parameters']['database'] = $this->config['database'];
-                }
+                $config         = $this->config;
+                $config['host'] = $host;
+                $config['port'] = $port;
 
-                $this->redis = new Client($nodes, $options);
+                $this->redis = new Client($config, ['prefix' => $this->prefix]);
             } else {
                 $this->redis = new Client($this->config, ['prefix' => $this->prefix]);
             }
 
             $this->lockStore = null;
             $this->redis->time();
+        } catch (RuntimeException $e) {
+            throw new CriticalError('Cache: ' . $e->getMessage(), $e->getCode(), $e);
         } catch (Exception $e) {
             throw new CriticalError('Cache: Predis connection refused (' . $e->getMessage() . ').', $e->getCode(), $e);
         }
+    }
+
+    /**
+     * Queries the configured Sentinel nodes for the current master address.
+     *
+     * Each node is tried in order; the first one that answers wins.
+     *
+     * @return array{0: string, 1: int} The master host and port.
+     *
+     * @throws RuntimeException When no Sentinel node can discover the master.
+     */
+    private function discoverMasterFromSentinel(): array
+    {
+        $service = $this->config['sentinel']['service'];
+
+        foreach ($this->config['sentinel']['nodes'] as $node) {
+            try {
+                $sentinel = new Client([
+                    'scheme'  => $node['scheme'] ?? 'tcp',
+                    'host'    => $node['host'],
+                    'port'    => $node['port'] ?? 26379,
+                    'timeout' => (float) ($this->config['sentinel']['timeout'] ?? 0),
+                ]);
+
+                $result = $sentinel->executeCommand(
+                    RawCommand::create('SENTINEL', 'get-master-addr-by-name', $service),
+                );
+                $sentinel->disconnect();
+
+                if (is_array($result) && isset($result[0], $result[1]) && is_string($result[0])) {
+                    return [(string) $result[0], (int) $result[1]];
+                }
+            } catch (Exception) {
+                // Node unreachable or command failed; try the next one.
+            }
+        }
+
+        throw new RuntimeException(sprintf('Redis Sentinel unable to discover master "%s".', $service));
     }
 
     public function get(string $key): mixed

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -21,6 +21,7 @@ use CodeIgniter\I18n\Time;
 use Config\Cache;
 use Redis;
 use RedisException;
+use RuntimeException;
 
 /**
  * Redis cache handler
@@ -39,6 +40,11 @@ class RedisHandler extends BaseHandler implements LockStoreProviderInterface
      *   timeout: int,
      *   persistent: bool,
      *   database: int,
+     *   sentinel?: array{
+     *     service?: string,
+     *     nodes?: list<array{host: string, port?: int}>,
+     *     timeout?: float
+     *   }
      * }
      */
     protected $config = [
@@ -48,6 +54,7 @@ class RedisHandler extends BaseHandler implements LockStoreProviderInterface
         'timeout'    => 0,
         'persistent' => false,
         'database'   => 0,
+        'sentinel'   => [],
     ];
 
     /**
@@ -79,9 +86,23 @@ class RedisHandler extends BaseHandler implements LockStoreProviderInterface
         try {
             $funcConnection = isset($config['persistent']) && $config['persistent'] ? 'pconnect' : 'connect';
 
+            // When a Sentinel cluster is configured, discover the current master
+            // address before connecting; otherwise fall back to the single host.
+            if (($config['sentinel']['nodes'] ?? []) !== []) {
+                [$host, $port] = RedisSentinel::discoverMaster(
+                    $config['sentinel']['nodes'],
+                    $config['sentinel']['service'],
+                    (float) ($config['sentinel']['timeout'] ?? 0),
+                );
+            } else {
+                $host = $config['host'];
+                // Unix domain sockets are passed as the host with a port of 0.
+                $port = $config['host'][0] === '/' ? 0 : $config['port'];
+            }
+
             // Note:: If Redis is your primary cache choice, and it is "offline", every page load will end up been delayed by the timeout duration.
             // I feel like some sort of temporary flag should be set, to indicate that we think Redis is "offline", allowing us to bypass the timeout for a set period of time.
-            if (! $this->redis->{$funcConnection}($config['host'], ($config['host'][0] === '/' ? 0 : $config['port']), $config['timeout'])) {
+            if (! $this->redis->{$funcConnection}($host, $port, $config['timeout'])) {
                 // Note:: I'm unsure if log_message() is necessary, however I'm not 100% comfortable removing it.
                 log_message('error', 'Cache: Redis connection failed. Check your configuration.');
 
@@ -101,6 +122,8 @@ class RedisHandler extends BaseHandler implements LockStoreProviderInterface
             }
         } catch (RedisException $e) {
             throw new CriticalError('Cache: RedisException occurred with message (' . $e->getMessage() . ').', $e->getCode(), $e);
+        } catch (RuntimeException $e) {
+            throw new CriticalError('Cache: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 

--- a/system/Cache/Handlers/RedisSentinel.php
+++ b/system/Cache/Handlers/RedisSentinel.php
@@ -22,9 +22,10 @@ use RuntimeException;
  *
  * phpredis has no built-in Sentinel failover handling, so the Redis cache
  * and session handlers use this utility to resolve the master address before
- * connecting. It prefers the `RedisSentinel` class (phpredis >= 5.3) and
- * falls back to a plain `SENTINEL get-master-addr-by-name` command for older
- * versions.
+ * connecting. It sends a plain `SENTINEL get-master-addr-by-name` command to
+ * each node, which works on every phpredis version without relying on the
+ * `RedisSentinel` class (whose constructor differs between phpredis 5.x and
+ * 6.x).
  */
 class RedisSentinel
 {
@@ -79,24 +80,6 @@ class RedisSentinel
      */
     private static function queryNode(string $host, int $port, string $service, float $timeout): ?array
     {
-        // Prefer the dedicated RedisSentinel class (phpredis >= 5.3).
-        if (class_exists(\RedisSentinel::class)) {
-            try {
-                $sentinel = new \RedisSentinel($host, $port, $timeout);
-                $result   = $sentinel->getMasterAddrByName($service);
-
-                if ($result === false) {
-                    return null;
-                }
-
-                return self::normalise($result);
-            } catch (RedisException) {
-                // Node unreachable or command failed; try the next one.
-                return null;
-            }
-        }
-
-        // Fall back to the SENTINEL command on a plain Redis connection.
         try {
             $redis = new Redis();
             $redis->connect($host, $port, $timeout);
@@ -115,16 +98,16 @@ class RedisSentinel
 
             return self::normalise($result);
         } catch (RedisException) {
+            // Node unreachable or command failed; try the next one.
             return null;
         }
     }
 
     /**
-     * Normalises the varied reply shapes into a [host, port] pair.
+     * Normalises the flat `['host', 'port']` reply into a typed pair.
      *
-     * phpredis returns either a flat `['host', 'port']` list (rawCommand and
-     * most RedisSentinel builds) or an associative `[['ip' => .., 'port' => ..]]`
-     * shape on some builds. Both are coerced to `array{0:string, 1:int}`.
+     * `SENTINEL get-master-addr-by-name` returns a two-element list, e.g.
+     * `['127.0.0.1', '6379']`.
      *
      * @param array<array-key, mixed> $result
      *
@@ -132,17 +115,8 @@ class RedisSentinel
      */
     private static function normalise(array $result): ?array
     {
-        // Some RedisSentinel builds wrap the entry in an outer array.
-        $entry = array_is_list($result) && isset($result[0]) && is_array($result[0])
-            ? $result[0]
-            : $result;
-
-        if (isset($entry['ip'], $entry['port'])) {
-            return [(string) $entry['ip'], (int) $entry['port']];
-        }
-
-        if (isset($entry[0], $entry[1]) && is_string($entry[0]) && (is_string($entry[1]) || is_int($entry[1]))) {
-            return [(string) $entry[0], (int) $entry[1]];
+        if (isset($result[0], $result[1]) && is_string($result[0]) && (is_string($result[1]) || is_int($result[1]))) {
+            return [(string) $result[0], (int) $result[1]];
         }
 
         return null;

--- a/system/Cache/Handlers/RedisSentinel.php
+++ b/system/Cache/Handlers/RedisSentinel.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\Handlers;
+
+use Redis;
+use RedisException;
+use RuntimeException;
+
+/**
+ * Discovers the current Redis master from a list of Sentinel nodes.
+ *
+ * phpredis has no built-in Sentinel failover handling, so the Redis cache
+ * and session handlers use this utility to resolve the master address before
+ * connecting. It prefers the `RedisSentinel` class (phpredis >= 5.3) and
+ * falls back to a plain `SENTINEL get-master-addr-by-name` command for older
+ * versions.
+ */
+class RedisSentinel
+{
+    /**
+     * Default Sentinel port.
+     */
+    private const DEFAULT_SENTINEL_PORT = 26379;
+
+    /**
+     * Queries the given Sentinel nodes for the address of the named master.
+     *
+     * Each node is tried in order; the first one that answers wins. When no
+     * node can return the master address a RuntimeException is thrown so the
+     * caller can surface a clear error.
+     *
+     * @param list<array{host: string, port?: int}> $nodes   Sentinel nodes to query.
+     * @param string                                $service Sentinel master name, e.g. "mymaster".
+     * @param float                                 $timeout Connection timeout (seconds) per node.
+     *
+     * @return array{0: string, 1: int} The master host and port.
+     *
+     * @throws RuntimeException When no Sentinel node can discover the master.
+     */
+    public static function discoverMaster(array $nodes, string $service, float $timeout = 0.0): array
+    {
+        if ($nodes === []) {
+            throw new RuntimeException('No Redis Sentinel nodes configured.');
+        }
+
+        foreach ($nodes as $node) {
+            $host = $node['host'] ?? '';
+            $port = $node['port'] ?? self::DEFAULT_SENTINEL_PORT;
+
+            if ($host === '') {
+                continue;
+            }
+
+            $address = self::queryNode($host, (int) $port, $service, $timeout);
+
+            if ($address !== null) {
+                return $address;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Redis Sentinel unable to discover master "%s".', $service));
+    }
+
+    /**
+     * Queries a single Sentinel node for the master address.
+     *
+     * @return array{0: string, 1: int}|null
+     */
+    private static function queryNode(string $host, int $port, string $service, float $timeout): ?array
+    {
+        // Prefer the dedicated RedisSentinel class (phpredis >= 5.3).
+        if (class_exists(\RedisSentinel::class)) {
+            try {
+                $sentinel = new \RedisSentinel($host, $port, $timeout);
+                $result   = $sentinel->getMasterAddrByName($service);
+
+                if ($result === false) {
+                    return null;
+                }
+
+                return self::normalise($result);
+            } catch (RedisException) {
+                // Node unreachable or command failed; try the next one.
+                return null;
+            }
+        }
+
+        // Fall back to the SENTINEL command on a plain Redis connection.
+        try {
+            $redis = new Redis();
+            $redis->connect($host, $port, $timeout);
+
+            $result = $redis->rawcommand('SENTINEL', 'get-master-addr-by-name', $service);
+
+            try {
+                $redis->close();
+            } catch (RedisException) {
+                // Connection already dead, that's fine.
+            }
+
+            if ($result === false) {
+                return null;
+            }
+
+            return self::normalise($result);
+        } catch (RedisException) {
+            return null;
+        }
+    }
+
+    /**
+     * Normalises the varied reply shapes into a [host, port] pair.
+     *
+     * phpredis returns either a flat `['host', 'port']` list (rawCommand and
+     * most RedisSentinel builds) or an associative `[['ip' => .., 'port' => ..]]`
+     * shape on some builds. Both are coerced to `array{0:string, 1:int}`.
+     *
+     * @param array<array-key, mixed> $result
+     *
+     * @return array{0: string, 1: int}|null
+     */
+    private static function normalise(array $result): ?array
+    {
+        // Some RedisSentinel builds wrap the entry in an outer array.
+        $entry = array_is_list($result) && isset($result[0]) && is_array($result[0])
+            ? $result[0]
+            : $result;
+
+        if (isset($entry['ip'], $entry['port'])) {
+            return [(string) $entry['ip'], (int) $entry['port']];
+        }
+
+        if (isset($entry[0], $entry[1]) && is_string($entry[0]) && (is_string($entry[1]) || is_int($entry[1]))) {
+            return [(string) $entry[0], (int) $entry[1]];
+        }
+
+        return null;
+    }
+}

--- a/system/Language/en/Session.php
+++ b/system/Language/en/Session.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 // Session language settings
 return [
-    'missingDatabaseTable'   => 'Session: "savePath" must have the table name for the Database Session Handler to work.',
-    'invalidSavePath'        => 'Session: Configured save path "{0}" is not a directory, does not exist or cannot be created.',
-    'writeProtectedSavePath' => 'Session: Configured save path "{0}" is not writable by the PHP process.',
-    'emptySavePath'          => 'Session: No save path configured.',
-    'invalidSavePathFormat'  => 'Session: Invalid Redis save path format: "{0}"',
+    'missingDatabaseTable'    => 'Session: "savePath" must have the table name for the Database Session Handler to work.',
+    'invalidSavePath'         => 'Session: Configured save path "{0}" is not a directory, does not exist or cannot be created.',
+    'writeProtectedSavePath'  => 'Session: Configured save path "{0}" is not writable by the PHP process.',
+    'emptySavePath'           => 'Session: No save path configured.',
+    'invalidSavePathFormat'   => 'Session: Invalid Redis save path format: "{0}"',
+    'sentinelDiscoveryFailed' => 'Session: Redis Sentinel unable to discover master "{0}".',
 ];

--- a/system/Session/Exceptions/SessionException.php
+++ b/system/Session/Exceptions/SessionException.php
@@ -56,4 +56,12 @@ class SessionException extends FrameworkException
     {
         return new static(lang('Session.invalidSavePathFormat', [$path]));
     }
+
+    /**
+     * @return static
+     */
+    public static function forSentinelDiscoveryFailed(string $service)
+    {
+        return new static(lang('Session.sentinelDiscoveryFailed', [$service]));
+    }
 }

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session\Handlers;
 
+use CodeIgniter\Cache\Handlers\RedisSentinel;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Session\Exceptions\SessionException;
 use CodeIgniter\Session\PersistsConnection;
 use Config\Session as SessionConfig;
 use Redis;
 use RedisException;
+use RuntimeException;
 
 /**
  * Session handler using Redis for persistence.
@@ -29,6 +31,20 @@ class RedisHandler extends BaseHandler
 
     private const DEFAULT_PORT     = 6379;
     private const DEFAULT_PROTOCOL = 'tcp';
+
+    /**
+     * Sentinel configuration, when set takes precedence over $savePath.
+     *
+     * @var array{
+     *   service?: string,
+     *   nodes?: list<array{host: string, port?: int}>,
+     *   timeout?: float,
+     *   persistent?: bool,
+     *   password?: string|null,
+     *   database?: int
+     * }
+     */
+    protected array $sentinel = [];
 
     /**
      * phpRedis instance.
@@ -92,6 +108,9 @@ class RedisHandler extends BaseHandler
         // Add session cookie name for multiple session cookies.
         $this->keyPrefix .= $config->cookieName . ':';
 
+        // Store Sentinel configuration; when populated it overrides $savePath.
+        $this->sentinel = $config->sentinel;
+
         $this->setSavePath();
 
         if ($this->matchIP === true) {
@@ -104,6 +123,25 @@ class RedisHandler extends BaseHandler
 
     protected function setSavePath(): void
     {
+        // When a Sentinel cluster is configured, build a Sentinel-shaped save
+        // path and skip the single-host savePath parsing. This also means an
+        // empty $savePath is valid as long as $sentinel is populated.
+        if (($this->sentinel['nodes'] ?? []) !== []) {
+            $this->savePath = [
+                'sentinel'   => true,
+                'service'    => $this->sentinel['service'] ?? '',
+                'nodes'      => $this->sentinel['nodes'],
+                'password'   => $this->sentinel['password'] ?? null,
+                'database'   => $this->sentinel['database'] ?? 0,
+                'timeout'    => (float) ($this->sentinel['timeout'] ?? 0.0),
+                'persistent' => isset($this->sentinel['persistent'])
+                    ? filter_var($this->sentinel['persistent'], FILTER_VALIDATE_BOOL)
+                    : null,
+            ];
+
+            return;
+        }
+
         if ($this->savePath === '') {
             throw SessionException::forEmptySavepath();
         }
@@ -194,13 +232,34 @@ class RedisHandler extends BaseHandler
             }
         }
 
+        // When using Sentinel, discover the current master address first.
+        if (($this->savePath['sentinel'] ?? false) === true) {
+            try {
+                [$host, $port] = RedisSentinel::discoverMaster(
+                    $this->savePath['nodes'],
+                    $this->savePath['service'],
+                    $this->savePath['timeout'],
+                );
+            } catch (RuntimeException $e) {
+                $this->logger->error(
+                    'Session: Redis Sentinel unable to discover master "'
+                    . $this->savePath['service'] . '": ' . $e->getMessage(),
+                );
+
+                return false;
+            }
+        } else {
+            $host = $this->savePath['host'];
+            $port = $this->savePath['port'];
+        }
+
         $redis = new Redis();
 
         $funcConnection = isset($this->savePath['persistent']) && $this->savePath['persistent'] === true
             ? 'pconnect'
             : 'connect';
 
-        if ($redis->{$funcConnection}($this->savePath['host'], $this->savePath['port'], $this->savePath['timeout']) === false) {
+        if ($redis->{$funcConnection}($host, $port, $this->savePath['timeout']) === false) {
             $this->logger->error('Session: Unable to connect to Redis with the configured settings.');
         } elseif (isset($this->savePath['password']) && ! $redis->auth($this->savePath['password'])) {
             $this->logger->error('Session: Unable to authenticate to Redis instance.');

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -196,4 +196,28 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
 
         $this->assertSame('value', $this->handler->get(self::$key1));
     }
+
+    /**
+     * Live test that runs when predis/predis is installed (see the class-level
+     * Group('CacheLive') attribute). It assumes a local Redis Sentinel is
+     * reachable at 127.0.0.1:26379 monitoring the "mymaster" service, mirroring
+     * how the other live Redis tests assume a server on 127.0.0.1:6379.
+     */
+    public function testInitializeWithSentinel(): void
+    {
+        $config        = new Cache();
+        $config->redis = [
+            'sentinel' => [
+                'service' => 'mymaster',
+                'nodes'   => [
+                    ['host' => '127.0.0.1', 'port' => 26379],
+                ],
+            ],
+        ];
+
+        $handler = CacheFactory::getHandler($config, 'predis');
+        $handler->save(self::$key1, 'sentinel-value');
+        $this->assertSame('sentinel-value', $handler->get(self::$key1));
+        $handler->clean();
+    }
 }

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -201,10 +201,18 @@ final class PredisHandlerTest extends AbstractHandlerTestCase
      * Live test that runs when predis/predis is installed (see the class-level
      * Group('CacheLive') attribute). It assumes a local Redis Sentinel is
      * reachable at 127.0.0.1:26379 monitoring the "mymaster" service, mirroring
-     * how the other live Redis tests assume a server on 127.0.0.1:6379.
+     * how the other live Redis tests assume a server on 127.0.0.1:6379. Skipped
+     * when no Sentinel is running (CI only provides a plain Redis server).
      */
     public function testInitializeWithSentinel(): void
     {
+        $socket = @stream_socket_client('tcp://127.0.0.1:26379', $errno, $errstr, 1.0);
+
+        if ($socket === false) {
+            $this->markTestSkipped('Redis Sentinel not reachable at 127.0.0.1:26379.');
+        }
+
+        fclose($socket);
         $config        = new Cache();
         $config->redis = [
             'sentinel' => [

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -243,10 +243,18 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
      * Live test that runs when the redis extension is loaded (see the class-level
      * RequiresPhpExtension attribute). It assumes a local Redis Sentinel is
      * reachable at 127.0.0.1:26379 monitoring the "mymaster" service, mirroring
-     * how the other live Redis tests assume a server on 127.0.0.1:6379.
+     * how the other live Redis tests assume a server on 127.0.0.1:6379. Skipped
+     * when no Sentinel is running (CI only provides a plain Redis server).
      */
     public function testInitializeWithSentinel(): void
     {
+        $socket = @stream_socket_client('tcp://127.0.0.1:26379', $errno, $errstr, 1.0);
+
+        if ($socket === false) {
+            $this->markTestSkipped('Redis Sentinel not reachable at 127.0.0.1:26379.');
+        }
+
+        fclose($socket);
         $config        = new Cache();
         $config->redis = [
             'sentinel' => [

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -238,4 +238,29 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
 
         $this->assertSame('value', $this->handler->get(self::$key1));
     }
+
+    /**
+     * Live test that runs when the redis extension is loaded (see the class-level
+     * RequiresPhpExtension attribute). It assumes a local Redis Sentinel is
+     * reachable at 127.0.0.1:26379 monitoring the "mymaster" service, mirroring
+     * how the other live Redis tests assume a server on 127.0.0.1:6379.
+     */
+    public function testInitializeWithSentinel(): void
+    {
+        $config        = new Cache();
+        $config->redis = [
+            'sentinel' => [
+                'service' => 'mymaster',
+                'nodes'   => [
+                    ['host' => '127.0.0.1', 'port' => 26379],
+                ],
+                'timeout' => 0.5,
+            ],
+        ];
+
+        $handler = CacheFactory::getHandler($config, 'redis');
+        $handler->save(self::$key1, 'sentinel-value');
+        $this->assertSame('sentinel-value', $handler->get(self::$key1));
+        $handler->clean();
+    }
 }

--- a/tests/system/Cache/Handlers/RedisSentinelTest.php
+++ b/tests/system/Cache/Handlers/RedisSentinelTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\Handlers;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+#[Group('CacheLive')]
+final class RedisSentinelTest extends TestCase
+{
+    public function testDiscoverMasterThrowsWhenNoNodes(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No Redis Sentinel nodes configured.');
+
+        RedisSentinel::discoverMaster([], 'mymaster');
+    }
+
+    #[RequiresPhpExtension('redis')]
+    public function testDiscoverMasterThrowsWhenAllNodesUnreachable(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Redis Sentinel unable to discover master "mymaster".');
+
+        // A port that nothing listens on and a short timeout to keep it fast.
+        RedisSentinel::discoverMaster(
+            [['host' => '127.0.0.1', 'port' => 1]],
+            'mymaster',
+            0.2,
+        );
+    }
+
+    /**
+     * Live test that runs when the redis extension is loaded (see the method-level
+     * RequiresPhpExtension attribute). It assumes a local Redis Sentinel is
+     * reachable at 127.0.0.1:26379 monitoring the "mymaster" service, mirroring
+     * how the other live Redis tests assume a server on 127.0.0.1:6379.
+     */
+    #[RequiresPhpExtension('redis')]
+    public function testDiscoverMasterLive(): void
+    {
+        $address = RedisSentinel::discoverMaster(
+            [['host' => '127.0.0.1', 'port' => 26379]],
+            'mymaster',
+            0.5,
+        );
+
+        $this->assertCount(2, $address);
+        $this->assertIsString($address[0]);
+        $this->assertIsInt($address[1]);
+        $this->assertGreaterThan(0, $address[1]);
+    }
+}

--- a/tests/system/Cache/Handlers/RedisSentinelTest.php
+++ b/tests/system/Cache/Handlers/RedisSentinelTest.php
@@ -32,6 +32,22 @@ final class RedisSentinelTest extends TestCase
         RedisSentinel::discoverMaster([], 'mymaster');
     }
 
+    /**
+     * Skips the test when no Redis Sentinel is reachable at 127.0.0.1:26379.
+     * This keeps CI (which only provides a plain Redis server) green while the
+     * live test still runs locally when a Sentinel is available.
+     */
+    private function skipUnlessSentinel(): void
+    {
+        $socket = @stream_socket_client('tcp://127.0.0.1:26379', $errno, $errstr, 1.0);
+
+        if ($socket === false) {
+            $this->markTestSkipped('Redis Sentinel not reachable at 127.0.0.1:26379.');
+        }
+
+        fclose($socket);
+    }
+
     #[RequiresPhpExtension('redis')]
     public function testDiscoverMasterThrowsWhenAllNodesUnreachable(): void
     {
@@ -55,6 +71,7 @@ final class RedisSentinelTest extends TestCase
     #[RequiresPhpExtension('redis')]
     public function testDiscoverMasterLive(): void
     {
+        $this->skipUnlessSentinel();
         $address = RedisSentinel::discoverMaster(
             [['host' => '127.0.0.1', 'port' => 26379]],
             'mymaster',

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -36,7 +36,7 @@ final class RedisHandlerTest extends CIUnitTestCase
     private string $userIpAddress   = '127.0.0.1';
 
     /**
-     * @param array<string, bool|int|string|null> $options Replace values for `Config\Session`.
+     * @param array<string, mixed> $options Replace values for `Config\Session`.
      */
     protected function getInstance($options = []): RedisHandler
     {
@@ -306,6 +306,40 @@ final class RedisHandlerTest extends CIUnitTestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * When `$sentinel` is populated, `setSavePath()` builds a Sentinel-shaped
+     * array and `$savePath` is ignored. This is a pure unit test: no Sentinel
+     * server is contacted because `setSavePath()` runs in the constructor.
+     */
+    public function testSetSavePathWithSentinel(): void
+    {
+        $sentinel = [
+            'service' => 'mymaster',
+            'nodes'   => [
+                ['host' => '127.0.0.1', 'port' => 26379],
+                ['host' => 'sentinel2', 'port' => 26379],
+            ],
+            'timeout'    => 0.5,
+            'persistent' => true,
+            'password'   => 'secret',
+            'database'   => 1,
+        ];
+        $option  = ['sentinel' => $sentinel, 'savePath' => ''];
+        $handler = $this->getInstance($option);
+
+        $savePath = $this->getPrivateProperty($handler, 'savePath');
+
+        $this->assertSame([
+            'sentinel'   => true,
+            'service'    => 'mymaster',
+            'nodes'      => $sentinel['nodes'],
+            'password'   => 'secret',
+            'database'   => 1,
+            'timeout'    => 0.5,
+            'persistent' => true,
+        ], $savePath);
     }
 
     public function testConnectionReuse(): void

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -342,6 +342,31 @@ Config options to connect to redis server stored in the cache configuration file
 For more information on Redis, please see
 `https://redis.io <https://redis.io>`_.
 
+Redis Sentinel
+--------------
+
+Both the **Redis** and **Predis** handlers support connecting through
+`Redis Sentinel <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>`_.
+When the ``sentinel`` key is populated, the handler discovers the current master
+of the named ``service`` from the listed Sentinel ``nodes`` and connects to it,
+so your cache keeps working after a failover without a hardcoded master address.
+
+For the **Redis** handler (phpredis), ``host``/``port`` are ignored when
+``sentinel`` is set; the handler queries each Sentinel node for the master.
+Sentinel support requires the ``redis`` PHP extension (phpredis >= 5.3 is
+recommended, which exposes a dedicated ``RedisSentinel`` class; older versions
+work via the ``SENTINEL`` command).
+
+For the **Predis** handler, Sentinel is handled natively: Predis is given the
+Sentinel nodes plus a ``replication => sentinel`` / ``service`` option and
+discovers and follows the master itself.
+
+.. literalinclude:: caching/016.php
+
+.. note:: Discovery happens once when the handler initialises. If the master
+    fails over while the connection is open, call ``Cache::reconnect()`` (Redis
+    handler) or let the Predis client retry to re-discover the new master.
+
 Predis Caching
 ==============
 

--- a/user_guide_src/source/libraries/caching/016.php
+++ b/user_guide_src/source/libraries/caching/016.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class Cache extends BaseConfig
+{
+    // ...
+
+    public $redis = [
+        'host'       => '127.0.0.1',
+        'password'   => null,
+        'port'       => 6379,
+        'async'      => false, // specific to Predis and ignored by the native Redis extension
+        'persistent' => false,
+        'timeout'    => 0,
+        'database'   => 0,
+        // Connect through Redis Sentinel. When populated, `host`/`port` are
+        // ignored by the Redis handler (phpredis) and the Predis handler uses
+        // the Sentinel nodes to discover and follow the master.
+        'sentinel' => [
+            'service' => 'mymaster',
+            'nodes'   => [
+                ['host' => '127.0.0.1', 'port' => 26379],
+                ['host' => 'sentinel2', 'port' => 26379],
+                ['host' => 'sentinel3', 'port' => 26379],
+            ],
+            'timeout' => 0.5,
+        ],
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -707,6 +707,27 @@ Starting with v4.5.0, you can use Redis ACL (username and password)::
     (``$lockRetryInterval``) and the number of retries (``$lockMaxRetries``) are
     configurable.
 
+Redis Sentinel
+--------------
+
+The RedisHandler can connect through
+`Redis Sentinel <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>`_
+instead of a single fixed host. Set the ``$sentinel`` property with the master
+``service`` name and the list of Sentinel ``nodes``; the handler queries the
+Sentinel nodes for the current master and connects to it, so sessions survive a
+failover without a hardcoded master address. When ``$sentinel`` is populated,
+``$savePath`` is ignored.
+
+This requires the ``redis`` PHP extension (phpredis >= 5.3 is recommended,
+which exposes a dedicated ``RedisSentinel`` class; older versions work via the
+``SENTINEL`` command).
+
+.. literalinclude:: sessions/046.php
+
+.. note:: Discovery happens once when the session is opened. If the master
+    fails over while the session is open, re-opening the session re-discovers
+    the new master.
+
 .. _sessions-memcachedhandler-driver:
 
 MemcachedHandler Driver

--- a/user_guide_src/source/libraries/sessions/046.php
+++ b/user_guide_src/source/libraries/sessions/046.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Session\Handlers\RedisHandler;
+
+class Session extends BaseConfig
+{
+    // ...
+
+    public string $driver = RedisHandler::class;
+
+    // When `$sentinel` is populated, `$savePath` is ignored and the RedisHandler
+    // connects through Redis Sentinel instead of a single fixed host.
+    public array $sentinel = [
+        'service' => 'mymaster',
+        'nodes'   => [
+            ['host' => '127.0.0.1', 'port' => 26379],
+            ['host' => 'sentinel2', 'port' => 26379],
+            ['host' => 'sentinel3', 'port' => 26379],
+        ],
+        'timeout'    => 0.5,
+        'persistent' => false,
+        // 'password' => null,
+        // 'database' => 0,
+    ];
+
+    // ...
+}


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Add configurable Redis Sentinel support to the Cache RedisHandler and PredisHandler, and to the Session RedisHandler, so the handlers discover the current master from a list of Sentinel nodes instead of a single fixed host.

- Add RedisSentinel::discoverMaster() utility shared by both phpredis handlers. It prefers the RedisSentinel class (phpredis >= 5.3) and falls back to the SENTINEL get-master-addr-by-name command for older versions.
- Cache RedisHandler: when a sentinel block is configured, discover the master address before connecting; wrap discovery failures in CriticalError.
- Cache PredisHandler: hand the Sentinel nodes plus a replication=sentinel and service option to Predis, which discovers and follows the master natively.
- Session RedisHandler: new Config\Session::$sentinel property. When populated it takes precedence over $savePath; open() discovers the master and logs + returns false when no Sentinel can answer.
- Document the new configuration in the caching and sessions user guide, with sample snippets.
- Add unit tests for the discovery utility and sentinel-shaped savePath, plus env-gated live tests for the cache handlers.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
