### PR TITLE
refactor: fix phpstan errors in `IncomingRequestTest`

### DIFF
--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -29,7 +29,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
-use TypeError;
 
 /**
  * @internal
@@ -38,7 +37,7 @@ use TypeError;
 #[Group('SeparateProcess')]
 final class IncomingRequestTest extends CIUnitTestCase
 {
-    private Request $request;
+    private IncomingRequest $request;
 
     #[WithoutErrorHandler]
     protected function setUp(): void
@@ -59,7 +58,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->request = $this->createRequest($config);
     }
 
-    private function createRequest(?App $config = null, $body = null, ?string $path = null): IncomingRequest
+    private function createRequest(?App $config = null, false|string|null $body = null, ?string $path = null): IncomingRequest
     {
         $config ??= new App();
         $path ??= '';
@@ -635,6 +634,9 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $request->getRawInputVar($var, $filter, $flag));
     }
 
+    /**
+     * @return iterable<array{string, mixed, mixed, mixed, mixed}>
+     */
     public static function provideCanGrabGetRawInputVar(): iterable
     {
         return [
@@ -729,6 +731,9 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertTrue($request->is(strtolower($value)));
     }
 
+    /**
+     * @return iterable<array{string}>
+     */
     public static function provideIsHTTPMethods(): iterable
     {
         yield from [
@@ -756,7 +761,6 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->expectExceptionMessage('Unknown type: invalid');
 
         $request = $this->request->withMethod('GET');
-
         $request->is('invalid');
     }
 
@@ -764,6 +768,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $request = $this->request->setHeader('Content-Type', 'application/json');
 
+        $this->assertInstanceOf(IncomingRequest::class, $request);
         $this->assertTrue($request->is('json'));
     }
 
@@ -771,6 +776,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $request = $this->request->setHeader('X-Requested-With', 'XMLHttpRequest');
 
+        $this->assertInstanceOf(IncomingRequest::class, $request);
         $this->assertTrue($request->is('ajax'));
     }
 
@@ -950,6 +956,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         ]);
 
         $gotit = $this->request->getFile('userfile');
+        $this->assertInstanceOf(UploadedFile::class, $gotit);
         $this->assertSame(124, $gotit->getSize());
     }
 
@@ -1047,12 +1054,12 @@ final class IncomingRequestTest extends CIUnitTestCase
         $expected = '123.123.123.123';
         service('superglobals')->setServer('REMOTE_ADDR', $expected);
 
-        $this->request = new Request(new App());
-        $this->request->populateHeaders();
+        $request = new Request(new App());
+        $request->populateHeaders();
 
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
         // call a second time to exercise the initial conditional block in getIPAddress()
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxy(): void
@@ -1068,11 +1075,11 @@ final class IncomingRequestTest extends CIUnitTestCase
             '192.168.5.0/24' => 'X-Forwarded-For',
         ];
         Factories::injectMock('config', App::class, $config);
-        $this->request = new Request();
-        $this->request->populateHeaders();
+        $request = new Request();
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyIPv6(): void
@@ -1087,11 +1094,11 @@ final class IncomingRequestTest extends CIUnitTestCase
             '2001:db8::2:1' => 'X-Forwarded-For',
         ];
         Factories::injectMock('config', App::class, $config);
-        $this->request = new Request();
-        $this->request->populateHeaders();
+        $request = new Request();
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyInvalidIPAddress(): void
@@ -1105,11 +1112,11 @@ final class IncomingRequestTest extends CIUnitTestCase
             '10.0.1.200'     => 'X-Forwarded-For',
             '192.168.5.0/24' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
