### PR TITLE
refactor: add precise parameter types to Router test fixtures

### DIFF
--- a/tests/system/Router/Controllers/BlogController.php
+++ b/tests/system/Router/Controllers/BlogController.php
@@ -21,7 +21,7 @@ class BlogController extends Controller
     {
     }
 
-    public function getSomeMethod($first = ''): void
+    public function getSomeMethod(string $first = ''): void
     {
     }
 }

--- a/tests/system/Router/Controllers/Index.php
+++ b/tests/system/Router/Controllers/Index.php
@@ -17,7 +17,7 @@ use CodeIgniter\Controller;
 
 class Index extends Controller
 {
-    public function getIndex($p1 = ''): void
+    public function getIndex(string $p1 = ''): void
     {
     }
 

--- a/tests/system/Router/Controllers/Mycontroller.php
+++ b/tests/system/Router/Controllers/Mycontroller.php
@@ -21,7 +21,7 @@ class Mycontroller extends Controller
     {
     }
 
-    public function getSomemethod($first = ''): void
+    public function getSomemethod(string $first = ''): void
     {
     }
 }

--- a/tests/system/Router/Controllers/Remap.php
+++ b/tests/system/Router/Controllers/Remap.php
@@ -18,7 +18,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 
 class Remap extends Controller
 {
-    public function _remap(string $method, ...$params): string
+    public function _remap(string $method, mixed ...$params): string
     {
         $method = 'process_' . $method;
 

--- a/tests/system/Router/Controllers/SubDir/BlogController.php
+++ b/tests/system/Router/Controllers/SubDir/BlogController.php
@@ -21,7 +21,7 @@ class BlogController extends Controller
     {
     }
 
-    public function getSomeMethod($first = ''): void
+    public function getSomeMethod(string $first = ''): void
     {
     }
 }

--- a/tests/system/Router/Controllers/Subfolder/Home.php
+++ b/tests/system/Router/Controllers/Subfolder/Home.php
@@ -17,7 +17,7 @@ use CodeIgniter\Controller;
 
 class Home extends Controller
 {
-    public function getIndex($p1 = null, $p2 = null): void
+    public function getIndex(?string $p1 = null, ?string $p2 = null): void
     {
     }
 }

--- a/tests/system/Router/Controllers/Subfolder/Sub/BlogController.php
+++ b/tests/system/Router/Controllers/Subfolder/Sub/BlogController.php
@@ -21,7 +21,7 @@ class BlogController extends Controller
     {
     }
 
-    public function getSomeMethod($first = ''): void
+    public function getSomeMethod(string $first = ''): void
     {
     }
 }

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -37,7 +37,7 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
 
         $loader = service('locator');
 
-        if ($moduleConfig === null) {
+        if (! $moduleConfig instanceof Modules) {
             $moduleConfig          = new Modules();
             $moduleConfig->enabled = false;
         }

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class DefinedRouteCollectorTest extends CIUnitTestCase
 {
-    private function createRouteCollection(array $config = [], $moduleConfig = null): RouteCollection
+    private function createRouteCollection(array $config = [], ?Modules $moduleConfig = null): RouteCollection
     {
         $defaults = [
             'Config' => APPPATH . 'Config',

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -35,7 +35,7 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         $this->resetFactories();
     }
 
-    protected function getCollector(array $config = [], array $files = [], $moduleConfig = null): RouteCollection
+    protected function getCollector(array $config = [], array $files = [], ?Modules $moduleConfig = null): RouteCollection
     {
         $defaults = [
             'Config' => APPPATH . 'Config',

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -47,7 +47,7 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
 
         $loader = service('locator');
 
-        if ($moduleConfig === null) {
+        if (! $moduleConfig instanceof Modules) {
             $moduleConfig          = new Modules();
             $moduleConfig->enabled = false;
         }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -56,7 +56,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $loader = service('locator');
 
-        if ($moduleConfig === null) {
+        if (! $moduleConfig instanceof Modules) {
             $moduleConfig          = new Modules();
             $moduleConfig->enabled = false;
         }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -44,7 +44,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         Services::injectMock('superglobals', new Superglobals());
     }
 
-    protected function getCollector(array $config = [], array $files = [], $moduleConfig = null): RouteCollection
+    protected function getCollector(array $config = [], array $files = [], ?Modules $moduleConfig = null): RouteCollection
     {
         $defaults = [
             'Config' => APPPATH . 'Config',

--- a/utils/phpstan-baseline/missingType.parameter.neon
+++ b/utils/phpstan-baseline/missingType.parameter.neon
@@ -1,4 +1,4 @@
-# total 26 errors
+# total 15 errors
 
 parameters:
     ignoreErrors:
@@ -66,61 +66,6 @@ parameters:
             message: '#^Method CodeIgniter\\Helpers\\URLHelper\\SiteUrlTest\:\:createRequest\(\) has parameter \$body with no type specified\.$#'
             count: 1
             path: ../../tests/system/Helpers/URLHelper/SiteUrlTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\BlogController\:\:getSomeMethod\(\) has parameter \$first with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/BlogController.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\Index\:\:getIndex\(\) has parameter \$p1 with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/Index.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\Mycontroller\:\:getSomemethod\(\) has parameter \$first with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/Mycontroller.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\Remap\:\:_remap\(\) has parameter \$params with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/Remap.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\SubDir\\BlogController\:\:getSomeMethod\(\) has parameter \$first with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/SubDir/BlogController.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\Subfolder\\Home\:\:getIndex\(\) has parameter \$p1 with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/Subfolder/Home.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\Subfolder\\Home\:\:getIndex\(\) has parameter \$p2 with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/Subfolder/Home.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\Controllers\\Subfolder\\Sub\\BlogController\:\:getSomeMethod\(\) has parameter \$first with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/Controllers/Subfolder/Sub/BlogController.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\DefinedRouteCollectorTest\:\:createRouteCollection\(\) has parameter \$moduleConfig with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/DefinedRouteCollectorTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionReverseRouteTest\:\:getCollector\(\) has parameter \$moduleConfig with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionReverseRouteTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:getCollector\(\) has parameter \$moduleConfig with no type specified\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
 
         -
             message: '#^Method CodeIgniter\\Security\\SecurityCSRFSessionRandomizeTokenTest\:\:createSession\(\) has parameter \$options with no type specified\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

Adds specific parameter types to 10 methods across the Router test fixtures and helper classes, replacing untyped parameters that PHPStan flagged as "no type specified." All changes are in test-only files. I tested it by running a full-project PHPStan scan and all the relevant tests.

Contributes to #7731 (PHPStan "no type specified" errors).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
