### PR TITLE
refactor: do not override `Exception`'s `$code` in `RedirectException`

### DIFF
--- a/system/HTTP/Exceptions/RedirectException.php
+++ b/system/HTTP/Exceptions/RedirectException.php
@@ -27,11 +27,9 @@ use Throwable;
 class RedirectException extends RuntimeException implements ExceptionInterface, ResponsableInterface, HTTPExceptionInterface
 {
     /**
-     * HTTP status code for redirects
-     *
-     * @var int
+     * Status code applied to a Response that arrives without a 3xx redirect status.
      */
-    protected $code = 302;
+    protected int $defaultStatusCode = 302;
 
     protected ?ResponseInterface $response = null;
 
@@ -61,7 +59,7 @@ class RedirectException extends RuntimeException implements ExceptionInterface, 
             }
 
             if ($this->response->getStatusCode() < 301 || $this->response->getStatusCode() > 308) {
-                $this->response->setStatusCode($this->code);
+                $this->response->setStatusCode($this->defaultStatusCode);
             }
         }
 

--- a/system/HTTP/Exceptions/RedirectException.php
+++ b/system/HTTP/Exceptions/RedirectException.php
@@ -27,7 +27,7 @@ use Throwable;
 class RedirectException extends RuntimeException implements ExceptionInterface, ResponsableInterface, HTTPExceptionInterface
 {
     /**
-     * Status code applied to a Response that arrives without a 3xx redirect status.
+     * Status code applied to a Response whose status is outside the 301-308 range.
      */
     protected int $defaultStatusCode = 302;
 

--- a/tests/system/HTTP/RedirectExceptionTest.php
+++ b/tests/system/HTTP/RedirectExceptionTest.php
@@ -76,6 +76,18 @@ final class RedirectExceptionTest extends TestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
+    public function testResponseWithoutStatusCodeUsesSubclassDefault(): void
+    {
+        $exception = new class (service('response')->setHeader('Location', 'location')) extends RedirectException {
+            protected int $defaultStatusCode = 307;
+        };
+
+        $response = $exception->getResponse();
+
+        $this->assertSame('location', $response->getHeaderLine('location'));
+        $this->assertSame(307, $response->getStatusCode());
+    }
+
     public function testLoggingLocationHeader(): void
     {
         Time::setTestNow('2023-11-25 12:00:00');

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -42,7 +42,7 @@ Behavior Changes
 - **Filters:** HTTP method matching for method-based filters is now case-sensitive. The keys in ``Config\Filters::$methods`` must exactly match the request method
   (e.g., ``GET``, ``POST``). Lowercase method names (e.g., ``post``) will no longer match.
 - **HTTP:** Routes defined with ``$routes->add()`` now also match HTTP ``QUERY`` requests. If the route has CSRF protection, remember that CSRF verification does not protect safe methods such as ``GET`` and ``QUERY``.
-- **HTTP:** ``CodeIgniter\HTTP\Exceptions\RedirectException`` no longer redeclares the inherited ``$code`` property. The status applied to a ``Response`` passed to the constructor without a 3xx status now comes from the new ``protected int $defaultStatusCode = 302`` property. Subclasses that overrode ``$code`` to change that status must override ``$defaultStatusCode`` instead.
+- **HTTP:** ``CodeIgniter\HTTP\Exceptions\RedirectException`` no longer redeclares the inherited ``$code`` property. The status applied to a ``Response`` passed to the constructor whose status is outside the 301-308 range now comes from the new ``protected int $defaultStatusCode = 302`` property. Subclasses that overrode ``$code`` to change that status must override ``$defaultStatusCode`` instead.
 - **Testing:** Tests using the ``FeatureTestTrait`` must now use uppercase HTTP method names when performing a request when using the ``call()`` method directly
   (e.g., ``$this->call('GET', '/path')`` instead of ``$this->call('get', '/path')``). Additionally, setting method-based routes using ``withRoutes()`` must
   also use uppercase method names (e.g., ``$this->withRoutes([['GET', 'home', 'Home::index']])``).

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -42,6 +42,7 @@ Behavior Changes
 - **Filters:** HTTP method matching for method-based filters is now case-sensitive. The keys in ``Config\Filters::$methods`` must exactly match the request method
   (e.g., ``GET``, ``POST``). Lowercase method names (e.g., ``post``) will no longer match.
 - **HTTP:** Routes defined with ``$routes->add()`` now also match HTTP ``QUERY`` requests. If the route has CSRF protection, remember that CSRF verification does not protect safe methods such as ``GET`` and ``QUERY``.
+- **HTTP:** ``CodeIgniter\HTTP\Exceptions\RedirectException`` no longer redeclares the inherited ``$code`` property. The status applied to a ``Response`` passed to the constructor without a 3xx status now comes from the new ``protected int $defaultStatusCode = 302`` property. Subclasses that overrode ``$code`` to change that status must override ``$defaultStatusCode`` instead.
 - **Testing:** Tests using the ``FeatureTestTrait`` must now use uppercase HTTP method names when performing a request when using the ``call()`` method directly
   (e.g., ``$this->call('GET', '/path')`` instead of ``$this->call('get', '/path')``). Additionally, setting method-based routes using ``withRoutes()`` must
   also use uppercase method names (e.g., ``$this->withRoutes([['GET', 'home', 'Home::index']])``).

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -82,6 +82,27 @@ the URI. Such calls must now pass a ``URI``:
 Any other call that omitted ``$uri`` or passed ``null`` already failed with
 ``Call to a member function getHost() on null``, so it needs no migration.
 
+RedirectException Default Status Code
+======================================
+
+``CodeIgniter\HTTP\Exceptions\RedirectException`` no longer redeclares the inherited ``$code`` property to store the status applied to a
+``Response`` whose status is outside the 301-308 range. If you have a subclass that overrode ``$code`` for this purpose, override the new
+``$defaultStatusCode`` property instead:
+
+.. code-block:: php
+
+    // Before
+    class MyRedirectException extends RedirectException
+    {
+        protected $code = 307;
+    }
+
+    // After
+    class MyRedirectException extends RedirectException
+    {
+        protected int $defaultStatusCode = 307;
+    }
+
 *********************
 Breaking Enhancements
 *********************

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 689 errors
+# total 688 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/property.phpDocType.neon
+++ b/utils/phpstan-baseline/property.phpDocType.neon
@@ -73,9 +73,9 @@ parameters:
             path: ../../system/Exceptions/PageNotFoundException.php
 
         -
-            message: '#^PHPDoc type int of property CodeIgniter\\HTTP\\Exceptions\\RedirectException\:\:\$code is not the same as PHPDoc type mixed of overridden property Exception\:\:\$code\.$#'
+            message: '#^PHPDoc type CodeIgniter\\HTTP\\URI of property CodeIgniter\\HTTP\\IncomingRequest\:\:\$uri is not the same as PHPDoc type CodeIgniter\\HTTP\\URI\|null of overridden property CodeIgniter\\HTTP\\OutgoingRequest\:\:\$uri\.$#'
             count: 1
-            path: ../../system/HTTP/Exceptions/RedirectException.php
+            path: ../../system/HTTP/IncomingRequest.php
 
         -
             message: '#^PHPDoc type string of property CodeIgniter\\Session\\Handlers\\FileHandler\:\:\$savePath is not the same as PHPDoc type array\<string, mixed\>\|string of overridden property CodeIgniter\\Session\\Handlers\\BaseHandler\:\:\$savePath\.$#'

--- a/utils/phpstan-baseline/property.phpDocType.neon
+++ b/utils/phpstan-baseline/property.phpDocType.neon
@@ -1,4 +1,4 @@
-# total 21 errors
+# total 20 errors
 
 parameters:
     ignoreErrors:
@@ -71,11 +71,6 @@ parameters:
             message: '#^PHPDoc type int of property CodeIgniter\\Exceptions\\PageNotFoundException\:\:\$code is not the same as PHPDoc type mixed of overridden property Exception\:\:\$code\.$#'
             count: 1
             path: ../../system/Exceptions/PageNotFoundException.php
-
-        -
-            message: '#^PHPDoc type CodeIgniter\\HTTP\\URI of property CodeIgniter\\HTTP\\IncomingRequest\:\:\$uri is not the same as PHPDoc type CodeIgniter\\HTTP\\URI\|null of overridden property CodeIgniter\\HTTP\\OutgoingRequest\:\:\$uri\.$#'
-            count: 1
-            path: ../../system/HTTP/IncomingRequest.php
 
         -
             message: '#^PHPDoc type string of property CodeIgniter\\Session\\Handlers\\FileHandler\:\:\$savePath is not the same as PHPDoc type array\<string, mixed\>\|string of overridden property CodeIgniter\\Session\\Handlers\\BaseHandler\:\:\$savePath\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
`RedirectException` redeclares the `$code` property from the base `Exception`. It is untyped, so we cannot natively declare an `int` type as it would fatal, nor add a phpdoc as phpstan will complain you're narrowing an invariant property. Moreover, the `$code` property is used here as the **HTTP status code** not the exception code. Thus, this PR proposes uses another property for the status code.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