-        $this->request->populateHeaders();
+        $request = new Request($config);
+        $request->populateHeaders();
 
         // spoofed address invalid
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyInvalidIPAddressIPv6(): void
@@ -1122,11 +1129,11 @@ final class IncomingRequestTest extends CIUnitTestCase
         $config->proxyIPs = [
             '2001:db8::2:1' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
-        $this->request->populateHeaders();
+        $request = new Request($config);
+        $request->populateHeaders();
 
         // spoofed address invalid
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyNotWhitelisted(): void
@@ -1140,11 +1147,11 @@ final class IncomingRequestTest extends CIUnitTestCase
             '10.0.1.200'     => 'X-Forwarded-For',
             '192.168.5.0/24' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
-        $this->request->populateHeaders();
+        $request = new Request($config);
+        $request->populateHeaders();
 
         // spoofed address invalid
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyNotWhitelistedIPv6(): void
@@ -1157,11 +1164,11 @@ final class IncomingRequestTest extends CIUnitTestCase
         $config->proxyIPs = [
             '2001:db8::2:1' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
-        $this->request->populateHeaders();
+        $request = new Request($config);
+        $request->populateHeaders();
 
         // spoofed address invalid
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxySubnet(): void
@@ -1173,11 +1180,11 @@ final class IncomingRequestTest extends CIUnitTestCase
         $config           = new App();
         $config->proxyIPs = ['192.168.5.0/24' => 'X-Forwarded-For'];
         Factories::injectMock('config', App::class, $config);
-        $this->request = new Request();
-        $this->request->populateHeaders();
+        $request = new Request();
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxySubnetIPv6(): void
@@ -1189,11 +1196,11 @@ final class IncomingRequestTest extends CIUnitTestCase
         $config           = new App();
         $config->proxyIPs = ['2001:db8:1234::/48' => 'X-Forwarded-For'];
         Factories::injectMock('config', App::class, $config);
-        $this->request = new Request();
-        $this->request->populateHeaders();
+        $request = new Request();
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyOutOfSubnet(): void
@@ -1204,11 +1211,11 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config           = new App();
         $config->proxyIPs = ['192.168.5.0/28' => 'X-Forwarded-For'];
-        $this->request    = new Request($config);
-        $this->request->populateHeaders();
+        $request          = new Request($config);
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyOutOfSubnetIPv6(): void
@@ -1219,11 +1226,11 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config           = new App();
         $config->proxyIPs = ['2001:db8:1234::/48' => 'X-Forwarded-For'];
-        $this->request    = new Request($config);
-        $this->request->populateHeaders();
+        $request          = new Request($config);
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyBothIPv4AndIPv6(): void
@@ -1237,23 +1244,11 @@ final class IncomingRequestTest extends CIUnitTestCase
             '192.168.5.0/28'     => 'X-Forwarded-For',
             '2001:db8:1234::/48' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
-        $this->request->populateHeaders();
+        $request = new Request($config);
+        $request->populateHeaders();
 
         // we should see the original forwarded address
-        $this->assertSame($expected, $this->request->getIPAddress());
-    }
-
-    public function testGetIPAddressThruProxyInvalidConfigString(): void
-    {
-        $this->expectException(TypeError::class);
-
-        $config           = new App();
-        $config->proxyIPs = '192.168.5.0/28';
-        $this->request    = new Request($config);
-        $this->request->populateHeaders();
-
-        $this->request->getIPAddress();
+        $this->assertSame($expected, $request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyInvalidConfigArray(): void
@@ -1264,12 +1259,12 @@ final class IncomingRequestTest extends CIUnitTestCase
         );
 
         $config           = new App();
-        $config->proxyIPs = ['192.168.5.0/28'];
+        $config->proxyIPs = ['192.168.5.0/28']; // @phpstan-ignore assign.propertyType (deliberately keyless, to assert the ConfigException)
         Factories::injectMock('config', App::class, $config);
-        $this->request = new Request();
-        $this->request->populateHeaders();
+        $request = new Request();
+        $request->populateHeaders();
 
-        $this->request->getIPAddress();
+        $request->getIPAddress();
     }
 
     // @TODO getIPAddress should have more testing, to 100% code coverage

--- a/utils/phpstan-baseline/assign.propertyType.neon
+++ b/utils/phpstan-baseline/assign.propertyType.neon
@@ -1,4 +1,4 @@
-# total 28 errors
+# total 26 errors
 
 parameters:
     ignoreErrors:
@@ -56,16 +56,6 @@ parameters:
             message: '#^Property CodeIgniter\\Filters\\HoneypotTest\:\:\$response \(CodeIgniter\\HTTP\\Response\|null\) does not accept CodeIgniter\\HTTP\\ResponseInterface\.$#'
             count: 4
             path: ../../tests/system/Filters/HoneypotTest.php
-
-        -
-            message: '#^Property Config\\App\:\:\$proxyIPs \(array\<string, string\>\) does not accept array\<int, string\>\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Property Config\\App\:\:\$proxyIPs \(array\<string, string\>\) does not accept string\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
 
         -
             message: '#^Property CodeIgniter\\Helpers\\CookieHelperTest\:\:\$response \(CodeIgniter\\HTTP\\Response\) does not accept CodeIgniter\\HTTP\\ResponseInterface\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 1434 errors
+# total 1381 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/method.notFound.neon
+++ b/utils/phpstan-baseline/method.notFound.neon
@@ -1,4 +1,4 @@
-# total 80 errors
+# total 33 errors
 
 parameters:
     ignoreErrors:
@@ -41,91 +41,6 @@ parameters:
             message: '#^Call to an undefined method CodeIgniter\\HTTP\\ResponseInterface\:\:pretend\(\)\.$#'
             count: 3
             path: ../../tests/system/Debug/ExceptionHandlerTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getCookie\(\)\.$#'
-            count: 2
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getDefaultLocale\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getFileMultiple\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getFile\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getFiles\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getGetPost\(\)\.$#'
-            count: 6
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getGet\(\)\.$#'
-            count: 2
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getLocale\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getOldInput\(\)\.$#'
-            count: 9
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getPostGet\(\)\.$#'
-            count: 6
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getPost\(\)\.$#'
-            count: 2
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getVar\(\)\.$#'
-            count: 2
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:isAJAX\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:isCLI\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:isSecure\(\)\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:is\(\)\.$#'
-            count: 5
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:negotiate\(\)\.$#'
-            count: 5
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
 
         -
             message: '#^Call to an undefined method CodeIgniter\\HTTP\\URI\:\:getRoutePath\(\)\.$#'

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1131 errors
+# total 1129 errors
 
 parameters:
     ignoreErrors:
@@ -4466,16 +4466,6 @@ parameters:
             message: '#^Method CodeIgniter\\Filters\\InvalidCharsTest\:\:provideCheckControlStringWithLineBreakAndTabReturnsTheString\(\) return type has no value type specified in iterable type iterable\.$#'
             count: 1
             path: ../../tests/system/Filters/InvalidCharsTest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequestTest\:\:provideCanGrabGetRawInputVar\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequestTest\:\:provideIsHTTPMethods\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
 
         -
             message: '#^Method CodeIgniter\\HTTP\\MessageTest\:\:provideArrayHeaderValue\(\) return type has no value type specified in iterable type iterable\.$#'

--- a/utils/phpstan-baseline/missingType.parameter.neon
+++ b/utils/phpstan-baseline/missingType.parameter.neon
@@ -1,4 +1,4 @@
-# total 31 errors
+# total 30 errors
 
 parameters:
     ignoreErrors:
@@ -71,11 +71,6 @@ parameters:
             message: '#^Function CodeIgniter\\HTTP\\Files\\rrmdir\(\) has parameter \$src with no type specified\.$#'
             count: 1
             path: ../../tests/system/HTTP/Files/FileMovingTest.php
-
-        -
-            message: '#^Method CodeIgniter\\HTTP\\IncomingRequestTest\:\:createRequest\(\) has parameter \$body with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/HTTP/IncomingRequestTest.php
 
         -
             message: '#^Method CodeIgniter\\Helpers\\URLHelper\\CurrentUrlTest\:\:createRequest\(\) has parameter \$body with no type specified\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Fixing the cluster of phpstan errors on `IncomingRequestTest`:
- Type the property as `IncomingRequest`, treat one-off uses of `Request` via local `$request`
- Add missing docblocks
- I deleted a test that asserts PHP's behavior (throwing a `TypeError` on passing string to array). That is simply ridiculous as a test

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
