### PR TITLE
refactor: add precise return type to `CodeIgniter::getPerformanceStats()`

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -775,6 +775,8 @@ class CodeIgniter
 
     /**
      * Returns an array with our basic performance stats collected.
+     *
+     * @return array{startTime: float|null, totalTime: float}
      */
     public function getPerformanceStats(): array
     {

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,12 +1,7 @@
-# total 1132 errors
+# total 1131 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^Method CodeIgniter\\CodeIgniter\:\:getPerformanceStats\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/CodeIgniter.php
-
         -
             message: '#^Method CodeIgniter\\Commands\\ListCommands\:\:listFull\(\) has parameter \$commands with no value type specified in iterable type array\.$#'
             count: 1


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->

**Description**

Adds a specific return-type annotation to CodeIgniter::getPerformanceStats() so static analysis knows exactly what's in the returned array (startTime: float|null and totalTime: float), instead of just "array". Removes the now-unneeded PHPStan baseline suppression for this method.

Contributes to #8732 (PHPStan "no value type specified in iterable type array" cleanup).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
