### PR TITLE
refactor: widen `Response` body and `Formatter` data typing to `mixed`

### DIFF
--- a/system/Format/FormatterInterface.php
+++ b/system/Format/FormatterInterface.php
@@ -21,7 +21,7 @@ interface FormatterInterface
     /**
      * Takes the given data and formats it.
      *
-     * @param array<array-key, mixed>|object|string $data
+     * @param mixed $data
      *
      * @return false|non-empty-string
      */

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -26,7 +26,7 @@ class JSONFormatter implements FormatterInterface
     /**
      * Takes the given data and formats it.
      *
-     * @param array<array-key, mixed>|object|string $data
+     * @param mixed $data
      *
      * @return false|non-empty-string
      */

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -27,7 +27,7 @@ class XMLFormatter implements FormatterInterface
     /**
      * Takes the given data and formats it.
      *
-     * @param array<array-key, mixed>|object|string $data
+     * @param mixed $data
      *
      * @return false|non-empty-string
      */

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -200,7 +200,7 @@ interface ResponseInterface extends MessageInterface
     /**
      * Converts the $body into JSON and sets the Content Type header.
      *
-     * @param array<array-key, mixed>|object|string $body
+     * @param mixed $body
      *
      * @return $this
      */
@@ -218,7 +218,7 @@ interface ResponseInterface extends MessageInterface
     /**
      * Converts $body into XML, and sets the correct Content-Type.
      *
-     * @param array<array-key, mixed>|string $body
+     * @param mixed $body
      *
      * @return $this
      */

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -169,7 +169,7 @@ trait ResponseTrait
     /**
      * Converts the $body into JSON and sets the Content Type header.
      *
-     * @param array<array-key, mixed>|object|string $body
+     * @param mixed $body
      *
      * @return $this
      */
@@ -201,7 +201,7 @@ trait ResponseTrait
     /**
      * Converts $body into XML, and sets the correct Content-Type.
      *
-     * @param array<array-key, mixed>|string $body
+     * @param mixed $body
      *
      * @return $this
      */
@@ -234,8 +234,8 @@ trait ResponseTrait
      * Handles conversion of the data into the appropriate format,
      * and sets the correct Content-Type header for our response.
      *
-     * @param array<array-key, mixed>|object|string $body
-     * @param string                                $format Valid: json, xml
+     * @param mixed  $body
+     * @param string $format Valid: json, xml
      *
      * @return false|string
      *

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -314,7 +314,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testGetJSONFalseJSON(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->response->setJSON(false, true); // @phpstan-ignore argument.type (Needed for testing)
+        $this->response->setJSON(false, true);
 
         // this should be FALSE - json_encode(false)
         $this->assertSame('false', $this->testResponse->getJSON());
@@ -323,7 +323,7 @@ final class TestResponseTest extends CIUnitTestCase
     public function testGetJSONTrueJSON(): void
     {
         $this->getTestResponse('<h1>Hello World</h1>');
-        $this->response->setJSON(true, true); // @phpstan-ignore argument.type (Needed for testing)
+        $this->response->setJSON(true, true);
 
         // this should be TRUE - json_encode(true)
         $this->assertSame('true', $this->testResponse->getJSON());

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -22,6 +22,8 @@ Message Changes
 Changes
 *******
 
+- **Response:** ``setJSON()`` and ``setXML()``, and the ``FormatterInterface::format()`` contract implemented by ``JSONFormatter`` and ``XMLFormatter``, now type their body/data parameter as ``mixed`` instead of ``array|object|string``, matching what they already accepted at runtime (e.g., scalars and ``bool``).
+
 ************
 Deprecations
 ************


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
The formatters can genuinely take in any form of data but their phpdocs unnecessarily narrow down their inputs to `array|object|string`. This widens it to `mixed`. Consequently, `Response::setJSON` now also takes a `mixed` body instead of the incorrectly narrowed one.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
